### PR TITLE
hardware: nafarr: peripherals: io: Update Programmable IO

### DIFF
--- a/docs/source/hardware/peripherals/pio.rst
+++ b/docs/source/hardware/peripherals/pio.rst
@@ -3,63 +3,181 @@
 Programmable IO
 ###############
 
-The Programmable IO IP Core is a versatile and highly configurable module designed for generating and controlling low-speed digital interfaces. It features an internal state machine that can be programmed to drive the IO signal in various sequences. This allows the IP core to support a wide range of protocols and custom interfaces by bit-banging the signal according to the programmed commands.
+The Programmable IO (PIO) IP Core is a versatile and highly configurable module designed for generating and controlling low-speed digital interfaces. It features an internal state machine that executes a user-defined program stored in on-chip memory to drive IO signals in precise sequences. This allows the IP core to support a wide range of protocols and custom interfaces by bit-banging signals according to the programmed commands, without requiring continuous CPU intervention.
+
+Program Memory
+**************
+
+Unlike a streaming FIFO approach, the PIO stores its program in an internal memory. Software writes instructions sequentially into the program memory via the bus interface. A write pointer tracks the next free slot, and an execution pointer tracks the currently executing instruction. Execution begins when the enable flag is set, which also resets both the execution pointer and the loop counter to zero.
+
+This separation of loading and execution means software can fill the entire program buffer before starting the state machine, removing any real-time loading pressure.
+
+To replace a running program, disable the controller, issue a program reset (which resets the write pointer), write the new instructions, then re-enable.
 
 State Machine
 *************
 
-The core of the Programmable IO IP Core is its internal state machine, which operates in four distinct states:
+The state machine reads instructions from program memory and executes them in sequence. The following commands are supported:
+
+**Single-pin commands** use the ``pin`` field to select the target IO pin:
 
 1. **Signal High (HIGH)**
 
-   * In this state, the IO signal is set to a high logic level (1).
-   * This state is used when the protocol requires a high signal on the IO line.
+   * Sets the selected pin to a high logic level (output, driven high).
    * Command value: 0x0
 
 2. **Signal Low (LOW)**
 
-   * In this state, the IO signal is set to a low logic level (0).
-   * This state is used when the protocol requires a low signal on the IO line.
-   * Command value: 0x1
-
-3. **Wait (WAIT)**
-
-   * The WAIT state introduces a delay in the signal transition.
-   * It is useful for timing control, ensuring that the signal remains in its current state for a specified period.
+   * Sets the selected pin to a low logic level (output, driven low).
    * Command value: 0x2
 
-4. **Read (READ)**
+3. **Float (FLOAT)**
 
-   * In the READ state, the core samples the IO signal and returns its value.
-   * This state is essential for protocols that require reading data from the IO line.
-   * Command value: 0x3
+   * Sets the selected pin to a high-impedance (input) state.
+   * Command value: 0x4
 
-Command Interface
-*****************
+4. **Toggle (TOGGLE)**
 
-The state machine transitions between these states based on commands received via a control interface. Each command specifies the next state and any necessary parameters, such as the duration of the WAIT state or the number of pins to read in the READ state.
+   * Toggles the direction of the selected pin (output ↔ input).
+   * Command value: 0x6
 
-**Example Commands:**
+5. **Wait (WAIT)**
 
-* **SET_HIGH:** Transition to the HIGH state.
-* **SET_LOW:** Transition to the LOW state.
-* **SET_WAIT(n):** Enter the WAIT state for 'n' clock cycles.
-* **READ:** Transition to the READ state and capture the current IO signal.
+   * Holds execution for a number of clock-divider ticks specified in the ``data`` field.
+   * Command value: 0x8
+
+6. **Wait for High (WAIT_FOR_HIGH)**
+
+   * Stalls execution until the selected pin reads a high level.
+   * Command value: 0x9
+
+7. **Wait for Low (WAIT_FOR_LOW)**
+
+   * Stalls execution until the selected pin reads a low level.
+   * Command value: 0xA
+
+8. **Read (READ)**
+
+   * Sets the selected pin to input mode, waits for ``readDelayValue`` clock-divider ticks
+     (configured globally via the read delay register) to allow the line to settle, then samples
+     the pin and pushes the result into the read FIFO.
+   * Stalls until the read FIFO accepts the result (backpressure).
+   * The ``data`` field of a READ instruction is ignored.
+   * Command value: 0xB
+
+**Multi-pin commands** use the ``data`` field as a bitmask — each bit corresponds to one IO pin:
+
+9. **Signal High Set (HIGH_SET)**
+
+   * Sets all pins indicated by the ``data`` bitmask to output high.
+   * Command value: 0x1
+
+10. **Signal Low Set (LOW_SET)**
+
+    * Sets all pins indicated by the ``data`` bitmask to output low.
+    * Command value: 0x3
+
+11. **Float Set (FLOAT_SET)**
+
+    * Sets all pins indicated by the ``data`` bitmask to high-impedance (input).
+    * Command value: 0x5
+
+12. **Toggle Set (TOGGLE_SET)**
+
+    * Toggles the direction of all pins indicated by the ``data`` bitmask.
+    * Command value: 0x7
+
+**Program flow commands:**
+
+13. **Loop (LOOP)**
+
+    * Controls program repetition.
+    * ``data = 0``: jumps back to instruction 0 indefinitely (endless loop).
+    * ``data = N``: runs the program N times in total, then advances past the LOOP instruction
+      and asserts the ``loopDone`` interrupt.
+    * If the ``stopAtLoop`` control bit is set when the LOOP instruction is reached, the state
+      machine always advances past it regardless of ``data``, allowing software to gracefully
+      terminate an endless loop. See the ``stopAtLoop`` register field.
+    * Command value: 0xC
+
+Command Encoding
+****************
+
+Each instruction is a 32-bit word with the following layout:
+
+.. code-block:: text
+
+   Bit  3 - 0 : command   (4-bit enum, see command values above)
+   Bit  P - 4 : pin       (log2Up(io.width) bits, 0 for multi-pin commands)
+   Bit 31 - Q : data      (dataWidth bits, bitmask for _SET commands, count for WAIT/READ/LOOP)
+
+   where P = 3 + log2Up(io.width), Q = P + 1
 
 Usage
 *****
 
-To utilize the Programmable IO IP Core for bit-banging various low-speed interfaces, users must configure the state machine with a sequence of commands that reflect the desired protocol's timing and signal transitions. The commands can be sent in real-time, allowing dynamic reconfiguration based on operational needs.
+**Example: Blink pin 0 forever**
 
-**Example Sequence:**
+.. code-block:: c
 
-1. **SET_LOW:** Start with the signal low.
-2. **SET_WAIT(10):** Wait for 10 clock cycles.
-3. **SET_HIGH:** Set the signal high.
-4. **SET_WAIT(5):** Wait for 5 clock cycles.
-5. **READ:** Read the signal to capture the input value.
+   // 1. Stop and reset the program memory
+   WRITE32(PIO_ENABLE, 0);
+   WRITE32(PIO_STATUS, 1);          // any write triggers programReset
 
