### PR TITLE
hardware: nafarr: system: Rework Reset- and ClockController

### DIFF
--- a/hardware/scala/nafarr/system/clock/ClockControllerCtrl.scala
+++ b/hardware/scala/nafarr/system/clock/ClockControllerCtrl.scala
@@ -14,12 +14,6 @@ import nafarr.blackboxes.lattice.ecp5.LatticePLL
 import nafarr.system.reset.ResetControllerCtrl
 
 object ClockControllerCtrl {
-  def apply(
-      parameter: Parameter,
-      resetParameter: ResetControllerCtrl.Parameter,
-      resetCtrl: ResetControllerCtrl.ResetControllerCtrl
-  ) =
-    ClockControllerCtrl(parameter, resetParameter, resetCtrl)
 
   case class Parameter(domains: List[ClockParameter]) {
     // TODO check synchronousWith is before
@@ -30,211 +24,196 @@ object ClockControllerCtrl {
     }
   }
 
-  case class Io(parameter: Parameter, resetParameter: ResetControllerCtrl.Parameter)
-      extends Bundle {
-    val clocks = in(UInt(parameter.domains.length bits))
-    val resets = in(UInt(resetParameter.domains.length bits))
-  }
-
   case class Config(parameter: Parameter) extends Bundle {
     val enable = UInt(parameter.domains.length bits)
   }
 
-  case class ClockControllerCtrl(
-      parameter: Parameter,
-      resetParameter: ResetControllerCtrl.Parameter,
-      resetCtrl: ResetControllerCtrl.ResetControllerCtrl
-  ) extends Component {
+  abstract class ClockControllerBase(parameter: Parameter) extends Component {
+    addAttribute("keep_hierarchy", "yes")
     val io = new Bundle {
+      val mainClock = in(Bool())
+      val mainReset = in(Bool())
       val clocks = out(UInt(parameter.domains.length bits))
-      val buildConnection = Io(parameter, resetParameter)
       val config = in(Config(parameter))
     }
-    io.clocks := io.buildConnection.clocks
 
     var generatedClocks = List[Bool]()
-    var clockDict = Map[String, ClockDomain]()
+    var clockDict = Map[String, (ClockDomain, Int)]()
+    def getClockDomainByName(name: String): ClockDomain = clockDict(name)._1
+    def getPortIndexByName(name: String): Int = clockDict(name)._2
+  }
+
+  def connect(
+      parameter: Parameter,
+      clockCtrl: ClockControllerBase,
+      resetCtrl: ResetControllerCtrl.ResetControllerBase
+  ): Unit = {
     for ((domain, index) <- parameter.domains.zipWithIndex) {
-      clockDict += domain.name -> {
-        val cd = ClockDomain.internal(
-          name = domain.name,
-          frequency = FixedFrequency(domain.frequency),
-          config = domain.resetConfig
-        )
-        cd.clock := io.buildConnection.clocks(index)
-        if (!domain.reset.isEmpty) {
-          cd.reset := io.buildConnection.resets(resetCtrl.getResetByName(domain.reset)._2)
-        }
-        if (!domain.synchronousWith.isEmpty()) {
-          cd.setSynchronousWith(getClockDomainByName(domain.synchronousWith))
-        }
-        cd
-      }
-    }
-    def getClockDomainByName(name: String): ClockDomain = clockDict.get(name).get
-
-    def buildXilinxPll(
-        clock: Bool,
-        resetCtrl: ResetControllerCtrl.ResetControllerCtrl,
-        clockFrequency: HertzNumber,
-        clocks: List[String],
-        multiply: Int
-    ) {
-      val clockCtrlClockDomain = ClockDomain(
-        clock = clock,
-        frequency = FixedFrequency(clockFrequency),
-        config = ClockDomainConfig(
-          resetKind = BOOT
-        )
+      val cd = ClockDomain.internal(
+        name = domain.name,
+        frequency = FixedFrequency(domain.frequency),
+        config = domain.resetConfig
       )
-
-      val clockCtrl = new ClockingArea(clockCtrlClockDomain) {
-        val pll = XilinxPLL.PLLE2_BASE(CLKFBOUT_MULT = multiply).connect()
+      cd.clock := clockCtrl.io.clocks(index)
+      if (!domain.reset.isEmpty) {
+        cd.reset := resetCtrl.io.resets(resetCtrl.getResetByName(domain.reset)._2)
       }
-
-      def addClock(index: Int, frequency: HertzNumber) = index match {
-        case 0 => clockCtrl.pll.addClock0(frequency)
-        case 1 => clockCtrl.pll.addClock1(frequency)
-        case 2 => clockCtrl.pll.addClock2(frequency)
-        case 3 => clockCtrl.pll.addClock3(frequency)
-        case 4 => clockCtrl.pll.addClock4(frequency)
-        case 5 => clockCtrl.pll.addClock5(frequency)
+      if (!domain.synchronousWith.isEmpty()) {
+        cd.setSynchronousWith(clockCtrl.getClockDomainByName(domain.synchronousWith))
       }
-      def getClockPin(index: Int) = index match {
-        case 0 => clockCtrl.pll.CLKOUT0
-        case 1 => clockCtrl.pll.CLKOUT1
-        case 2 => clockCtrl.pll.CLKOUT2
-        case 3 => clockCtrl.pll.CLKOUT3
-        case 4 => clockCtrl.pll.CLKOUT4
-        case 5 => clockCtrl.pll.CLKOUT5
-      }
-
-      for ((clock, index) <- clocks.zipWithIndex) {
-        val (domainIndex, domain) = parameter.getDomainByName(clock)
-        io.buildConnection.clocks(domainIndex) := addClock(index, domain.frequency)
-        generatedClocks = generatedClocks :+ getClockPin(index)
-      }
-      io.buildConnection.resets <> resetCtrl.io.resets
+      clockCtrl.clockDict += domain.name -> (cd, index)
     }
+  }
 
-    def buildLatticeECP5Pll(
-        clock: Bool,
-        resetCtrl: ResetControllerCtrl.ResetControllerCtrl,
-        clockFrequency: HertzNumber,
-        clocks: List[String],
-        clockVco: HertzNumber = 400 MHz
-    ) {
+  case class ClockDividerController(
+      parameter: Parameter,
+      inputClock: ClockParameter,
+      clocks: List[String]
+  ) extends ClockControllerBase(parameter) {
+    val inputHz = inputClock.frequency.toDouble
 
-      val clockPair = (clockFrequency.toDouble / 1e6, clockVco.toDouble / 1e6)
+    val clockCtrlClockDomain = ClockDomain(
+      clock = io.mainClock,
+      reset = io.mainReset,
+      frequency = FixedFrequency(inputClock.frequency),
+      config = inputClock.resetConfig
+    )
 
-      val (clkIDiv, clkFbDiv, clkOpDiv) = clockPair match {
-        case (100, 400) => (2, 1, 8)
-      }
+    val clockCtrl = new ClockingArea(clockCtrlClockDomain) {
+      for (clockName <- clocks) {
+        val (domainIndex, domain) = parameter.getDomainByName(clockName)
+        val outputHz = domain.frequency.toDouble
 
-      val clockCtrlClockDomain = ClockDomain(
-        clock = clock,
-        frequency = FixedFrequency(clockFrequency),
-        config = ClockDomainConfig(
-          resetKind = BOOT
+        require(
+          inputHz % outputHz == 0,
+          s"Clock '$clockName': output frequency ${outputHz.toLong} Hz does not divide input frequency ${inputHz.toLong} Hz evenly"
         )
-      )
+        val divider = (inputHz / outputHz).toInt
+        require(
+          divider >= 1,
+          s"Clock '$clockName': divider $divider must be >= 1"
+        )
 
-      val clockCtrl = new ClockingArea(clockCtrlClockDomain) {
-        val pll0 = LatticePLL.EHXPLLL().connect()
-        val pll1 = LatticePLL.EHXPLLL().connect()
-      }
-
-      def addClock(index: Int, frequency: HertzNumber) = index match {
-        case 0 => clockCtrl.pll0.addClock0(frequency)
-        case 1 => clockCtrl.pll0.addClock1(frequency)
-        case 2 => clockCtrl.pll0.addClock2(frequency)
-        case 3 => clockCtrl.pll1.addClock0(frequency)
-        case 4 => clockCtrl.pll1.addClock1(frequency)
-        case 5 => clockCtrl.pll1.addClock2(frequency)
-      }
-      def getClockPin(index: Int) = index match {
-        case 0 => clockCtrl.pll0.CLKOS
-        case 1 => clockCtrl.pll0.CLKOS2
-        case 2 => clockCtrl.pll0.CLKOS3
-        case 3 => clockCtrl.pll1.CLKOS
-        case 4 => clockCtrl.pll1.CLKOS2
-        case 5 => clockCtrl.pll1.CLKOS3
-      }
-
-      for ((clock, index) <- clocks.zipWithIndex) {
-        val (domainIndex, domain) = parameter.getDomainByName(clock)
-        io.buildConnection.clocks(domainIndex) := addClock(index, domain.frequency)
-        generatedClocks = generatedClocks :+ getClockPin(index)
-      }
-      io.buildConnection.resets <> resetCtrl.io.resets
-      clockCtrl.pll0.calculate(clkIDiv, clkFbDiv, clkOpDiv)
-      clockCtrl.pll1.calculate(clkIDiv, clkFbDiv, clkOpDiv)
-    }
-
-    def buildClockDivider(
-        clock: Bool,
-        resetCtrl: ResetControllerCtrl.ResetControllerCtrl,
-        inputClock: ClockParameter,
-        clocks: List[String]
-    ) {
-      val inputHz = inputClock.frequency.toDouble
-
-      val clockCtrlClockDomain = ClockDomain(
-        clock = clock,
-        reset = resetCtrl.getResetByName(inputClock.reset)._1,
-        frequency = FixedFrequency(inputClock.frequency),
-        config = inputClock.resetConfig
-      )
-
-      val clockCtrl = new ClockingArea(clockCtrlClockDomain) {
-        for (clockName <- clocks) {
-          val (domainIndex, domain) = parameter.getDomainByName(clockName)
-          val outputHz = domain.frequency.toDouble
-
+        val clockOut = if (divider == 1) {
+          io.mainClock
+        } else {
           require(
-            inputHz % outputHz == 0,
-            s"Clock '$clockName': output frequency ${outputHz.toLong} Hz does not divide input frequency ${inputHz.toLong} Hz evenly"
+            divider % 2 == 0,
+            s"Clock '$clockName': divider $divider must be even to generate a 50% duty cycle clock"
           )
-          val divider = (inputHz / outputHz).toInt
-          require(
-            divider >= 1,
-            s"Clock '$clockName': divider $divider must be >= 1"
-          )
-
-          val clockOut = if (divider == 1) {
-            clock
+          val halfPeriod = divider / 2
+          val divided = Reg(Bool()) init False
+          if (halfPeriod == 1) {
+            divided := !divided
           } else {
-            require(
-              divider % 2 == 0,
-              s"Clock '$clockName': divider $divider must be even to generate a 50% duty cycle clock"
-            )
-            val halfPeriod = divider / 2
-            val divided = Reg(Bool()) init False
-            if (halfPeriod == 1) {
+            val counter = Reg(UInt(log2Up(halfPeriod) bits)) init 0
+            when(counter === halfPeriod - 1) {
+              counter := 0
               divided := !divided
-            } else {
-              val counter = Reg(UInt(log2Up(halfPeriod) bits)) init 0
-              when(counter === halfPeriod - 1) {
-                counter := 0
-                divided := !divided
-              } otherwise {
-                counter := counter + 1
-              }
+            } otherwise {
+              counter := counter + 1
             }
-            divided
           }
-          io.buildConnection.clocks(domainIndex) := clockOut
-          generatedClocks = generatedClocks :+ clockOut
+          divided
         }
+        io.clocks(domainIndex) := clockOut
       }
-      io.buildConnection.resets <> resetCtrl.io.resets
+    }
+  }
+
+  case class LatticeECP5PllController(
+      parameter: Parameter,
+      inputClock: ClockParameter,
+      clocks: List[String],
+      clockVco: HertzNumber = 400 MHz
+  ) extends ClockControllerBase(parameter) {
+    val clockFrequency = inputClock.frequency
+    val clockPair = (clockFrequency.toDouble / 1e6, clockVco.toDouble / 1e6)
+
+    val (clkIDiv, clkFbDiv, clkOpDiv) = clockPair match {
+      case (100, 400) => (2, 1, 8)
     }
 
-    def buildDummy(clock: Bool, resetCtrl: ResetControllerCtrl.ResetControllerCtrl) {
-      for (((domain), index) <- parameter.domains.zipWithIndex) {
-        io.buildConnection.clocks(index) := clock
-      }
-      io.buildConnection.resets <> resetCtrl.io.resets
+    val clockCtrlClockDomain = ClockDomain(
+      clock = io.mainClock,
+      frequency = FixedFrequency(clockFrequency),
+      config = ClockDomainConfig(
+        resetKind = BOOT
+      )
+    )
+
+    val clockCtrl = new ClockingArea(clockCtrlClockDomain) {
+      val pll0 = LatticePLL.EHXPLLL().connect()
+      val pll1 = LatticePLL.EHXPLLL().connect()
+    }
+
+    def addClock(index: Int, frequency: HertzNumber) = index match {
+      case 0 => clockCtrl.pll0.addClock0(frequency)
+      case 1 => clockCtrl.pll0.addClock1(frequency)
+      case 2 => clockCtrl.pll0.addClock2(frequency)
+      case 3 => clockCtrl.pll1.addClock0(frequency)
+      case 4 => clockCtrl.pll1.addClock1(frequency)
+      case 5 => clockCtrl.pll1.addClock2(frequency)
+    }
+    def getClockPin(index: Int) = index match {
+      case 0 => clockCtrl.pll0.CLKOS
+      case 1 => clockCtrl.pll0.CLKOS2
+      case 2 => clockCtrl.pll0.CLKOS3
+      case 3 => clockCtrl.pll1.CLKOS
+      case 4 => clockCtrl.pll1.CLKOS2
+      case 5 => clockCtrl.pll1.CLKOS3
+    }
+
+    for ((clock, index) <- clocks.zipWithIndex) {
+      val (domainIndex, domain) = parameter.getDomainByName(clock)
+      io.clocks(domainIndex) := addClock(index, domain.frequency)
+      generatedClocks = generatedClocks :+ getClockPin(index)
+    }
+    clockCtrl.pll0.calculate(clkIDiv, clkFbDiv, clkOpDiv)
+    clockCtrl.pll1.calculate(clkIDiv, clkFbDiv, clkOpDiv)
+  }
+
+  case class XilinxPllController(
+      parameter: Parameter,
+      inputClock: ClockParameter,
+      clocks: List[String],
+      multiply: Int
+  ) extends ClockControllerBase(parameter) {
+    val clockFrequency = inputClock.frequency
+
+    val clockCtrlClockDomain = ClockDomain(
+      clock = io.mainClock,
+      frequency = FixedFrequency(clockFrequency),
+      config = ClockDomainConfig(
+        resetKind = BOOT
+      )
+    )
+
+    val clockCtrl = new ClockingArea(clockCtrlClockDomain) {
+      val pll = XilinxPLL.PLLE2_BASE(CLKFBOUT_MULT = multiply).connect()
+    }
+
+    def addClock(index: Int, frequency: HertzNumber) = index match {
+      case 0 => clockCtrl.pll.addClock0(frequency)
+      case 1 => clockCtrl.pll.addClock1(frequency)
+      case 2 => clockCtrl.pll.addClock2(frequency)
+      case 3 => clockCtrl.pll.addClock3(frequency)
+      case 4 => clockCtrl.pll.addClock4(frequency)
+      case 5 => clockCtrl.pll.addClock5(frequency)
+    }
+    def getClockPin(index: Int) = index match {
+      case 0 => clockCtrl.pll.CLKOUT0
+      case 1 => clockCtrl.pll.CLKOUT1
+      case 2 => clockCtrl.pll.CLKOUT2
+      case 3 => clockCtrl.pll.CLKOUT3
+      case 4 => clockCtrl.pll.CLKOUT4
+      case 5 => clockCtrl.pll.CLKOUT5
+    }
+
+    for ((clock, index) <- clocks.zipWithIndex) {
+      val (domainIndex, domain) = parameter.getDomainByName(clock)
+      io.clocks(domainIndex) := addClock(index, domain.frequency)
+      generatedClocks = generatedClocks :+ getClockPin(index)
     }
   }
 }

--- a/hardware/scala/nafarr/system/reset/ResetControllerCtrl.scala
+++ b/hardware/scala/nafarr/system/reset/ResetControllerCtrl.scala
@@ -10,20 +10,10 @@ import spinal.lib.bus.misc.BusSlaveFactory
 import scala.collection.mutable.Map
 
 object ResetControllerCtrl {
-  def apply(parameter: Parameter) = {
-    val resetCtrl = ResetControllerCtrl(parameter)
-    resetCtrl.io.trigger <> U(0, parameter.domains.length bits)
-    resetCtrl
-  }
 
   case class Parameter(domains: List[ResetParameter]) {
     for (domain <- domains)
       require(domain.delay > 0, s"Delay for reset domain ${domain.name} must at least 1 cycle!")
-  }
-
-  case class Io(parameter: Parameter) extends Bundle {
-    val resets = in UInt (parameter.domains.length bits)
-    val trigger = out UInt (parameter.domains.length bits)
   }
 
   case class Config(parameter: Parameter) extends Bundle {
@@ -32,19 +22,15 @@ object ResetControllerCtrl {
     val acknowledge = Bool
   }
 
-  case class ResetControllerCtrl(parameter: Parameter) extends Component {
+  abstract class ResetControllerBase(parameter: Parameter) extends Component {
+    addAttribute("keep_hierarchy", "yes")
     val io = new Bundle {
-      val resets = out UInt (parameter.domains.length bits)
-      val trigger = in UInt (parameter.domains.length bits)
-      val buildConnection = Io(parameter)
+      val mainReset = in(Bool())
+      val mainClock = in(Bool())
+      val resets = out(UInt(parameter.domains.length bits))
+      val trigger = in(UInt(parameter.domains.length bits))
       val config = in(Config(parameter))
     }
-    io.resets := io.buildConnection.resets
-    val ctrlTrigger = U(0, parameter.domains.length bits)
-    when(io.config.acknowledge) {
-      ctrlTrigger := io.config.trigger
-    }
-    io.buildConnection.trigger := io.config.enable & (io.trigger | ctrlTrigger)
 
     var resetDict = Map[String, (Bool, Int)]()
     var triggerDict = Map[String, Bool]()
@@ -52,38 +38,77 @@ object ResetControllerCtrl {
       resetDict += domain.name -> (io.resets(index), index)
       triggerDict += domain.name -> io.trigger(index)
     }
-    def getResetByName(name: String): (Bool, Int) = resetDict.get(name).get
+    def getResetByName(name: String): (Bool, Int) = {
+      resetDict.get(name).get
+    }
     def triggerByNameWithCond(name: String, cond: Bool) {
       triggerDict.get(name).get.setWhen(cond)
     }
+  }
 
-    def buildXilinx(clock: Bool) {
-      val resetCtrlClockDomain = ClockDomain(
-        clock = clock,
-        config = ClockDomainConfig(
-          resetKind = BOOT
-        )
-      )
+  case class DummyResetController(parameter: Parameter) extends ResetControllerBase(parameter) {
+    val resetCtrlClockDomain = ClockDomain(
+      clock = io.mainClock,
+      reset = io.mainReset,
+      config = ClockDomainConfig(resetKind = spinal.core.SYNC, resetActiveLevel = LOW)
+    )
 
-      val resetCtrl = new ClockingArea(resetCtrlClockDomain) {
-        for (((domain), index) <- parameter.domains.zipWithIndex) {
-          val resetUnbuffered = True
-          val counter = Reg(UInt(log2Up(domain.delay) bits)).init(0)
-          when(counter =/= U(domain.delay - 1)) {
-            counter := counter + 1
-            resetUnbuffered := False
-          }
-          when(counter === U(domain.delay - 1) && BufferCC(io.buildConnection.trigger(index))) {
-            counter := 0
-          }
-          io.buildConnection.resets(index) := RegNext(resetUnbuffered)
+    val internalResets = UInt(parameter.domains.length bits)
+    val mainResetFanout = io.mainReset #* parameter.domains.length
+
+    val resetCtrl = new ClockingArea(resetCtrlClockDomain) {
+      val configAcknowledge = BufferCC(io.config.acknowledge)
+      val configTrigger = BufferCC(io.config.trigger)
+      val configEnable = BufferCC(io.config.enable)
+      val trigger = BufferCC(io.trigger)
+
+      for (((domain), index) <- parameter.domains.zipWithIndex) {
+        val resetUnbuffered = True
+        // Extend external reset with one cycle.
+        val locked = RegInit(False)
+        val counter = Reg(UInt(log2Up(domain.delay) bits)).init(0)
+
+        when(configAcknowledge && configTrigger(index)) {
+          locked := False
         }
+        when(configEnable(index) && trigger(index)) {
+          locked := False
+        }
+        when(!locked && counter =/= U(domain.delay - 1)) {
+          counter := counter + 1
+          resetUnbuffered := False
+        }
+        when(counter === U(domain.delay - 1)) {
+          counter := 0
+          locked := True
+        }
+        internalResets(index) := RegNext(resetUnbuffered)
       }
     }
 
-    def buildDummy(reset: Bool) {
+    io.resets := internalResets & mainResetFanout.asUInt
+  }
+
+  case class GeneratorResetController(parameter: Parameter) extends ResetControllerBase(parameter) {
+    val resetCtrlClockDomain = ClockDomain(
+      clock = io.mainClock,
+      config = ClockDomainConfig(
+        resetKind = BOOT
+      )
+    )
+
+    val resetCtrl = new ClockingArea(resetCtrlClockDomain) {
       for (((domain), index) <- parameter.domains.zipWithIndex) {
-        io.buildConnection.resets(index) := reset
+        val resetUnbuffered = True
+        val counter = Reg(UInt(log2Up(domain.delay) bits)).init(0)
+        when(counter =/= U(domain.delay - 1)) {
+          counter := counter + 1
+          resetUnbuffered := False
+        }
+        when(counter === U(domain.delay - 1) && BufferCC(io.trigger(index))) {
+          counter := 0
+        }
+        io.resets(index) := RegNext(resetUnbuffered)
       }
     }
   }


### PR DESCRIPTION
The previous version of reset and clock controller had almost no logic inside the controller module inside. This is not ideal when adding one of those controllers as macro, since it won't place the actual hardware inside.

Rework both controllers to move the reset and clock logic inside the module.