### PR TITLE
hardware: nafarr: system: Rework {Clock,Reset}ControllerCtrl

### DIFF
--- a/hardware/scala/nafarr/system/reset/ResetControllerCtrl.scala
+++ b/hardware/scala/nafarr/system/reset/ResetControllerCtrl.scala
@@ -42,13 +42,13 @@ object ResetControllerCtrl {
     }
     io.buildConnection.trigger := io.config.enable & (io.trigger | ctrlTrigger)
 
-    var resetDict = Map[String, Bool]()
+    var resetDict = Map[String, (Bool, Int)]()
     var triggerDict = Map[String, Bool]()
     for ((domain, index) <- parameter.domains.zipWithIndex) {
-      resetDict += domain.name -> io.resets(index)
+      resetDict += domain.name -> (io.resets(index), index)
       triggerDict += domain.name -> io.trigger(index)
     }
-    def getResetByName(name: String): Bool = resetDict.get(name).get
+    def getResetByName(name: String): (Bool, Int) = resetDict.get(name).get
     def triggerByNameWithCond(name: String, cond: Bool) {
       triggerDict.get(name).get.setWhen(cond)
     }


### PR DESCRIPTION
Use ClockDomain.internal with a CD name to not generate clock and reset signals with _zz_. Instead, those should have real names.

This change is required to generate Verilog which can be used with OpenROAD blocks.