### PR TITLE
Fixes for GPIO and IHP Blackbox

### DIFF
--- a/hardware/scala/nafarr/blackboxes/ihp/common/IO.scala
+++ b/hardware/scala/nafarr/blackboxes/ihp/common/IO.scala
@@ -28,14 +28,10 @@ object IhpPowerIoCell {
 }
 
 object Edge extends Enumeration {
-  val North, South, East, West = Value
-
-  override def toString: String = this match {
-    case North => "north"
-    case South => "south"
-    case East => "east"
-    case West => "west"
-  }
+  val North = Value("north")
+  val South = Value("south")
+  val East = Value("east")
+  val West = Value("west")
 }
 
 object IhpPowerIo {

--- a/hardware/scala/nafarr/peripherals/io/gpio/Gpio.scala
+++ b/hardware/scala/nafarr/peripherals/io/gpio/Gpio.scala
@@ -43,7 +43,7 @@ object Gpio {
         name: String,
         address: BigInt,
         size: BigInt,
-        irqNumber: Option[Int] = null
+        irqNumber: Option[Int] = None
     ) = {
       val baseAddress = "%x".format(address.toInt)
       val regSize = "%04x".format(size.toInt)
@@ -67,7 +67,7 @@ object Gpio {
         name: String,
         address: BigInt,
         size: BigInt,
-        irqNumber: Option[Int] = null
+        irqNumber: Option[Int] = None
     ) = {
       val baseAddress = "%08x".format(address.toInt)
       val regSize = "%04x".format(size.toInt)
@@ -86,8 +86,7 @@ case class Apb3Gpio(
       parameter,
       Apb3(busConfig),
       Apb3SlaveFactory(_)
-    ) { val dummy = 0 }
-
+    )
 case class WishboneGpio(
     parameter: GpioCtrl.Parameter,
     busConfig: WishboneConfig = WishboneConfig(10, 32)
@@ -95,8 +94,7 @@ case class WishboneGpio(
       parameter,
       Wishbone(busConfig.copy(addressWidth = 10)),
       WishboneSlaveFactory(_)
-    ) { val dummy = 0 }
-
+    )
 case class AvalonMMGpio(
     parameter: GpioCtrl.Parameter,
     busConfig: AvalonMMConfig = AvalonMMConfig.fixed(12, 32, 1)
@@ -104,4 +102,4 @@ case class AvalonMMGpio(
       parameter,
       AvalonMM(busConfig),
       AvalonMMSlaveFactory(_)
-    ) { val dummy = 0 }
+    )

--- a/hardware/scala/nafarr/peripherals/io/gpio/GpioCtrl.scala
+++ b/hardware/scala/nafarr/peripherals/io/gpio/GpioCtrl.scala
@@ -17,27 +17,31 @@ object GpioCtrl {
   case class Parameter(
       io: Gpio.Parameter,
       readBufferDepth: Int = 0,
-      var output: Seq[Int] = null,
-      var input: Seq[Int] = null,
-      var interrupt: Seq[Int] = null,
+      output: Option[Seq[Int]] = None,
+      input: Option[Seq[Int]] = None,
+      interrupt: Option[Seq[Int]] = None,
       invertWriteEnable: Boolean = false
-  ) {
-    if (output == null)
-      output = (0 until io.width)
-    if (input == null)
-      input = (0 until io.width)
-    if (interrupt == null)
-      interrupt = (0 until io.width)
-  }
+  )
   object Parameter {
     def default(width: Int = 32, invertWriteEnable: Boolean = false) =
-      Parameter(Gpio.Parameter(width), 1, null, null, null, invertWriteEnable)
+      Parameter(Gpio.Parameter(width), 1, invertWriteEnable = invertWriteEnable)
     def noInterrupt(width: Int = 32, invertWriteEnable: Boolean = false) =
-      Parameter(Gpio.Parameter(width), 1, null, null, Seq[Int](), invertWriteEnable)
+      Parameter(
+        Gpio.Parameter(width),
+        1,
+        interrupt = Some(Seq.empty),
+        invertWriteEnable = invertWriteEnable
+      )
     def onlyOutput(width: Int = 32, invertWriteEnable: Boolean = false) =
-      Parameter(Gpio.Parameter(width), 0, null, Seq[Int](), Seq[Int](), invertWriteEnable)
+      Parameter(
+        Gpio.Parameter(width),
+        0,
+        input = Some(Seq.empty),
+        interrupt = Some(Seq.empty),
+        invertWriteEnable = invertWriteEnable
+      )
     def onlyInput(width: Int = 32) =
-      Parameter(Gpio.Parameter(width), 0, Seq[Int](), null, null)
+      Parameter(Gpio.Parameter(width), 0, output = Some(Seq.empty))
   }
 
   case class Config(p: Parameter) extends Bundle {
@@ -121,24 +125,24 @@ object GpioCtrl {
       for (i <- 0 until pins) {
         val pin = bank * 32 + i
         // IO registers
-        if (p.input.contains(pin))
+        if (p.input.forall(_.contains(pin)))
           busCtrl.read(ctrl.value(pin), inputAddr, i)
-        if (p.output.contains(pin)) {
+        if (p.output.forall(_.contains(pin))) {
           busCtrl.driveAndRead(ctrl.config.write(pin), outputAddr, i).init(False)
         } else {
           busCtrl.read(False, outputAddr, i)
           ctrl.config.write(pin) := False
         }
-        if (p.output.contains(pin) && p.input.contains(in)) {
+        if (p.output.forall(_.contains(pin)) && p.input.forall(_.contains(pin))) {
           busCtrl.driveAndRead(ctrl.config.direction(pin), directionAddr, i).init(False)
         } else {
-          val direction = RegInit(Bool(p.output.contains(pin)))
+          val direction = RegInit(Bool(p.output.forall(_.contains(pin))))
           direction.allowUnsetRegToAvoidLatch
           busCtrl.read(direction, directionAddr, i)
           ctrl.config.direction(pin) := direction
         }
         // Interrupt controller
-        if (p.interrupt.contains(pin)) {
+        if (p.interrupt.forall(_.contains(pin))) {
           irqHighCtrl.io.inputs(i) := ctrl.irqHigh.valid(pin)
           irqLowCtrl.io.inputs(i) := ctrl.irqLow.valid(pin)
           irqRiseCtrl.io.inputs(i) := ctrl.irqRise.valid(pin)

--- a/test/scala/nafarr/peripherals/io/gpio/Apb3GpioTest.scala
+++ b/test/scala/nafarr/peripherals/io/gpio/Apb3GpioTest.scala
@@ -29,9 +29,9 @@ class Apb3GpioTest extends AnyFunSuite {
       val dut = Apb3Gpio(GpioCtrl.Parameter(
           io = Gpio.Parameter(32),
           readBufferDepth = 1,
-          input = Seq[Int](0, 1, 2, 3, 5, 7, 31),
-          output = Seq[Int](0, 3, 4, 5, 6, 7, 31),
-          interrupt = Seq[Int](0, 3, 5, 7, 31)
+          input = Some(Seq(0, 1, 2, 3, 5, 7, 31)),
+          output = Some(Seq(0, 3, 4, 5, 6, 7, 31)),
+          interrupt = Some(Seq(0, 3, 5, 7, 31))
         )
       )
       dut.ctrl.io.value.simPublic()


### PR DESCRIPTION
    hardware: nafarr: periphals: Improve GPIO
    
    Fix undefined variable 'in' in GpioCtrl.Mapper (should be 'pin'), which caused
    a compilation error for bidirectional GPIO pins. Replace null-initialized mutable
    var fields in Parameter with Option[Seq[Int]] = None, update factory methods and
    all call sites accordingly. Fix Option[Int] = null defaults in deviceTreeZephyr
    and headerBareMetal to use None. Remove unused dummy vals from Apb3Gpio,
    WishboneGpio, and AvalonMMGpio.

------

    hardware: nafarr: blackboxes: ihp: Fix Warning
    
    Don't overwrite the toString function and use .Value directly.
