### PR TITLE
hardware: nafarr: peripherals: io: pwm: Use correct offset

### DIFF
--- a/hardware/scala/nafarr/peripherals/io/pwm/PwmCtrl.scala
+++ b/hardware/scala/nafarr/peripherals/io/pwm/PwmCtrl.scala
@@ -119,7 +119,7 @@ object PwmCtrl {
 
     val channelCfg = Reg(ctrl.channels)
     for (i <- 0 until p.io.channels) {
-      val channel = offset + 0x8 + i * 0x10
+      val channel = offset + 8 + i * 12
 
       channelCfg(i).enable.init(False)
       channelCfg(i).invert.init(False)


### PR DESCRIPTION
The control and timing register for one PWM channel are only 12 Bytes wide and not 16.