### PR TITLE
Fix Documentation

### DIFF
--- a/docs/source/hardware/index.rst
+++ b/docs/source/hardware/index.rst
@@ -1,4 +1,4 @@
-Hardware
+IP Cores
 ########
 
 The following list offers an overview of all available IP cores.

--- a/docs/source/hardware/peripherals/i2c-controller.rst
+++ b/docs/source/hardware/peripherals/i2c-controller.rst
@@ -93,7 +93,7 @@ Available bus architectures:
 By default, all buses are defined with 12 bit address and 32 bit data width.
 
 Parameter
-=========
+~~~~~~~~~
 
 `I2c.Parameter` defines the IO pins of the I2C controller.
 


### PR DESCRIPTION
- Fix I2C Controller heading level for `Parameter`
- Change `Hardware` to `IP Cores` because this chapter is now included in ElemRV.