-This sequence could be part of a protocol where the signal is pulled low, held for a period, then raised, and a value is read from the line.
+   // 2. Set clock divider
+   WRITE32(PIO_CLK_DIV, 99);        // tick every 100 cycles
+
+   // 3. Load program
+   WRITE32(PIO_TX, CMD(HIGH, pin=0, data=0));
+   WRITE32(PIO_TX, CMD(WAIT, pin=0, data=500));
+   WRITE32(PIO_TX, CMD(LOW,  pin=0, data=0));
+   WRITE32(PIO_TX, CMD(WAIT, pin=0, data=500));
+   WRITE32(PIO_TX, CMD(LOOP, pin=0, data=0)); // endless
+
+   // 4. Enable IRQ mask and start
+   WRITE32(PIO_IRQ_MASK, 0x2);      // unmask loopDone (optional for endless)
+   WRITE32(PIO_ENABLE, 1);          // rising edge resets execPtr and loopCounter
+
+**Example: Run 3 times, receive loopDone interrupt, reload**
+
+.. code-block:: c
+
+   WRITE32(PIO_ENABLE, 0);
+   WRITE32(PIO_STATUS, 1);
+
+   WRITE32(PIO_TX, CMD(HIGH, 0, 0));
+   WRITE32(PIO_TX, CMD(WAIT, 0, 100));
+   WRITE32(PIO_TX, CMD(LOW,  0, 0));
+   WRITE32(PIO_TX, CMD(WAIT, 0, 100));
+   WRITE32(PIO_TX, CMD(LOOP, 0, 3)); // run 3 times, then loopDone
+
+   WRITE32(PIO_IRQ_MASK, 0x2);
+   WRITE32(PIO_ENABLE, 1);
+
+   // In the ISR when loopDone fires:
+   WRITE32(PIO_ENABLE, 0);
+   WRITE32(PIO_STATUS, 1);          // reset write pointer
+   // ... write new program ...
+   WRITE32(PIO_ENABLE, 1);          // re-arm execPtr via rising edge
+
+**Example: gracefully stop an endless loop and reload**
+
+.. code-block:: c
+
+   // Program is running an endless LOOP — stopping with stopAtLoop:
+   //   1. Set stopAtLoop (bit 1). The state machine completes the current
+   //      iteration and advances past the LOOP instruction on the next pass.
+   WRITE32(PIO_ENABLE, READ32(PIO_ENABLE) | 0x2);
+
+   //   2. Poll until execPtr == writePtr (state machine has idled).
+   while ((READ32(PIO_STATUS) & 0xFF) != ((READ32(PIO_STATUS) >> 8) & 0xFF));
+
+   //   3. Clear stopAtLoop, then reload.
+   WRITE32(PIO_ENABLE, READ32(PIO_ENABLE) & ~0x2);
+   WRITE32(PIO_ENABLE, 0);          // disable
+   WRITE32(PIO_STATUS, 1);          // reset write pointer
+   // ... write new program ...
+   WRITE32(PIO_ENABLE, 1);          // re-arm and start
 
 Applications
 ************
@@ -67,7 +185,7 @@ Applications
 The flexibility of the Programmable IO IP Core makes it suitable for a variety of applications, including but not limited to:
 
 * Custom serial communication protocols
-* GPIO signal manipulation
+* Precise GPIO signal sequencing without CPU polling
 * Interface with legacy hardware with specific timing requirements
 * Prototyping new digital communication standards
 
@@ -100,7 +218,7 @@ Parameter
      - Number of IO pins. Must be greater then 0.
      -
 
-`PioCtrl.InitParameter` defines the initialization values for certian registers.
+`PioCtrl.InitParameter` defines the initialization values for certain registers.
 
 .. list-table:: PioCtrl.InitParameter
    :widths: 25 25 25 25
@@ -121,10 +239,10 @@ Parameter
 
 .. note::
 
-   Parameter in InitParameter with a value "0" are equal to disabled. This allows to
-   only set certain parameters.
+   Parameters in InitParameter with a value of ``0`` are treated as disabled. This allows
+   selectively initializing only certain registers.
 
-`PioCtrl.MemoryMappedParameter` defines the FIFO width.
+`PioCtrl.MemoryMappedParameter` defines the program memory and read FIFO depths.
 
 .. list-table:: PioCtrl.MemoryMappedParameter
    :widths: 25 25 25 25
@@ -136,11 +254,11 @@ Parameter
      - Default
    * - commandFifoDepth
      - Int
-     - FIFO depth for incoming commands.
+     - Depth of the program memory (maximum number of instructions).
      - 16
    * - readFifoDepth
      - Int
-     - FIFO depth for outgoing read results.
+     - Depth of the read result FIFO.
      - 8
 
 `PioCtrl.PermissionParameter` defines the permission rules for bus access.
@@ -155,7 +273,7 @@ Parameter
      - Default
    * - busCanWriteClockDividerConfig
      - Boolean
-     - Toggles bus access to the clock divider.
+     - Toggles bus write access to the clock divider.
      -
 
 `PioCtrl.Parameter` configures the programmable IO controller. It uses `Pio.Parameter` as parameter.
@@ -186,12 +304,11 @@ Parameter
      - PermissionParameter.granted
    * - memory
      - PioCtrl.MemoryMappedParameter
-     - Class to define FIFO depth.
+     - Class to define program memory and read FIFO depth.
      - MemoryMappedParameter.default
    * - dataWidth
      - Int
-     - Width of the data field used in the command FIFO to pass additional information to the
-       controller.
+     - Width of the data field in each instruction word.
      - 24
    * - clockDividerWidth
      - Int
@@ -201,8 +318,16 @@ Parameter
      - Int
      - Width of the read delay counter.
      - 8
+   * - interrupt
+     - Boolean
+     - Enables the interrupt controller with loopDone and RX data sources.
+     - true
+   * - error
+     - Boolean
+     - Enables the error controller with a read FIFO overflow source.
+     - true
 
-`PioCtrl.Parameter` has some functions with pre-predefined parameters for common use-cases.
+`PioCtrl.Parameter` has some functions with pre-defined parameters for common use-cases.
 
 .. code-block:: scala
 
@@ -218,7 +343,7 @@ Register Mapping
 
 .. |ip-identification-id-value| replace:: 0x1
 .. |ip-identification-major-version| replace:: 0x1
-.. |ip-identification-minor-version| replace:: 0x0
+.. |ip-identification-minor-version| replace:: 0x1
 .. |ip-identification-patch-version| replace:: 0x0
 
 .. include:: ../ipidentification.rsti
@@ -252,8 +377,7 @@ This block discloses information about the IP core to software drivers to simpli
      - dataWidth
      -
      - Rx
-     - Width of the data field used in the command FIFO to pass additional information to the
-       controller.
+     - Width of the data field in each instruction word.
    * - 7 - 0
      - IO width
      -
@@ -264,22 +388,22 @@ This block discloses information about the IP core to software drivers to simpli
      - readFifoDepth
      -
      - Rx
-     - Depth of the read FIFO.
+     - Depth of the read result FIFO.
    * - 7 - 0
      - commandFifoDepth
      -
      - Rx
-     - Depth of the command FIFO.
+     - Depth of the program memory (maximum number of instructions).
    * - 0x010
      - 0
      - busCanWriteClockDividerConfig
      -
      - Rx
-     - Flag whether the clock divider is writable.
+     - Flag whether the clock divider register is bus-writable.
 
-**Command and Read FIFO:**
+**Control:**
 
-.. flat-table:: Command and Read FIFO
+.. flat-table:: Control Registers
    :widths: 10 10 15 10 10 45
    :header-rows: 1
 
@@ -290,36 +414,73 @@ This block discloses information about the IP core to software drivers to simpli
      - Permission
      - Description
    * - :rspan:`1` 0x014
+     - 1
+     - stopAtLoop
+     - 0
+     - RW
+     - When set, the next LOOP instruction encountered advances the execution pointer past the
+       LOOP instruction instead of jumping back, regardless of the loop count. Once the execution
+       pointer reaches the write pointer the state machine idles. Clear this bit after the
+       program has stopped. Used by software to gracefully terminate an endless loop.
+   * - 0
+     - enable
+     - 0
+     - RW
+     - Enables program execution. A low-to-high transition resets the execution pointer and
+       loop counter to zero.
+
+**Program Memory and Read FIFO:**
+
+.. flat-table:: Program Memory and Read FIFO Registers
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - :rspan:`1` 0x018
      - 16
