### PR TITLE
SPI: Add Quad I/O Support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,6 +17,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/hardware/scala/nafarr/IpIdentification.scala
+++ b/hardware/scala/nafarr/IpIdentification.scala
@@ -13,8 +13,8 @@ object IpIdentification {
     IpIdentificationCtrl(id, major, minor, patch)
 
   object Ids extends SpinalEnum {
-    val Gpio, Pio, Pwm, Uart, I2cController, I2cDevice, SpiController, SpiDevice, AesAccelerator,
-        AesMaskedAccelerator, Reset, Clock = newElement()
+    val Gpio, Pio, Pwm, Uart, I2cController, I2cDevice, SpiController, SpiXipController, SpiDevice,
+        AesAccelerator, AesMaskedAccelerator, Reset, Clock = newElement()
   }
 
   case class IpIdentificationCtrl(

--- a/hardware/scala/nafarr/memory/spi/Axi4ReadOnlySpiXipController.scala
+++ b/hardware/scala/nafarr/memory/spi/Axi4ReadOnlySpiXipController.scala
@@ -18,7 +18,8 @@ case class Axi4ReadOnlySpiXipController(
     cfgBusConfig: Apb3Config = Apb3Config(12, 32)
 ) extends Component {
   val io = new Bundle {
-    val cfgBus = slave(Apb3(cfgBusConfig))
+    val cfgSpiBus = slave(Apb3(cfgBusConfig))
+    val cfgXipBus = slave(Apb3(cfgBusConfig))
     val dataBus = slave(Axi4ReadOnly(dataBusConfig))
     val spi = master(Spi.Io(parameter.io))
     val interrupt = out(Bool)
@@ -79,6 +80,9 @@ case class Axi4ReadOnlySpiXipController(
     }
   }
 
-  val busFactory = Apb3SlaveFactory(io.cfgBus)
-  SpiControllerCtrl.Mapper(busFactory, spiControllerCtrl.io, parameter)
+  val busSpiFactory = Apb3SlaveFactory(io.cfgSpiBus)
+  SpiControllerCtrl.Mapper(busSpiFactory, spiControllerCtrl.io, parameter)
+
+  val busXipFactory = Apb3SlaveFactory(io.cfgXipBus)
+  SpiXipControllerCtrl.Mapper(busXipFactory, spiXipControllerCtrl.io.config, parameter)
 }

--- a/hardware/scala/nafarr/memory/spi/BmbSpiXipController.scala
+++ b/hardware/scala/nafarr/memory/spi/BmbSpiXipController.scala
@@ -19,7 +19,8 @@ case class BmbSpiXipController(
 ) extends Component {
   val io = new Bundle {
     val dataBus = slave(Bmb(dataBusConfig))
-    val cfgBus = slave(Wishbone(cfgBusConfig.copy(addressWidth = 10)))
+    val cfgSpiBus = slave(Wishbone(cfgBusConfig.copy(addressWidth = 10)))
+    val cfgXipBus = slave(Wishbone(cfgBusConfig.copy(addressWidth = 10)))
     val spi = master(Spi.Io(parameter.io))
     val interrupt = out(Bool)
   }
@@ -96,6 +97,9 @@ case class BmbSpiXipController(
     }
   }
 
-  val cfgBusFactory = WishboneSlaveFactory(io.cfgBus)
-  SpiControllerCtrl.Mapper(cfgBusFactory, spiControllerCtrl.io, parameter)
+  val cfgSpiBusFactory = WishboneSlaveFactory(io.cfgSpiBus)
+  SpiControllerCtrl.Mapper(cfgSpiBusFactory, spiControllerCtrl.io, parameter)
+
+  val cfgXipBusFactory = WishboneSlaveFactory(io.cfgXipBus)
+  SpiXipControllerCtrl.Mapper(cfgXipBusFactory, spiXipControllerCtrl.io.config, parameter)
 }

--- a/hardware/scala/nafarr/peripherals/com/spi/SpiController.scala
+++ b/hardware/scala/nafarr/peripherals/com/spi/SpiController.scala
@@ -14,11 +14,12 @@ import nafarr.peripherals.PeripheralsComponent
 
 object SpiController {
   object CmdMode extends SpinalEnum(binarySequential) {
-    val DATA, CS = newElement()
+    val DATA, CS, DUMMYCYCLES = newElement()
   }
 
   case class CmdData(p: SpiControllerCtrl.Parameter) extends Bundle {
     val data = Bits(p.dataWidth bits)
+    val mode = Bits(p.modeWidth bits)
     val read = Bool
   }
 
@@ -27,12 +28,17 @@ object SpiController {
     val index = UInt(log2Up(p.io.csWidth) bits)
   }
 
+  case class CmdDummyCycles(p: SpiControllerCtrl.Parameter) extends Bundle {
+    val cycles = UInt(log2Up(p.maxDummyCycles * 2) bits)
+  }
+
   case class Cmd(p: SpiControllerCtrl.Parameter) extends Bundle {
     val mode = CmdMode()
     val args = Bits(Math.max(widthOf(CmdData(p)), widthOf(CmdCs(p))) bits)
 
     def isData = mode === CmdMode.DATA
     def isCs = mode === CmdMode.CS
+    def isDummyCycles = mode === CmdMode.DUMMYCYCLES
     def argsData = {
       val ret = CmdData(p)
       ret.assignFromBits(args)
@@ -40,6 +46,11 @@ object SpiController {
     }
     def argsCs = {
       val ret = CmdCs(p)
+      ret.assignFromBits(args)
+      ret
+    }
+    def argsDummyCycles = {
+      val ret = CmdDummyCycles(p)
       ret.assignFromBits(args)
       ret
     }

--- a/test/scala/nafarr/memory/spi/Axi4ReadOnlySpiXipControllerTest.scala
+++ b/test/scala/nafarr/memory/spi/Axi4ReadOnlySpiXipControllerTest.scala
@@ -27,7 +27,8 @@ class Axi4ReadOnlySpiXipControllerTest extends AnyFunSuite {
     }
     compiled.doSim("default signals") { dut =>
       dut.clockDomain.forkStimulus(10)
-      dut.io.cfgBus.PENABLE #= false
+      dut.io.cfgSpiBus.PENABLE #= false
+      dut.io.cfgXipBus.PENABLE #= false
       dut.io.dataBus.ar.valid #= false
       dut.io.dataBus.r.ready #= false
       dut.clockDomain.waitSampling(5)
@@ -40,7 +41,8 @@ class Axi4ReadOnlySpiXipControllerTest extends AnyFunSuite {
     compiled.doSim("single read") { dut =>
       dut.clockDomain.forkStimulus(10)
 
-      dut.io.cfgBus.PENABLE #= false
+      dut.io.cfgSpiBus.PENABLE #= false
+      dut.io.cfgXipBus.PENABLE #= false
       dut.io.dataBus.ar.valid #= false
       dut.io.dataBus.r.ready #= false
       dut.io.spi.dq.read #= BigInt("10", 2)


### PR DESCRIPTION
Extend the SPI and SPI XIP controller by the Quad I/O protocol to increase the SPI bandwidth.