### PR TITLE
Minor Fixes

### DIFF
--- a/hardware/scala/nafarr/peripherals/com/spi/SpiControllerCtrl.scala
+++ b/hardware/scala/nafarr/peripherals/com/spi/SpiControllerCtrl.scala
@@ -23,7 +23,7 @@ object SpiControllerCtrl {
   object InitParameter {
     def disabled = InitParameter(false, false, 0 Hz)
     def default = InitParameter(false, false, 100 kHz)
-    def fast = InitParameter(false, false, 1 MHz)
+    def fast = InitParameter(false, false, 5 MHz)
   }
 
   case class PermissionParameter(

--- a/hardware/scala/nafarr/system/clock/ClockControllerCtrl.scala
+++ b/hardware/scala/nafarr/system/clock/ClockControllerCtrl.scala
@@ -122,10 +122,15 @@ object ClockControllerCtrl {
         resetCtrl: ResetControllerCtrl.ResetControllerCtrl,
         clockFrequency: HertzNumber,
         clocks: List[String],
-        CLKI_DIV: Int = 1,
-        CLKFB_DIV: Int = 1,
-        CLKOP_DIV: Int = 1
+        clockVco: HertzNumber = 400 MHz
     ) {
+
+      val clockPair = (clockFrequency.toDouble / 1e6, clockVco.toDouble / 1e6)
+
+      val (clkIDiv, clkFbDiv, clkOpDiv) = clockPair match {
+        case (100, 400) => (2, 1, 8)
+      }
+
       val clockCtrlClockDomain = ClockDomain(
         clock = clock,
         frequency = FixedFrequency(clockFrequency),
@@ -155,7 +160,7 @@ object ClockControllerCtrl {
         generatedClocks = generatedClocks :+ getClockPin(index)
       }
       io.buildConnection.resets <> resetCtrl.io.resets
-      clockCtrl.pll.calculate(CLKI_DIV, CLKFB_DIV, CLKOP_DIV)
+      clockCtrl.pll.calculate(clkIDiv, clkFbDiv, clkOpDiv)
     }
 
     def buildDummy(clock: Bool, resetCtrl: ResetControllerCtrl.ResetControllerCtrl) {


### PR DESCRIPTION
- Revert the OCRAM data rotation
- Increase SPI frequency for the `fast` parameter to 5 MHz
- Add look-up table to ECP5 based PLL ClockController to simplify chip top-level file