-     - validBit
+     - valid
      -
      - Rx
-     - This bit contains a 1 when the result FIFO returned valid payload.
+     - Set when the read FIFO returned a valid result. Must be checked before consuming the payload.
    * - 15 - 0
-     - resultFifo
+     - readResult
      -
      - Rx
-     - Payload from the result FIFO.
-   * - 0x014
+     - Result sampled by the last READ command, consumed from the read FIFO on each read.
+   * - 0x018
      - 31 - 0
-     - commandFifo
+     - programWrite
      -
      - xW
-     - Sends a command to the controller with the following payload:
-         * Lower two bits define the command.
-         * Decimal number of the pin.
-         * Additional data.
-   * - :rspan:`2` 0x018
+     - Writes one instruction word into program memory at the current write pointer position
+       and advances the write pointer.
+   * - :rspan:`2` 0x01C
      - 31 - 24
-     - occupancy
+     - rxOccupancy
      -
      - Rx
-     - Number of occupied slots in the result FIFO.
-   * - 23 - 16
-     - vacancy
+     - Number of unread results currently in the read FIFO.
+   * - 15 - 8
+     - writePtr
      -
      - Rx
-     - Number of empty slots in the command FIFO.
+     - Current program write pointer (next free instruction slot).
+   * - 7 - 0
+     - execPtr
+     -
+     - Rx
+     - Current execution pointer (instruction being executed).
+   * - 0x01C
+     - 31 - 0
+     - programReset
+     -
+     - xW
+     - Any write resets the write pointer to zero, allowing the program memory to be overwritten.
 
 **Clock Divider and Read Delay:**
 
@@ -333,15 +494,85 @@ This block discloses information about the IP core to software drivers to simpli
      - Default
      - Permission
      - Description
-   * - 0x01C
+   * - 0x020
      - clockDividerWidth - 0
      - clockDividerValue
      - Depends on `PioCtrl.InitParameter`
      - RW or Rx
-     - Value for the clock divider counter to divide down the input clock.
-   * - 0x020
+     - Value for the clock divider counter. The divider produces one tick every ``value + 1``
+       input clock cycles. Write access depends on ``busCanWriteClockDividerConfig``.
+   * - 0x024
      - readDelayWidth - 0
-     - ReadDelayValue
+     - readDelayValue
      - Depends on `PioCtrl.InitParameter`
-     - RW or Rx
-     - Number of cycles to delay during the read action.
+     - RW
+     - Number of clock-divider ticks to wait after switching a pin to input mode before sampling
+       it during a READ command. Applies globally to all READ instructions. Set to 0 to sample
+       immediately.
+
+**Error Controller:**
+
+Present when ``PioCtrl.Parameter.error = true``. Follows the standard interrupt controller
+pattern: writing a ``1`` to a pending bit clears it; the mask register enables individual
+error sources.
+
+.. flat-table:: Error Controller Registers
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - 0x028
+     - 0
+     - readFifoOverflow pending
+     - 0
+     - RW
+     - Sticky flag set when a READ result is dropped because the read FIFO is full.
+       Write ``1`` to clear.
+   * - 0x02C
+     - 0
+     - readFifoOverflow mask
+     - 0
+     - RW
+     - Enables the read FIFO overflow error source.
+
+**Interrupt Controller:**
+
+Present when ``PioCtrl.Parameter.interrupt = true``. Same pattern as the error controller.
+
+.. flat-table:: Interrupt Controller Registers
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - :rspan:`1` 0x030
+     - 1
+     - loopDone pending
+     - 0
+     - RW
+     - Sticky flag set when a LOOP N command finishes all N iterations. Write ``1`` to clear.
+   * - 0
+     - rxData pending
+     - 0
+     - RW
+     - Sticky flag set when the read FIFO contains at least one result. Write ``1`` to clear.
+   * - :rspan:`1` 0x034
+     - 1
+     - loopDone mask
+     - 0
+     - RW
+     - Enables the loopDone interrupt source.
+   * - 0
+     - rxData mask
+     - 0
+     - RW
+     - Enables the RX data available interrupt source.

--- a/hardware/scala/nafarr/peripherals/io/pio/Pio.scala
+++ b/hardware/scala/nafarr/peripherals/io/pio/Pio.scala
@@ -29,10 +29,12 @@ object Pio {
     val io = new Bundle {
       val bus = slave(busType())
       val pio = Io(parameter.io)
+      val interrupt = out(Bool)
     }
 
     val ctrl = PioCtrl(parameter)
     ctrl.io.pio <> io.pio
+    io.interrupt <> ctrl.io.interrupt
 
     val mapper = PioCtrl.Mapper(factory(io.bus), ctrl.io, parameter)
 
@@ -40,11 +42,13 @@ object Pio {
         name: String,
         address: BigInt,
         size: BigInt,
-        irqNumber: Option[Int] = null
+        irqNumber: Option[Int] = None
     ) = {
       val baseAddress = "%08x".format(address.toInt)
       val regSize = "%04x".format(size.toInt)
       var dt = s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
+      if (irqNumber.isDefined)
+        dt += s"""#define ${name.toUpperCase}_IRQ\t\t${irqNumber.get}\n"""
       dt
     }
   }

--- a/hardware/scala/nafarr/peripherals/io/pio/PioCtrl.scala
+++ b/hardware/scala/nafarr/peripherals/io/pio/PioCtrl.scala
@@ -47,13 +47,20 @@ object PioCtrl {
       memory: MemoryMappedParameter = MemoryMappedParameter.default,
       dataWidth: Int = 24,
       clockDividerWidth: Int = 20,
-      readDelayWidth: Int = 8
+      readDelayWidth: Int = 8,
+      interrupt: Boolean = true,
+      error: Boolean = true
   ) {
-    val ioDataWidth = io.width + dataWidth
     require(
-      ioDataWidth + 2 <= 32,
-      s"IO width and data width exceed with $ioDataWidth the 30 bit limit."
+      // 4-bit command + 4-bit pin + dataWidth bits data must fit in 32 bits
+      dataWidth + 8 <= 32,
+      s"dataWidth $dataWidth exceeds the 24-bit limit (4-bit command + 4-bit pin + dataWidth <= 32)."
     )
+    require(
+      io.width <= 16,
+      s"IO width ${io.width} exceeds the 16-pin limit of the 4-bit pin field."
+    )
+    require(io.width <= dataWidth, s"IO width must be small or equal to data width.")
 
     require(
       (init != null && init.clockDivider > 0) ||
@@ -70,12 +77,13 @@ object PioCtrl {
   }
 
   object CommandType extends SpinalEnum(binarySequential) {
-    val HIGH, LOW, WAIT, READ = newElement()
+    val HIGH, HIGH_SET, LOW, LOW_SET, FLOAT, FLOAT_SET, TOGGLE, TOGGLE_SET, WAIT, WAIT_FOR_HIGH,
+        WAIT_FOR_LOW, READ, LOOP = newElement()
   }
 
   case class CommandContainer(parameter: Parameter) extends Bundle {
     val command = CommandType()
-    val pin = UInt(log2Up(parameter.io.width) bits)
+    val pin = UInt(4 bits)
     val data = Bits(parameter.dataWidth bits)
   }
 
@@ -86,14 +94,21 @@ object PioCtrl {
   case class Config(parameter: Parameter) extends Bundle {
     val clockDivider = UInt(parameter.clockDividerWidth bits)
     val readDelay = UInt(parameter.readDelayWidth bits)
+    val enable = Bool()
+    val stopAtLoop = Bool()
+    val programReset = Bool()
   }
 
   case class Io(parameter: Parameter) extends Bundle {
     val pio = Pio.Io(parameter.io)
+    val interrupt = out(Bool)
+    val pendingInterrupts = in(Bits(2 bits))
     val config = in(Config(parameter))
-    val commands = slave(Stream(CommandContainer(parameter)))
+    val programWrite = slave(Flow(CommandContainer(parameter)))
+    val writePtr = out(UInt(log2Up(parameter.memory.commandFifoDepth) bits))
+    val execPtr = out(UInt(log2Up(parameter.memory.commandFifoDepth) bits))
+    val loopDone = out(Bool)
     val read = master(Stream(ReadContainer(parameter)))
-    val readIsFull = in(Bool)
   }
 
   case class PioCtrl(parameter: Parameter) extends Component {
@@ -110,53 +125,163 @@ object PioCtrl {
     clockDivider.io.value := io.config.clockDivider
     clockDivider.io.reload := False
 
+    io.interrupt := io.pendingInterrupts.orR
+    io.loopDone := False
+
+    // Program memory
+    val ptrWidth = log2Up(parameter.memory.commandFifoDepth)
+    val programMem = Mem(CommandContainer(parameter), parameter.memory.commandFifoDepth)
+    val writePtrReg = Reg(UInt(ptrWidth bits)).init(0)
+    val execPtrReg = Reg(UInt(ptrWidth bits)).init(0)
+    val loopCounter = Reg(UInt(parameter.dataWidth bits)).init(0)
+
+    when(io.programWrite.valid) {
+      programMem.write(writePtrReg, io.programWrite.payload)
+      writePtrReg := writePtrReg + 1
+    }
+    when(io.config.programReset) {
+      writePtrReg := 0
+    }
+    io.writePtr := writePtrReg
+    io.execPtr := execPtrReg
+
+    // Reset execution state on enable rising edge
+    val enablePrev = RegNext(io.config.enable, False)
+    when(io.config.enable && !enablePrev) {
+      execPtrReg := 0
+      loopCounter := 0
+    }
+
+    val currentCmd = programMem.readAsync(execPtrReg)
+    val pinNumber = currentCmd.pin.resize(log2Up(parameter.io.width))
+
+    val readContainer = ReadContainer(parameter)
+    readContainer.result := value(pinNumber).asBits
+
     val fsm = new StateMachine {
       val counter = Reg(UInt(parameter.dataWidth bits)).init(0)
       val write = Reg(Bits(parameter.io.width bits)).init(0)
       val direction = Reg(Bits(parameter.io.width bits)).init(0)
-      io.commands.ready := False
       io.read.valid := False
-      val pinNumber = io.commands.payload.pin.resize(log2Up(parameter.io.width))
-      val readContainer = ReadContainer(parameter)
-      readContainer.result := value(pinNumber).asBits
       io.read.payload := readContainer
 
       val stateIdle: State = new State with EntryPoint {
         whenIsActive {
-          when(io.commands.valid) {
-            switch(io.commands.payload.command) {
+          when(io.config.enable && (execPtrReg < writePtrReg)) {
+            switch(currentCmd.command) {
               is(CommandType.HIGH) {
                 goto(stateHigh)
+              }
+              is(CommandType.HIGH_SET) {
+                goto(stateHighSet)
               }
               is(CommandType.LOW) {
                 goto(stateLow)
               }
+              is(CommandType.LOW_SET) {
+                goto(stateLowSet)
+              }
+              is(CommandType.FLOAT) {
+                goto(stateFloat)
+              }
+              is(CommandType.FLOAT_SET) {
+                goto(stateFloatSet)
+              }
+              is(CommandType.TOGGLE) {
+                goto(stateToggle)
+              }
+              is(CommandType.TOGGLE_SET) {
+                goto(stateToggleSet)
+              }
               is(CommandType.WAIT) {
                 goto(stateWait)
               }
+              is(CommandType.WAIT_FOR_HIGH) {
+                goto(stateWaitForHigh)
+              }
+              is(CommandType.WAIT_FOR_LOW) {
+                goto(stateWaitForLow)
+              }
               is(CommandType.READ) {
                 goto(stateRead)
+              }
+              is(CommandType.LOOP) {
+                goto(stateLoop)
               }
             }
           }
         }
       }
+
+      // Single-cycle states: execute and advance execPtr in the same cycle
       val stateHigh = new State {
         whenIsActive {
           direction(pinNumber) := True
           write(pinNumber) := True
+          execPtrReg := execPtrReg + 1
           goto(stateIdle)
         }
-        onExit(io.commands.ready := True)
+      }
+      val stateHighSet = new State {
+        whenIsActive {
+          val mask = currentCmd.data(parameter.io.width - 1 downto 0)
+          direction := direction | mask
+          write := write | mask
+          execPtrReg := execPtrReg + 1
+          goto(stateIdle)
+        }
       }
       val stateLow = new State {
         whenIsActive {
           direction(pinNumber) := True
           write(pinNumber) := False
+          execPtrReg := execPtrReg + 1
           goto(stateIdle)
         }
-        onExit(io.commands.ready := True)
       }
+      val stateLowSet = new State {
+        whenIsActive {
+          val mask = currentCmd.data(parameter.io.width - 1 downto 0)
+          direction := direction | mask
+          write := write & ~mask
+          execPtrReg := execPtrReg + 1
+          goto(stateIdle)
+        }
+      }
+      val stateFloat = new State {
+        whenIsActive {
+          direction(pinNumber) := False
+          write(pinNumber) := False
+          execPtrReg := execPtrReg + 1
+          goto(stateIdle)
+        }
+      }
+      val stateFloatSet = new State {
+        whenIsActive {
+          val mask = currentCmd.data(parameter.io.width - 1 downto 0)
+          direction := direction & ~mask
+          write := write & ~mask
+          execPtrReg := execPtrReg + 1
+          goto(stateIdle)
+        }
+      }
+      val stateToggle = new State {
+        whenIsActive {
+          write(pinNumber) := !write(pinNumber)
+          execPtrReg := execPtrReg + 1
+          goto(stateIdle)
+        }
+      }
+      val stateToggleSet = new State {
+        whenIsActive {
+          val mask = currentCmd.data(parameter.io.width - 1 downto 0)
+          write := write ^ mask
+          execPtrReg := execPtrReg + 1
+          goto(stateIdle)
+        }
+      }
+
+      // Multi-cycle states: advance execPtr only when done
       val stateWait = new State {
         onEntry {
           clockDivider.io.reload := True
@@ -166,11 +291,27 @@ object PioCtrl {
           when(clockDivider.io.tick) {
             counter := counter + 1
           }
-          when(counter.asBits === io.commands.payload.data) {
+          when(counter.asBits === currentCmd.data) {
+            execPtrReg := execPtrReg + 1
             goto(stateIdle)
           }
         }
-        onExit(io.commands.ready := True)
+      }
+      val stateWaitForHigh = new State {
+        whenIsActive {
+          when(value(pinNumber)) {
+            execPtrReg := execPtrReg + 1
+            goto(stateIdle)
+          }
+        }
+      }
+      val stateWaitForLow = new State {
+        whenIsActive {
+          when(!value(pinNumber)) {
+            execPtrReg := execPtrReg + 1
+            goto(stateIdle)
+          }
+        }
       }
       val stateRead = new State {
         onEntry {
@@ -179,13 +320,39 @@ object PioCtrl {
         }
         whenIsActive {
           direction(pinNumber) := False
-          counter := counter + 1
-          when(counter.asBits === B(io.config.readDelay, parameter.dataWidth bits)) {
+          when(clockDivider.io.tick) {
+            counter := counter + 1
+          }
+          when(counter === io.config.readDelay.resized) {
             io.read.valid := True
-            goto(stateIdle)
+            when(io.read.ready) {
+              execPtrReg := execPtrReg + 1
+              goto(stateIdle)
+            }
           }
         }
-        onExit(io.commands.ready := True)
+      }
+
+      // LOOP: data=0 endless, data=N run N times total then fire loopDone
+      // When stopAtLoop is set, always advance past the LOOP instruction so
+      // execPtr reaches writePtr and flush can detect completion.
+      val stateLoop = new State {
+        whenIsActive {
+          when(io.config.stopAtLoop) {
+            loopCounter := 0
+            execPtrReg := execPtrReg + 1
+          } elsewhen (currentCmd.data === 0) {
+            execPtrReg := 0
+          } elsewhen (loopCounter < currentCmd.data.asUInt - 1) {
+            loopCounter := loopCounter + 1
+            execPtrReg := 0
+          } otherwise {
+            loopCounter := 0
+            io.loopDone := True
+            execPtrReg := execPtrReg + 1
+          }
+          goto(stateIdle)
+        }
       }
     }
 
@@ -198,7 +365,7 @@ object PioCtrl {
       ctrl: Io,
       p: Parameter
   ) extends Area {
-    val idCtrl = IpIdentification(IpIdentification.Ids.Pio, 1, 0, 0)
+    val idCtrl = IpIdentification(IpIdentification.Ids.Pio, 1, 1, 0)
     idCtrl.driveFrom(busCtrl)
     val staticOffset = idCtrl.length
 
@@ -221,42 +388,77 @@ object PioCtrl {
     }
     val regOffset = staticOffset + 0xc
 
+    // Basic control
+    val enable = Reg(ctrl.config.enable).init(False)
+    busCtrl.readAndWrite(enable, regOffset + 0x00, bitOffset = 0x0)
+    ctrl.config.enable := enable
+
+    val stopAtLoop = Reg(ctrl.config.stopAtLoop).init(False)
+    busCtrl.readAndWrite(stopAtLoop, regOffset + 0x00, bitOffset = 0x1)
+    ctrl.config.stopAtLoop := stopAtLoop
+
     val tx = new Area {
+      // Write into program memory: each bus write advances writePtr
       val cmdContainer = CommandContainer(p)
-      val streamUnbuffered =
-        busCtrl.createAndDriveFlow(cmdContainer, address = regOffset + 0x00).toStream
-      val (stream, fifoOccupancy) =
-        streamUnbuffered.queueWithOccupancy(p.memory.commandFifoDepth)
-      val fifoVacancy = p.memory.commandFifoDepth - fifoOccupancy
-      busCtrl.read(fifoVacancy, address = regOffset + 0x04, bitOffset = 16)
-      ctrl.commands << stream
-      streamUnbuffered.ready.allowPruning()
+      ctrl.programWrite << busCtrl.createAndDriveFlow(cmdContainer, address = regOffset + 0x04)
+
+      // Program status (read) and reset (write) share the same address:
+      //   read  -> execPtr[7:0] | writePtr[15:8] | rxOccupancy[31:24] (set by rx area)
+      //   write -> pulse programReset (any write triggers reset)
+      busCtrl.read(ctrl.execPtr, address = regOffset + 0x08, bitOffset = 0)
+      busCtrl.read(ctrl.writePtr, address = regOffset + 0x08, bitOffset = 8)
+      val programResetPulse = Bool()
+      programResetPulse := False
+      busCtrl.onWrite(regOffset + 0x08) {
+        programResetPulse := True
+      }
+      ctrl.config.programReset := programResetPulse
     }
 
     val rx = new Area {
       val (stream, fifoOccupancy) = ctrl.read.queueWithOccupancy(p.memory.readFifoDepth)
-      ctrl.readIsFull := fifoOccupancy >= p.memory.readFifoDepth - 1
+      val readIsFull = fifoOccupancy >= p.memory.readFifoDepth - 1
       busCtrl.readStreamNonBlocking(
         stream,
-        address = regOffset + 0x00,
+        address = regOffset + 0x04,
         validBitOffset = 16,
         payloadBitOffset = 0
       )
-      busCtrl.read(fifoOccupancy, address = regOffset + 0x04, bitOffset = 24)
+      busCtrl.read(fifoOccupancy, address = regOffset + 0x08, bitOffset = 24)
     }
 
     val clockDivider = Reg(UInt(p.clockDividerWidth bits))
     if (p.init != null && p.init.clockDivider != 0)
       clockDivider.init(p.init.clockDivider)
     if (p.permission != null && p.permission.busCanWriteClockDividerConfig)
-      busCtrl.write(clockDivider, regOffset + 0x08)
-    busCtrl.read(clockDivider, regOffset + 0x08)
+      busCtrl.write(clockDivider, regOffset + 0x0c)
+    busCtrl.read(clockDivider, regOffset + 0x0c)
     ctrl.config.clockDivider := clockDivider
 
     val readDelay = Reg(UInt(p.readDelayWidth bits))
     if (p.init != null && p.init.readDelay != 0)
       readDelay.init(p.init.readDelay)
-    busCtrl.readAndWrite(readDelay, regOffset + 0x0c)
+    busCtrl.readAndWrite(readDelay, regOffset + 0x10)
     ctrl.config.readDelay := readDelay
+
+    val error = new Area {
+      if (p.error) {
+        val errorCtrl = new InterruptCtrl(1)
+        errorCtrl.driveFrom(busCtrl, regOffset + 0x14)
+        errorCtrl.io.inputs(0) := rx.readIsFull && ctrl.read.valid // read FIFO is full error
+      }
+    }
+
+    val interrupt = new Area {
+      if (p.interrupt) {
+        val irqCtrl = new InterruptCtrl(2)
+        irqCtrl.driveFrom(busCtrl, regOffset + 0x1c)
+        irqCtrl.io.inputs(0) := (rx.fifoOccupancy > 0)
+        irqCtrl.io.inputs(1) := ctrl.loopDone
+        ctrl.pendingInterrupts := irqCtrl.io.pendings
+      } else {
+        ctrl.pendingInterrupts := 0
+      }
+    }
   }
 }

--- a/test/scala/nafarr/peripherals/io/pio/Apb3PioTest.scala
+++ b/test/scala/nafarr/peripherals/io/pio/Apb3PioTest.scala
@@ -13,11 +13,30 @@ import nafarr.CheckTester._
 import spinal.lib.bus.amba3.apb.sim.Apb3Driver
 
 class Apb3PioTest extends AnyFunSuite {
+  def fillCommands(apb: Apb3Driver, regOffset: Int, commands: List[BigInt]) {
+    // Disable engine and reset write pointer
+    apb.write(BigInt(regOffset), BigInt("00000", 2))
+    apb.write(BigInt(regOffset + 8), BigInt("00000", 2))
+    for (cmd <- commands) {
+      apb.write(BigInt(regOffset + 4), cmd)
+    }
+    // Enable engine
+    apb.write(BigInt(regOffset), BigInt("00001", 2))
+  }
+
+  def generateCmd(pin: Int, cmd: SpinalEnumElement[PioCtrl.CommandType.type], data: Option[BigInt] = None) = {
+    data match {
+      case Some(d) => (d << 8) | BigInt(pin << 4 | cmd.position)
+      case None    => BigInt(pin << 4 | cmd.position)
+    }
+  }
+
+
   test("parameters") {
     generationShouldFail(Apb3Pio(PioCtrl.Parameter.default(0)))
     generationShouldPass(Apb3Pio(PioCtrl.Parameter.default(1)))
-    generationShouldPass(Apb3Pio(PioCtrl.Parameter.default(6)))
-    generationShouldFail(Apb3Pio(PioCtrl.Parameter.default(7)))
+    generationShouldPass(Apb3Pio(PioCtrl.Parameter.default(16)))
+    generationShouldFail(Apb3Pio(PioCtrl.Parameter.default(17)))
 
     generationShouldPass(Apb3Pio(PioCtrl.Parameter.light()))
 
@@ -35,6 +54,11 @@ class Apb3PioTest extends AnyFunSuite {
 
     generationShouldPass {
       val parameter = PioCtrl.Parameter(io = Pio.Parameter(10), dataWidth = 20)
+      Apb3Pio(parameter)
+    }
+
+    generationShouldFail {
+      val parameter = PioCtrl.Parameter(io = Pio.Parameter(1), dataWidth = 25)
       Apb3Pio(parameter)
     }
 
@@ -73,8 +97,8 @@ class Apb3PioTest extends AnyFunSuite {
         "IP Identification 0x0 should return 00080001 - API: 0, Length: 8, ID: 1"
       )
       assert(
-        apb.read(BigInt(4)) == BigInt("01000000", 16),
-        "IP Identification 0x4 should return 01000000 - 1.0.0"
+        apb.read(BigInt(4)) == BigInt("01010000", 16),
+        "IP Identification 0x4 should return 01000000 - 1.1.0"
       )
 
       /* Read readBufferDepth, clockDividerWidth, dataWidth, io.Width */
@@ -97,10 +121,11 @@ class Apb3PioTest extends AnyFunSuite {
 
       /* Read FIFO status */
       assert(
-        apb.read(BigInt(regOffset + 4)) == BigInt("00100000", 16),
-        "Unable to read 00100000 from Pio FIFO status"
+        apb.read(BigInt(regOffset + 8)) == BigInt("00000000", 16),
+        "Unable to read 00000000 from Pio FIFO status"
       )
     }
+
     compiled.doSim("read value") { dut =>
       dut.clockDomain.forkStimulus(10)
       fork {
@@ -120,61 +145,66 @@ class Apb3PioTest extends AnyFunSuite {
       dut.clockDomain.waitFallingEdge()
 
       dut.io.pio.pins.read #= BigInt("00", 2)
-      apb.write(BigInt(regOffset), BigInt("011", 2))
-      dut.clockDomain.waitSampling(10)
+      fillCommands(apb, regOffset, List(
+        generateCmd(0, PioCtrl.CommandType.READ),
+        generateCmd(1, PioCtrl.CommandType.READ)
+      ))
+      dut.clockDomain.waitSampling(15)
       assert(
-        apb.read(BigInt(regOffset)) == BigInt("00010000", 16),
+        apb.read(BigInt(regOffset + 4)) == BigInt("00010000", 16),
         "Unable to read value 0 from Pio pin 0"
       )
-      apb.write(BigInt(regOffset), BigInt("111", 2))
-      dut.clockDomain.waitSampling(10)
       assert(
-        apb.read(BigInt(regOffset)) == BigInt("00010000", 16),
+        apb.read(BigInt(regOffset + 4)) == BigInt("00010000", 16),
         "Unable to read value 0 from Pio pin 1"
       )
 
       dut.io.pio.pins.read #= BigInt("01", 2)
-      apb.write(BigInt(regOffset), BigInt("011", 2))
-      dut.clockDomain.waitSampling(10)
+      fillCommands(apb, regOffset, List(
+        generateCmd(0, PioCtrl.CommandType.READ),
+        generateCmd(1, PioCtrl.CommandType.READ)
+      ))
+      dut.clockDomain.waitSampling(15)
       assert(
-        apb.read(BigInt(regOffset)) == BigInt("00010001", 16),
+        apb.read(BigInt(regOffset + 4)) == BigInt("00010001", 16),
         "Unable to read value 1 from Pio pin 0"
       )
-      apb.write(BigInt(regOffset), BigInt("111", 2))
-      dut.clockDomain.waitSampling(10)
       assert(
-        apb.read(BigInt(regOffset)) == BigInt("00010000", 16),
+        apb.read(BigInt(regOffset + 4)) == BigInt("00010000", 16),
         "Unable to read value 0 from Pio pin 1"
       )
 
       dut.io.pio.pins.read #= BigInt("10", 2)
-      apb.write(BigInt(regOffset), BigInt("011", 2))
-      dut.clockDomain.waitSampling(10)
+      fillCommands(apb, regOffset, List(
+        generateCmd(0, PioCtrl.CommandType.READ),
+        generateCmd(1, PioCtrl.CommandType.READ)
+      ))
+      dut.clockDomain.waitSampling(15)
       assert(
-        apb.read(BigInt(regOffset)) == BigInt("00010000", 16),
+        apb.read(BigInt(regOffset + 4)) == BigInt("00010000", 16),
         "Unable to read value 0 from Pio pin 0"
       )
-      apb.write(BigInt(regOffset), BigInt("111", 2))
-      dut.clockDomain.waitSampling(10)
       assert(
-        apb.read(BigInt(regOffset)) == BigInt("00010001", 16),
+        apb.read(BigInt(regOffset + 4)) == BigInt("00010001", 16),
         "Unable to read value 1 from Pio pin 1"
       )
 
       dut.io.pio.pins.read #= BigInt("11", 2)
-      apb.write(BigInt(regOffset), BigInt("011", 2))
-      dut.clockDomain.waitSampling(10)
+      fillCommands(apb, regOffset, List(
+        generateCmd(0, PioCtrl.CommandType.READ),
+        generateCmd(1, PioCtrl.CommandType.READ)
+      ))
+      dut.clockDomain.waitSampling(15)
       assert(
-        apb.read(BigInt(regOffset)) == BigInt("00010001", 16),
+        apb.read(BigInt(regOffset + 4)) == BigInt("00010001", 16),
         "Unable to read value 1 from Pio pin 0"
       )
-      apb.write(BigInt(regOffset), BigInt("111", 2))
-      dut.clockDomain.waitSampling(10)
       assert(
-        apb.read(BigInt(regOffset)) == BigInt("00010001", 16),
+        apb.read(BigInt(regOffset + 4)) == BigInt("00010001", 16),
         "Unable to read value 1 from Pio pin 1"
       )
     }
+
     compiled.doSim("toggle IO") { dut =>
       dut.clockDomain.forkStimulus(10)
       fork {
@@ -193,66 +223,393 @@ class Apb3PioTest extends AnyFunSuite {
       dut.clockDomain.waitSampling(2)
       dut.clockDomain.waitFallingEdge()
 
-      /* Set value HIGH */
       assert(
         dut.io.pio.pins.write.toBigInt == BigInt("00", 2),
         "Default PIO output value should be 00"
       )
-      apb.write(BigInt(regOffset), BigInt("000", 2))
+      assert(
+        dut.io.pio.pins.writeEnable.toBigInt == BigInt("00", 2),
+        "PIO direction value should be 00"
+      )
+
+      fillCommands(apb, regOffset, List(
+        generateCmd(0, PioCtrl.CommandType.HIGH)
+      ))
       dut.clockDomain.waitSampling(4)
+
       assert(
         dut.io.pio.pins.write.toBigInt == BigInt("01", 2),
         "PIO output value should be 01"
       )
-      assert(dut.io.pio.pins.writeEnable.toBigInt == BigInt("01", 2))
-      apb.write(BigInt(regOffset), BigInt("100", 2))
+      assert(
+        dut.io.pio.pins.writeEnable.toBigInt == BigInt("01", 2),
+        "PIO direction value should be 01"
+      )
+
+      fillCommands(apb, regOffset, List(
+        generateCmd(1, PioCtrl.CommandType.HIGH)
+      ))
       dut.clockDomain.waitSampling(4)
+
       assert(
         dut.io.pio.pins.write.toBigInt == BigInt("11", 2),
         "PIO output value should be 11"
       )
-      assert(dut.io.pio.pins.writeEnable.toBigInt == BigInt("11", 2))
+      assert(
+        dut.io.pio.pins.writeEnable.toBigInt == BigInt("11", 2),
+        "PIO direction value should be 11"
+      )
 
-      /* Wait 2 clock cycles and set LOW */
-      apb.write(BigInt(regOffset), BigInt("10010", 2))
-      apb.write(BigInt(regOffset), BigInt("001", 2))
-
-      /* clock divider = 2 (3 cycles), 2 wait cycles result in 6 cycles + 4 cycles overhead */
-      for (_ <- 0 until 10) {
-        assert(
-          dut.io.pio.pins.write.toBigInt == BigInt("11", 2),
-          "PIO output value should be 11"
-        )
-        assert(dut.io.pio.pins.writeEnable.toBigInt == BigInt("11", 2))
-        dut.clockDomain.waitSampling(1)
-      }
+      fillCommands(apb, regOffset, List(
+        generateCmd(1, PioCtrl.CommandType.LOW)
+      ))
+      dut.clockDomain.waitSampling(4)
 
       assert(
-        dut.io.pio.pins.write.toBigInt == BigInt("10", 2),
+        dut.io.pio.pins.write.toBigInt == BigInt("01", 2),
         "PIO output value should be 01"
       )
-      assert(dut.io.pio.pins.writeEnable.toBigInt == BigInt("11", 2))
+      assert(
+        dut.io.pio.pins.writeEnable.toBigInt == BigInt("11", 2),
+        "PIO direction value should be 11"
+      )
 
-
-      /* Wait 6 clock cycles and set LOW */
-      apb.write(BigInt(regOffset), BigInt("110010", 2))
-      apb.write(BigInt(regOffset), BigInt("101", 2))
-
-      /* clock divider = 2 (3 cycles), 6 wait cycles result in 18 cycles + 4 cycles overhead */
-      for (_ <- 0 until 22) {
-        assert(
-          dut.io.pio.pins.write.toBigInt == BigInt("10", 2),
-          "PIO output value should be 11"
-        )
-        assert(dut.io.pio.pins.writeEnable.toBigInt == BigInt("11", 2))
-        dut.clockDomain.waitSampling(1)
-      }
+      fillCommands(apb, regOffset, List(
+        generateCmd(0, PioCtrl.CommandType.LOW)
+      ))
+      dut.clockDomain.waitSampling(4)
 
       assert(
         dut.io.pio.pins.write.toBigInt == BigInt("00", 2),
         "PIO output value should be 00"
       )
-      assert(dut.io.pio.pins.writeEnable.toBigInt == BigInt("11", 2))
+      assert(
+        dut.io.pio.pins.writeEnable.toBigInt == BigInt("11", 2),
+        "PIO direction value should be 11"
+      )
+
+      fillCommands(apb, regOffset, List(
+        generateCmd(0, PioCtrl.CommandType.TOGGLE)
+      ))
+      dut.clockDomain.waitSampling(4)
+
+      assert(
+        dut.io.pio.pins.write.toBigInt == BigInt("01", 2),
+        "PIO output value should be 01"
+      )
+      assert(
+        dut.io.pio.pins.writeEnable.toBigInt == BigInt("11", 2),
+        "PIO direction value should be 11"
+      )
+
+      fillCommands(apb, regOffset, List(
+        generateCmd(1, PioCtrl.CommandType.TOGGLE)
+      ))
+      dut.clockDomain.waitSampling(4)
+
+      assert(
+        dut.io.pio.pins.write.toBigInt == BigInt("11", 2),
+        "PIO output value should be 11"
+      )
+      assert(
+        dut.io.pio.pins.writeEnable.toBigInt == BigInt("11", 2),
+        "PIO direction value should be 11"
+      )
+
+      fillCommands(apb, regOffset, List(
+        generateCmd(0, PioCtrl.CommandType.FLOAT)
+      ))
+      dut.clockDomain.waitSampling(4)
+
+      assert(
+        dut.io.pio.pins.write.toBigInt == BigInt("10", 2),
+        "PIO output value should be 10"
+      )
+      assert(
+        dut.io.pio.pins.writeEnable.toBigInt == BigInt("10", 2),
+        "PIO direction value should be 10"
+      )
+
+      fillCommands(apb, regOffset, List(
+        generateCmd(1, PioCtrl.CommandType.FLOAT)
+      ))
+      dut.clockDomain.waitSampling(4)
+
+      assert(
+        dut.io.pio.pins.write.toBigInt == BigInt("00", 2),
+        "PIO output value should be 00"
+      )
+      assert(
+        dut.io.pio.pins.writeEnable.toBigInt == BigInt("00", 2),
+        "PIO direction value should be 00"
+      )
+    }
+
+    compiled.doSim("toggle IO - SET") { dut =>
+      dut.clockDomain.forkStimulus(10)
+      fork {
+        dut.clockDomain.fallingEdge()
+        sleep(10)
+        while (true) {
+          dut.clockDomain.clockToggle()
+          sleep(5)
+        }
+      }
+
+      val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
+      val regOffset = dut.mapper.regOffset
+
+      /* Wait for reset and check initialized state */
+      dut.clockDomain.waitSampling(2)
+      dut.clockDomain.waitFallingEdge()
+
+      assert(
+        dut.io.pio.pins.write.toBigInt == BigInt("00", 2),
+        "Default PIO output value should be 00"
+      )
+      assert(
+        dut.io.pio.pins.writeEnable.toBigInt == BigInt("00", 2),
+        "PIO direction value should be 00"
+      )
+
+      fillCommands(apb, regOffset, List(
+        generateCmd(0, PioCtrl.CommandType.HIGH_SET, Some(BigInt("11", 2)))
+      ))
+      dut.clockDomain.waitSampling(4)
+
+      assert(
+        dut.io.pio.pins.write.toBigInt == BigInt("11", 2),
+        "PIO output value should be 11"
+      )
+      assert(
+        dut.io.pio.pins.writeEnable.toBigInt == BigInt("11", 2),
+        "PIO direction value should be 11"
+      )
+
+      fillCommands(apb, regOffset, List(
+        generateCmd(0, PioCtrl.CommandType.LOW_SET, Some(BigInt("11", 2)))
+      ))
+      dut.clockDomain.waitSampling(4)
+
+      assert(
+        dut.io.pio.pins.write.toBigInt == BigInt("00", 2),
+        "PIO output value should be 00"
+      )
+      assert(
+        dut.io.pio.pins.writeEnable.toBigInt == BigInt("11", 2),
+        "PIO direction value should be 11"
+      )
+
+      fillCommands(apb, regOffset, List(
+        generateCmd(0, PioCtrl.CommandType.TOGGLE_SET, Some(BigInt("11", 2)))
+      ))
+      dut.clockDomain.waitSampling(4)
+
+      assert(
+        dut.io.pio.pins.write.toBigInt == BigInt("11", 2),
+        "PIO output value should be 11"
+      )
+      assert(
+        dut.io.pio.pins.writeEnable.toBigInt == BigInt("11", 2),
+        "PIO direction value should be 11"
+      )
+
+      fillCommands(apb, regOffset, List(
+        generateCmd(0, PioCtrl.CommandType.FLOAT_SET, Some(BigInt("11", 2)))
+      ))
+      dut.clockDomain.waitSampling(4)
+
+      assert(
+        dut.io.pio.pins.write.toBigInt == BigInt("00", 2),
+        "PIO output value should be 00"
+      )
+      assert(
+        dut.io.pio.pins.writeEnable.toBigInt == BigInt("00", 2),
+        "PIO direction value should be 00"
+      )
+    }
+
+    compiled.doSim("wait commands") { dut =>
+      dut.clockDomain.forkStimulus(10)
+      fork {
+        dut.clockDomain.fallingEdge()
+        sleep(10)
+        while (true) {
+          dut.clockDomain.clockToggle()
+          sleep(5)
+        }
+      }
+
+      val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
+      val regOffset = dut.mapper.regOffset
+
+      /* Wait for reset and check initialized state */
+      dut.clockDomain.waitSampling(2)
+      dut.clockDomain.waitFallingEdge()
+
+      dut.io.pio.pins.read #= BigInt("00", 2)
+      fillCommands(apb, regOffset, List(
+        generateCmd(0, PioCtrl.CommandType.LOW),
+        generateCmd(0, PioCtrl.CommandType.WAIT, Some(BigInt(5))),
+        generateCmd(0, PioCtrl.CommandType.HIGH),
+        generateCmd(0, PioCtrl.CommandType.WAIT, Some(BigInt(5))),
+        generateCmd(0, PioCtrl.CommandType.LOW)
+      ))
+      // IDLE -> 1 Cycle
+      // LOW -> 1 Cycle
+      // IDLE -> 1 Cycle
+      // WAIT -> 5 runs * 3 CLOCK TICKS + 1 Cycle
+      // IDLE -> 1 Cycle
+      // HIGH -> 1 Cycle
+      for (index <- 0 to 21) {
+        assert(
+          dut.io.pio.pins.write.toBigInt == BigInt("00", 2),
+          "PIO output value should be 00"
+        )
+        dut.clockDomain.waitSampling(1)
+      }
+      // WAIT -> 5 runs * 3 CLOCK TICKS + 1 Cycle
+      // IDLE -> 1 Cycle
+      // LOW -> 1 Cycle
+      // Next clock
+      for (index <- 0 until 19) {
+        assert(
+          dut.io.pio.pins.write.toBigInt == BigInt("01", 2),
+          "PIO output value should be 01"
+        )
+        dut.clockDomain.waitSampling(1)
+      }
+      assert(
+        dut.io.pio.pins.write.toBigInt == BigInt("00", 2),
+        "PIO output value should be 00"
+      )
+    }
+
+    compiled.doSim("wait for commands") { dut =>
+      dut.clockDomain.forkStimulus(10)
+      fork {
+        dut.clockDomain.fallingEdge()
+        sleep(10)
+        while (true) {
+          dut.clockDomain.clockToggle()
+          sleep(5)
+        }
+      }
+
+      val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
+      val regOffset = dut.mapper.regOffset
+
+      /* Wait for reset and check initialized state */
+      dut.clockDomain.waitSampling(2)
+      dut.clockDomain.waitFallingEdge()
+
+      dut.io.pio.pins.read #= BigInt("00", 2)
+      fillCommands(apb, regOffset, List(
+        generateCmd(0, PioCtrl.CommandType.HIGH),
+        generateCmd(1, PioCtrl.CommandType.WAIT_FOR_HIGH),
+        generateCmd(0, PioCtrl.CommandType.LOW),
+        generateCmd(1, PioCtrl.CommandType.WAIT_FOR_LOW),
+        generateCmd(0, PioCtrl.CommandType.HIGH)
+      ))
+      dut.clockDomain.waitSampling(3)
+      for (index <- 0 to 50) {
+        assert(
+          dut.io.pio.pins.write.toBigInt == BigInt("01", 2),
+          "PIO output value should be 01"
+        )
+        dut.clockDomain.waitSampling(1)
+      }
+      dut.io.pio.pins.read #= BigInt("10", 2)
+      // 2 cycles input buffers
+      // IDLE -> 1 Cycle
+      // LOW -> 1 Cycle
+      // Next clock
+      for (index <- 0 to 5) {
+        assert(
+          dut.io.pio.pins.write.toBigInt == BigInt("01", 2),
+          "PIO output value should be 01"
+        )
+        dut.clockDomain.waitSampling(1)
+      }
+      for (index <- 0 to 50) {
+        assert(
+          dut.io.pio.pins.write.toBigInt == BigInt("00", 2),
+          "PIO output value should be 00"
+        )
+        dut.clockDomain.waitSampling(1)
+      }
+      dut.io.pio.pins.read #= BigInt("00", 2)
+      // 2 cycles input buffers
+      // IDLE -> 1 Cycle
+      // HIGH -> 1 Cycle
+      // Next clock
+      for (index <- 0 to 5) {
+        assert(
+          dut.io.pio.pins.write.toBigInt == BigInt("00", 2),
+          "PIO output value should be 00"
+        )
+        dut.clockDomain.waitSampling(1)
+      }
+      for (index <- 0 to 50) {
+        assert(
+          dut.io.pio.pins.write.toBigInt == BigInt("01", 2),
+          "PIO output value should be 01"
+        )
+        dut.clockDomain.waitSampling(1)
+      }
+    }
+
+    compiled.doSim("loop commands") { dut =>
+      dut.clockDomain.forkStimulus(10)
+      fork {
+        dut.clockDomain.fallingEdge()
+        sleep(10)
+        while (true) {
+          dut.clockDomain.clockToggle()
+          sleep(5)
+        }
+      }
+
+      val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
+      val regOffset = dut.mapper.regOffset
+
+      /* Wait for reset and check initialized state */
+      dut.clockDomain.waitSampling(2)
+      dut.clockDomain.waitFallingEdge()
+
+      dut.io.pio.pins.read #= BigInt("00", 2)
+      fillCommands(apb, regOffset, List(
+        generateCmd(0, PioCtrl.CommandType.HIGH),
+        generateCmd(0, PioCtrl.CommandType.WAIT, Some(BigInt(5))),
+        generateCmd(0, PioCtrl.CommandType.LOW),
+        generateCmd(0, PioCtrl.CommandType.WAIT, Some(BigInt(5))),
+        generateCmd(0, PioCtrl.CommandType.LOOP, Some(BigInt(3)))
+      ))
+      dut.clockDomain.waitSampling(3)
+      for (loop <- 0 to 2) {
+        // WAIT -> 5 runs * 3 CLOCK TICKS + 1 Cycle
+        // IDLE -> 1 Cycle
+        // LOW -> 1 Cycle
+        for (index <- 0 to 18) {
+          assert(
+            dut.io.pio.pins.write.toBigInt == BigInt("01", 2),
+            "PIO output value should be 01"
+          )
+          dut.clockDomain.waitSampling(1)
+        }
+        // WAIT -> 5 runs * 3 CLOCK TICKS + 1 Cycle
+        // IDLE -> 1 Cycle
+        // LOOP -> 1 Cycle
+        // IDLE -> 1 Cycle
+        // Next clock
+        for (index <- 0 until 21) {
+          assert(
+            dut.io.pio.pins.write.toBigInt == BigInt("00", 2),
+            "PIO output value should be 00"
+          )
+          dut.clockDomain.waitSampling(1)
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Extend the Programmable IO by more features:
* Add FLOAT command to set pins floating
* Add TOGGLE command to toggle the output pin
* Add WAIT_FOR_{HIGH,LOW} to wait for a high/low level
* Add {HIGH,LOW,TOGGLE,FLOAT}_SET to set multiple pins with one command.
* Add LOOP command to repeat commands multiple times

Additionally to these new commands, the IP core now has a ring buffer instead a TX FIFO to repeat command sequences multiple times.

The register mapping has an error and interrupt controller.