### PR TITLE
hardware: nafarr: peripherals: io: Update PWM

### DIFF
--- a/docs/source/hardware/peripherals/pwm.rst
+++ b/docs/source/hardware/peripherals/pwm.rst
@@ -3,57 +3,158 @@
 Pulse-Width Modulation
 ######################
 
-The Pulse-Width Modulation (PWM) IO Core is a configurable module designed to generate PWM signals with precise control over the signal's period and duty cycle. The core uses two internal counters to define the characteristics of the output waveform: the Period Counter and the Pulse Width Counter. These counters allow the PWM core to produce a rectangular wave with a defined frequency and duty cycle, making it suitable for applications such as motor control, LED dimming, and signal modulation.
+The Pulse-Width Modulation (PWM) IP Core is a multi-channel controller for generating
+precise PWM signals. Each channel operates independently with its own clock divider and
+waveform registers, making the core suitable for motor control (H-bridge with dead-time
+insertion), LED dimming, and multi-phase power conversion.
 
-Internal Counters
-*****************
+Features
+********
 
-1. **Period Counter**
+* Configurable number of independent channels
+* Per-channel clock divider for independent frequency scaling
+* Two alignment modes per channel: edge-aligned (asymmetric) and center-aligned (symmetric)
+* Waveform defined by ``risingEdge`` and ``fallingEdge`` thresholds for flexible duty cycle
+* Shadow-buffered waveform registers — updates take effect glitch-free at the next period boundary
+* Complementary output with programmable dead-time blanking (shoot-through protection)
+* Phase offset: counters start at a configurable offset on enable or ``syncIn``
+* N-shot mode: run a precise number of complete periods then freeze
+* ``syncIn`` signal to align multiple channels to an external reference
+* Per-channel ``syncOut`` pulse at the period boundary for daisy-chaining
+* ``faultIn`` override: forces all outputs to safe idle state (highest priority)
+* Per-channel period-complete interrupt
 
-   * The Period Counter defines the total length of one PWM cycle, which determines the frequency of the output wave.
-   * It counts the number of clock cycles that make up one full period of the PWM signal.
-   * The frequency of the PWM signal is inversely proportional to the value of the Period Counter.
+IO Signals
+**********
 
-2. **Pulse Width Counter**
+.. list-table:: Pwm.Io
+   :widths: 20 10 70
+   :header-rows: 1
 
-   * The Pulse Width Counter determines the duration within the period when the PWM signal is high (logic level 1).
-   * It controls the duty cycle of the PWM signal, which is the ratio of the pulse width to the total period.
-   * A higher Pulse Width Counter value increases the time the signal remains high during each period, resulting in a higher duty cycle.
+   * - Signal
+     - Direction
+     - Description
+   * - output
+     - out
+     - Primary PWM outputs, one bit per channel.
+   * - compOutput
+     - out
+     - Complementary outputs, one bit per channel. Inverse of ``output`` with dead-time
+       blanking applied.
+   * - syncOut
+     - out
+     - Sync pulse outputs, one bit per channel. Pulses for one clock cycle at each period
+       boundary (edge-aligned: counter wrap; center-aligned: counter peak).
+   * - syncIn
+     - in
+     - Global synchronisation input. Resets the counter of every enabled channel to its
+       ``phaseOffset`` value on the same clock edge.
+   * - faultIn
+     - in
+     - Global fault input (highest priority). While asserted, all primary and complementary
+       outputs are forced to their safe idle state (the ``invert`` level), regardless of
+       any other setting.
+   * - interrupt
+     - out
+     - OR of all pending period-complete interrupts across all channels.
 
 Operation
 *********
 
-During each PWM cycle, the core follows this sequence:
+Waveform Generation
+===================
 
-1. **Initialization:** Both counters are initialized at the start of each period. The Period Counter sets the overall length of the PWM cycle, and the Pulse Width Counter sets the duration for which the signal remains high.
+The output level of each channel is determined by comparing the running counter against
+two thresholds, ``risingEdge`` and ``fallingEdge``:
 
-2. **Signal Toggle:** The PWM signal is set high at the start of the period. When the Pulse Width Counter reaches its defined value, the signal toggles to low (logic level 0).
+* Output is **active** (``!invert``) when ``counter >= risingEdge && counter <= fallingEdge``.
+* Output is **idle** (``invert``) outside that window.
 
-3. **Cycle Completion:** The signal remains low until the Period Counter completes the full cycle. At the end of the period, the counters reset, and a new PWM cycle begins.
+Setting ``invert = 1`` swaps the active and idle levels, producing an active-low signal.
 
-Configuration Parameters
-************************
+Edge-Aligned Mode (``mode = 0``)
+=================================
 
-* **Period:** Configurable to define the frequency of the PWM signal. A lower period value results in a higher frequency.
+The counter counts **down** from ``period`` to 0 and then reloads:
 
-* **Pulse Width:** Configurable to define the duty cycle. The pulse width value is set to a fraction of the period, determining how long the signal stays high during each cycle.
+.. code-block:: text
 
-* **Invert Output:** Change the output value and start the PWM cycle with low (logic level 0).
+   period ─┐           ┌─ period
+           │           │
+           └───────────┘
+           ↑           ↑
+        syncOut      syncOut   (pulses at counter wrap = 0)
 
-**Example Configuration:**
+The ``syncOut`` pulse is emitted when the counter wraps to ``period``. This mode produces
+a left-aligned (asymmetric) waveform and minimises switching noise compared to center-aligned
+mode when multiple channels are used at the same phase.
 
-* **Period = 1000 clock cycles:** The PWM signal has a period of 1000 clock cycles, setting the overall frequency of the waveform.
+Center-Aligned Mode (``mode = 1``)
+====================================
 
-* **Pulse Width = 250 clock cycles:** The PWM signal remains high for 250 clock cycles within each period, giving a duty cycle of 25%.
+The counter counts **up** from 0 to ``period``, then back down to 0 (triangular):
 
-Application
-***********
+.. code-block:: text
 
-The PWM IO Core is suitable for various applications that require precise control of signal timing and duty cycles, including:
+        syncOut
+          ↓
+   period /\
+         /  \
+        /    \
+   0 ──/      \──
 
-* **Motor Speed Control:** Adjusting the duty cycle to control the speed of DC motors.
-* **LED Dimming:** Varying the duty cycle to control the brightness of LEDs.
-* **Signal Generation:** Creating modulated signals for communication systems.
+The ``syncOut`` pulse is emitted when the counter reaches ``period`` (the peak). This mode
+produces a symmetric (center-aligned) waveform and is commonly used in motor drives.
+
+Shadow Buffering
+================
+
+``risingEdge``, ``fallingEdge``, and ``period`` are shadow-buffered. Writing these
+registers via the bus updates the shadow copy immediately, but the live waveform registers
+are only latched at two moments:
+
+1. On the **rising edge of enable** (channel freshly enabled).
+2. At each **period boundary** (counter wrap or down-count to 0 in center-aligned mode).
+
+This ensures that duty cycle and period changes are always applied atomically at a known
+point in the waveform, with no glitches.
+
+Dead-Time Insertion
+===================
+
+When ``deadTime > 0``, both outputs are forced to their idle state for ``deadTime`` clock
+ticks whenever the primary output transitions. This prevents simultaneous conduction in
+H-bridge topologies (shoot-through):
+
+.. code-block:: text
+
+   output     ───┐  ···  ┌─────
+   compOutput ───┘  ···  └─────
+                  ← dt →
+
+Dead-time is applied symmetrically on both the rising and falling edges of ``output``.
+Setting ``deadTime = 0`` disables dead-time insertion.
+
+N-Shot Mode
+===========
+
+By default (``shotCount = 0``), each channel runs continuously. Setting ``shotCount = N``
+causes the channel to run exactly N complete periods and then stop:
+
+* On each period boundary the internal ``shotRemaining`` counter is decremented.
+* When ``shotRemaining`` reaches 1, ``shotDone`` is set and the channel freezes.
+* Re-enabling the channel (``enable`` rising edge) clears ``shotDone`` and reloads
+  ``shotRemaining`` from the shadow register.
+
+Phase Offset and Synchronisation
+=================================
+
+``phaseOffset`` controls where the counter starts when a channel is first enabled or when
+a ``syncIn`` pulse is received. Setting different offsets on multiple channels distributes
+their switching events in time, reducing ripple current in multi-phase converters.
+
+``syncIn`` is a single global signal that resets **all** enabled channel counters to their
+respective ``phaseOffset`` values simultaneously on the same clock edge.
 
 Configuration
 *************
@@ -69,7 +170,7 @@ By default, all buses are defined with 12 bit address and 32 bit data width.
 Parameter
 =========
 
-`Pwm.Parameter` defines the amount of channels in the PWM controller.
+``Pwm.Parameter`` defines the number of channels.
 
 .. list-table:: Pwm.Parameter
    :widths: 25 25 25 25
@@ -79,12 +180,12 @@ Parameter
      - Type
      - Description
      - Default
-   * - Channels
+   * - channels
      - Int
-     - Number of channels. Must be greater then 0.
+     - Number of independent PWM channels. Must be greater than 0.
      -
 
-`PwmCtrl.InitParameter` defines the initialization values for certian registers.
+``PwmCtrl.InitParameter`` defines the initialization values for certain registers.
 
 .. list-table:: PwmCtrl.InitParameter
    :widths: 25 25 25 25
@@ -96,15 +197,15 @@ Parameter
      - Default
    * - clockDivider
      - Int
-     - Initialization value of the internal clock divider
+     - Initialization value of the per-channel clock divider.
      - 0
 
 .. note::
 
-   Parameter in InitParameter with a value "0" are equal to disabled. This allows to
-   only set certain parameters.
+   A value of ``0`` in ``InitParameter`` means the field is not initialized (disabled).
+   This allows initializing only specific fields.
 
-`PwmCtrl.PermissionParameter` defines the permission rules for bus access.
+``PwmCtrl.PermissionParameter`` defines bus-access permission rules.
 
 .. list-table:: PwmCtrl.PermissionParameter
    :widths: 25 25 25 25
@@ -116,10 +217,10 @@ Parameter
      - Default
    * - busCanWriteClockDividerConfig
      - Boolean
-     - Toggles bus access to the clock divider.
+     - When ``false``, the clock divider register is read-only from the bus.
      -
 
-`PwmCtrl.Parameter` configures the PWM controller. It uses `Pwm.Parameter` as parameter.
+``PwmCtrl.Parameter`` configures the PWM controller.
 
 .. list-table:: PwmCtrl.Parameter
    :widths: 25 25 25 25
@@ -131,30 +232,38 @@ Parameter
      - Default
    * - io
      - Pwm.Parameter
-     - Class with IO parameters
+     - IO parameters (channel count).
      -
    * - init
      - PwmCtrl.InitParameter
-     - Class to parametrize the initialization values.
+     - Initialization values.
      - InitParameter.disabled
    * - permission
      - PwmCtrl.PermissionParameter
-     - Class to set bus access.
+     - Bus access permissions.
      - PermissionParameter.granted
    * - clockDividerWidth
      - Int
-     - Width of the clock divider counter.
+     - Bit width of the per-channel clock divider counter.
      - 20
    * - channelPeriodWidth
      - Int
-     - Width of the period counter.
+     - Bit width of the period counter.
      - 20
    * - channelPulseWidth
      - Int
-     - Width of the pulse counter.
+     - Bit width of the ``risingEdge`` and ``fallingEdge`` registers.
      - 20
+   * - deadTimeWidth
+     - Int
+     - Bit width of the dead-time counter.
+     - 8
+   * - shotCountWidth
+     - Int
+     - Bit width of the N-shot counter.
+     - 8
 
-`PwmCtrl.Parameter` has some functions with pre-predefined parameters for common use-cases.
+``PwmCtrl.Parameter`` provides a convenience factory:
 
 .. code-block:: scala
 
@@ -174,7 +283,7 @@ Register Mapping
 
 **Self Disclosure:**
 
-This block discloses information about the IP core to software drivers to simplify them.
+This block discloses implementation widths and channel count to software drivers.
 
 .. flat-table:: Self Disclosure Registers
    :widths: 10 10 15 10 10 45
@@ -191,19 +300,19 @@ This block discloses information about the IP core to software drivers to simpli
      - channelPeriodWidth
      -
      - Rx
-     - Width of the period counter.
+     - Bit width of the period counter.
    * - 23 - 16
      - channelPulseWidth
      -
      - Rx
-     - Width of the pulse counter.
+     - Bit width of the risingEdge/fallingEdge registers.
    * - 15 - 8
      - clockDividerWidth
      -
      - Rx
-     - Width of the clock divider counter.
+     - Bit width of the clock divider counter.
    * - 7 - 0
-     - IO channels
+     - channels
      -
      - Rx
      - Number of channels.
@@ -212,11 +321,25 @@ This block discloses information about the IP core to software drivers to simpli
      - busCanWriteClockDividerConfig
      -
      - Rx
-     - Flag whether the clock divider is writable.
+     - ``1`` if the clock divider register is writable from the bus.
+   * - :rspan:`1` 0x010
+     - 15 - 8
+     - shotCountWidth
+     -
+     - Rx
+     - Bit width of the N-shot counter.
+   * - 7 - 0
+     - deadTimeWidth
+     -
+     - Rx
+     - Bit width of the dead-time counter.
 
-**Clock Divider:**
+**Interrupts:**
 
-.. flat-table:: Clock Divider
+Period-complete interrupts use a standard interrupt controller with one bit per channel.
+Writing ``1`` to a bit in the IP register clears (acknowledges) that interrupt.
+
+.. flat-table:: Interrupt Registers
    :widths: 10 10 15 10 10 45
    :header-rows: 1
 
@@ -226,46 +349,150 @@ This block discloses information about the IP core to software drivers to simpli
      - Default
      - Permission
      - Description
-   * - 0x010
-     - clockDividerWidth - 0
-     - clockDividerValue
-     - Depends on `PwmCtrl.InitParameter`
-     - RW or Rx
-     - Value for the clock divider counter to divide down the input clock.
+   * - 0x014
+     - channels - 0
+     - periodComplete IP
+     - 0
+     - RW1C
+     - Pending period-complete flags, one bit per channel. Write ``1`` to clear.
+   * - 0x018
+     - channels - 0
+     - periodComplete IE
+     - 0
+     - RW
+     - Enable mask for period-complete interrupts, one bit per channel.
+
+**Error Detection:**
+
+The error module uses a standard interrupt controller with two classes of error source.
+Writing ``1`` to a bit in the error IP register clears (acknowledges) that error.
+
+.. flat-table:: Error Registers
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - :rspan:`1` 0x01C
+     - 0
+     - faultIn IP
+     - 0
+     - RW1C
+     - Set on the rising edge of ``faultIn``. Indicates that a hardware fault was
+       asserted. Write ``1`` to clear.
+   * - channels - 1
+     - configError IP
+     - 0
+     - RW1C
+     - Per-channel configuration error flags. Bit *n+1* is set when
+       ``fallingEdge > period`` in channel *n*'s shadow registers.
+       Write ``1`` to clear.
+   * - :rspan:`1` 0x020
+     - 0
+     - faultIn IE
+     - 0
+     - RW
+     - Enable mask for the ``faultIn`` error interrupt.
+   * - channels - 1
+     - configError IE
+     - 0
+     - RW
+     - Per-channel enable mask for configuration error interrupts.
 
 **Channel Configuration:**
 
-.. flat-table:: Channel Configuration
+Each channel occupies 0x28 (40) bytes. Channel *n* starts at address
+``0x024 + n * 0x028``.
+
+.. flat-table:: Channel Registers (base = 0x024 + n * 0x028)
    :widths: 10 10 15 10 10 45
    :header-rows: 1
 
-   * - Address
+   * - Offset
      - Bit
      - Field
      - Default
      - Permission
      - Description
-   * - :rspan:`1` 0x014
+   * - :rspan:`2` +0x00
      - 0
      - enable
      - 0
      - RW
-     - This bit can toggle whether the channel should output a rectangular wave.
+     - Enable the channel. On the rising edge of this bit, live waveform registers are
+       latched from shadow and the counter is reset to ``phaseOffset``.
    * - 1
      - invert
      - 0
      - RW
-     - Invert the output wave from active-high to active-low.
-   * - 0x018
+     - Invert both outputs. When set, idle state is logic-high and active state is
+       logic-low.
+   * - 2
+     - mode
+     - 0
+     - RW
+     - Alignment mode. ``0`` = edge-aligned (count-down), ``1`` = center-aligned
+       (triangle counter).
+   * - +0x04
+     - clockDividerWidth - 0
+     - clockDivider
+     - InitParameter
+     - RW or Rx
+     - Per-channel clock divider. The channel tick rate is
+       ``f_clk / (clockDivider + 1)``. Read-only if
+       ``busCanWriteClockDividerConfig = false``.
+   * - +0x08
      - channelPeriodWidth - 0
-     - periodWidth
+     - period
      - 0
      - RW
-     - Defines the number of cycles one wave period should be.
-   * - 0x01C
+     - Shadow period. Latched into the live period register at the next period boundary.
+   * - +0x0C
      - channelPulseWidth - 0
-     - channelWidth
+     - risingEdge
      - 0
      - RW
-     - Defines the number of cycles when the output wave level will change. This counter resets to
-       default value as soon as the period is over.
+     - Shadow rising-edge threshold. Output goes active when ``counter >= risingEdge``.
+   * - +0x10
+     - channelPulseWidth - 0
+     - fallingEdge
+     - 0
+     - RW
+     - Shadow falling-edge threshold. Output goes idle when ``counter > fallingEdge``.
+   * - +0x14
+     - deadTimeWidth - 0
+     - deadTime
+     - 0
+     - RW
+     - Dead-time in clock ticks. Both outputs are blanked for this many ticks on every
+       output transition. ``0`` disables dead-time insertion.
+   * - +0x18
+     - channelPeriodWidth - 0
+     - phaseOffset
+     - 0
+     - RW
+     - Counter start value applied on enable or ``syncIn``. Use to distribute switching
+       events across multiple channels.
+   * - +0x1C
+     - shotCountWidth - 0
+     - shotCount
+     - 0
+     - RW
+     - Number of complete periods to generate. ``0`` = continuous operation.
+   * - :rspan:`1` +0x20
+     - 0
+     - configError
+     -
+     - Rx
+     - Set when ``fallingEdge > period`` in the shadow registers, indicating an invalid
+       configuration.
+   * - 1
+     - shotDone
+     -
+     - Rx
+     - Set when an N-shot sequence has completed (only meaningful when
+       ``shotCount != 0``).

--- a/hardware/scala/nafarr/peripherals/io/pwm/Pwm.scala
+++ b/hardware/scala/nafarr/peripherals/io/pwm/Pwm.scala
@@ -18,6 +18,10 @@ object Pwm {
 
   case class Io(p: Parameter) extends Bundle {
     val output = out(Bits(p.channels bits))
+    val compOutput = out(Bits(p.channels bits))
+    val syncOut = out(Bits(p.channels bits))
+    val syncIn = in(Bool)
+    val faultIn = in(Bool)
   }
 
   class Core[T <: spinal.core.Data with IMasterSlave](
@@ -28,10 +32,12 @@ object Pwm {
     val io = new Bundle {
       val bus = slave(busType())
       val pwm = Io(p.io)
+      val interrupt = out(Bool)
     }
 
     val ctrl = PwmCtrl(p)
     ctrl.io.pwm <> io.pwm
+    io.interrupt := ctrl.io.interrupt
 
     val mapper = PwmCtrl.Mapper(factory(io.bus), ctrl.io, p)
 

--- a/hardware/scala/nafarr/peripherals/io/pwm/PwmCtrl.scala
+++ b/hardware/scala/nafarr/peripherals/io/pwm/PwmCtrl.scala
@@ -7,6 +7,7 @@ package nafarr.peripherals.io.pwm
 import spinal.core._
 import spinal.lib._
 import spinal.lib.bus.misc.BusSlaveFactory
+import spinal.lib.misc.InterruptCtrl
 import nafarr.IpIdentification
 import nafarr.library.ClockDivider
 
@@ -29,7 +30,9 @@ object PwmCtrl {
       permission: PermissionParameter = PermissionParameter.granted,
       clockDividerWidth: Int = 20,
       channelPeriodWidth: Int = 20,
-      channelPulseWidth: Int = 20
+      channelPulseWidth: Int = 20,
+      deadTimeWidth: Int = 8,
+      shotCountWidth: Int = 8
   ) {
     require(channelPeriodWidth >= channelPulseWidth, "Channel pulse cannot be wider than period.")
   }
@@ -37,56 +40,176 @@ object PwmCtrl {
     def default(channels: Int = 1) = Parameter(Pwm.Parameter(channels))
   }
 
-  case class Config(p: Parameter) extends Bundle {
-    val clockDivider = UInt(p.clockDividerWidth bits)
-  }
   case class ConfigChannel(p: Parameter) extends Bundle {
     val enable = Bool()
     val invert = Bool()
+    val mode = Bool() // False = edge-aligned, True = center-aligned
+    val clockDivider = UInt(p.clockDividerWidth bits)
     val period = UInt(p.channelPeriodWidth bits)
-    val pulse = UInt(p.channelPulseWidth bits)
+    val risingEdge = UInt(p.channelPulseWidth bits)
+    val fallingEdge = UInt(p.channelPulseWidth bits)
+    val deadTime = UInt(p.deadTimeWidth bits)
+    val phaseOffset = UInt(p.channelPeriodWidth bits)
+    val shotCount = UInt(p.shotCountWidth bits)
+  }
+
+  case class InterruptConfig(p: Parameter) extends Bundle {
+    val valid = out(Bits(p.io.channels bits))
+    val pending = in(Bits(p.io.channels bits))
   }
 
   case class Io(p: Parameter) extends Bundle {
     val pwm = Pwm.Io(p.io)
-    val config = in(Config(p))
-    val channels = in(Vec(ConfigChannel(p), p.io.channels))
+    val shadow = in(Vec(ConfigChannel(p), p.io.channels))
+    val shotDone = out(Bits(p.io.channels bits))
+    val interrupt = out(Bool)
+    val irqPeriodComplete = InterruptConfig(p)
+    val faultError = out(Bool)
+    val errorPending = in(Bool)
   }
 
   case class PwmCtrl(p: Parameter) extends Component {
     val io = Io(p)
 
-    val clockDivider = new ClockDivider(p.clockDividerWidth)
-    clockDivider.io.value := io.config.clockDivider
-    clockDivider.io.reload := False
-
     for (i <- 0 until p.io.channels) {
       val channel = new Area {
-        val periodCounter = Reg(UInt(p.channelPeriodWidth bits)).init(0)
-        val pulseCounter = Reg(UInt(p.channelPulseWidth bits)).init(0)
+        val s = io.shadow(i)
+
+        // Per-channel clock divider
+        val clockDivider = new ClockDivider(p.clockDividerWidth)
+        clockDivider.io.value := s.clockDivider
+        clockDivider.io.reload := False
         def tick = clockDivider.io.tick
 
-        io.pwm.output(i) := io.channels(i).invert
-        when(io.channels(i).enable) {
-          when(periodCounter === 0) {
-            periodCounter := io.channels(i).period
-            pulseCounter := io.channels(i).pulse
-          }
-          when(tick) {
-            periodCounter := periodCounter - 1
-            when(pulseCounter =/= U(0)) {
-              pulseCounter := pulseCounter - 1
+        // Shadow-buffered live waveform registers: latched on enable or period-end
+        val periodLive = Reg(UInt(p.channelPeriodWidth bits)).init(0)
+        val risingEdgeLive = Reg(UInt(p.channelPulseWidth bits)).init(0)
+        val fallingEdgeLive = Reg(UInt(p.channelPulseWidth bits)).init(0)
+
+        // Counter state
+        val periodCounter = Reg(UInt(p.channelPeriodWidth bits)).init(0)
+        val direction = Reg(Bool()).init(False) // False = up, True = down
+
+        // N-shot state
+        val shotDoneReg = Reg(Bool()).init(False)
+        val shotRemaining = Reg(UInt(p.shotCountWidth bits)).init(0)
+        val enablePrev = RegNext(s.enable, False)
+        val enableRise = s.enable && !enablePrev
+
+        // Dead-time state
+        val deadTimeCounter = Reg(UInt(p.deadTimeWidth bits)).init(0)
+
+        // Output comparison (at Area scope so RegNext can reference desired)
+        val desired =
+          periodCounter >= risingEdgeLive.resize(p.channelPeriodWidth) &&
+            periodCounter <= fallingEdgeLive.resize(p.channelPeriodWidth)
+        val desiredPrev = RegNext(desired, False)
+        val transition = desired =/= desiredPrev
+        val inDeadTime = s.deadTime =/= 0 && (transition || deadTimeCounter =/= 0)
+
+        // Period-complete wire (set inside mode logic below)
+        val periodComplete = Bool()
+        periodComplete := False
+
+        val shotActive = s.shotCount === 0 || !shotDoneReg
+
+        // Output defaults
+        io.pwm.output(i) := s.invert
+        io.pwm.compOutput(i) := s.invert
+        io.pwm.syncOut(i) := False
+        io.irqPeriodComplete.valid(i) := False
+        io.shotDone(i) := shotDoneReg
+
+        // On enable rising edge: load live regs and reset counter state
+        when(enableRise) {
+          periodLive := s.period
+          risingEdgeLive := s.risingEdge
+          fallingEdgeLive := s.fallingEdge
+          periodCounter := s.phaseOffset
+          direction := False
+          shotDoneReg := False
+          shotRemaining := s.shotCount
+        } elsewhen (s.enable && shotActive) {
+          when(!s.mode) {
+            // Edge-aligned: count down from periodLive to 0
+            when(periodCounter === 0) {
+              periodCounter := periodLive
+              io.pwm.syncOut(i) := True
+              periodComplete := True
+            } elsewhen (tick) {
+              periodCounter := periodCounter - 1
+            }
+          } otherwise {
+            // Center-aligned: count up to periodLive, then back down to 0
+            when(!direction) {
+              when(periodCounter === periodLive) {
+                direction := True
+                io.pwm.syncOut(i) := True
+              } elsewhen (tick) {
+                periodCounter := periodCounter + 1
+              }
+            } otherwise {
+              when(periodCounter === 0) {
+                direction := False
+                periodComplete := True
+              } elsewhen (tick) {
+                periodCounter := periodCounter - 1
+              }
             }
           }
-          when(pulseCounter =/= U(0)) {
-            io.pwm.output(i) := !io.channels(i).invert
+
+          // Latch shadow waveform registers on period-end
+          when(periodComplete) {
+            periodLive := s.period
+            risingEdgeLive := s.risingEdge
+            fallingEdgeLive := s.fallingEdge
           }
+
+          // N-shot: decrement on period-end, freeze when last shot completes
+          when(periodComplete && s.shotCount =/= 0) {
+            when(shotRemaining > 1) {
+              shotRemaining := shotRemaining - 1
+            } otherwise {
+              shotDoneReg := True
+            }
+          }
+
+          io.irqPeriodComplete.valid(i) := periodComplete
+
+          // Dead-time counter
+          when(transition) {
+            deadTimeCounter := s.deadTime
+          } elsewhen (deadTimeCounter =/= 0 && tick) {
+            deadTimeCounter := deadTimeCounter - 1
+          }
+
+          // Primary and complementary outputs with dead-time
+          io.pwm.output(i) := Mux(desired && !inDeadTime, !s.invert, s.invert)
+          io.pwm.compOutput(i) := Mux(!desired && !inDeadTime, !s.invert, s.invert)
         } otherwise {
-          periodCounter := io.channels(i).period
-          pulseCounter := io.channels(i).pulse
+          periodCounter := 0
+          direction := False
+          deadTimeCounter := 0
         }
-      }
+
+        // syncIn: reset all enabled channel counters to their phase offset
+        when(s.enable && io.pwm.syncIn) {
+          periodCounter := s.phaseOffset
+          direction := False
+        }
+
+        // faultIn: force all outputs to safe idle state (highest priority)
+        when(io.pwm.faultIn) {
+          io.pwm.output(i) := s.invert
+          io.pwm.compOutput(i) := s.invert
+        }
+      }.setName(s"ch$i")
     }
+
+    val faultInPrev = RegNext(io.pwm.faultIn, False)
+    io.faultError := io.pwm.faultIn && !faultInPrev
+
+    io.interrupt := io.irqPeriodComplete.pending.orR
   }
 
   case class Mapper(
@@ -94,55 +217,97 @@ object PwmCtrl {
       ctrl: Io,
       p: Parameter
   ) extends Area {
-    val idCtrl = IpIdentification(IpIdentification.Ids.Pwm, 1, 0, 0)
+    val idCtrl = IpIdentification(IpIdentification.Ids.Pwm, 1, 1, 0)
     idCtrl.driveFrom(busCtrl)
     val staticOffset = idCtrl.length
 
+    // Static word 1: implementation widths and channel count
     busCtrl.read(
       B(p.channelPeriodWidth, 8 bits) ## B(p.channelPulseWidth, 8 bits) ##
         B(p.clockDividerWidth, 8 bits) ## B(p.io.channels, 8 bits),
       staticOffset
     )
 
+    // Static word 2: dead-time and shot-count widths
+    busCtrl.read(
+      B(0, 16 bits) ## B(p.shotCountWidth, 8 bits) ## B(p.deadTimeWidth, 8 bits),
+      staticOffset + 0x4
+    )
+
     if (p.permission != null) {
       val permissionBits = Bool(p.permission.busCanWriteClockDividerConfig)
-      busCtrl.read(B(0, 32 - 1 bits) ## permissionBits, staticOffset + 0x4)
+      busCtrl.read(B(0, 32 - 1 bits) ## permissionBits, staticOffset + 0x8)
     } else {
-      busCtrl.read(B(0), staticOffset + 0x4)
-    }
-    val regOffset = staticOffset + 0x8
-
-    val config = new Area {
-      val cfg = Reg(ctrl.config)
-
-      if (p.init != null && p.init.clockDivider != 0)
-        cfg.clockDivider.init(p.init.clockDivider)
-      else
-        cfg.clockDivider.init(0)
-
-      if (p.permission != null && p.permission.busCanWriteClockDividerConfig)
-        busCtrl.write(cfg.clockDivider, address = regOffset + 0x00)
-      else
-        cfg.allowUnsetRegToAvoidLatch
-      busCtrl.read(cfg.clockDivider, address = regOffset + 0x00)
-
-      ctrl.config <> cfg
+      busCtrl.read(B(0), staticOffset + 0x8)
     }
 
-    val channelCfg = Reg(ctrl.channels)
+    val regOffset = staticOffset + 0xc
+
+    val irqPeriodCompleteCtrl = new InterruptCtrl(p.io.channels)
+    irqPeriodCompleteCtrl.driveFrom(busCtrl, regOffset + 0x00)
     for (i <- 0 until p.io.channels) {
-      val channel = regOffset + 4 + i * 12
+      irqPeriodCompleteCtrl.io.inputs(i) := ctrl.irqPeriodComplete.valid(i)
+      ctrl.irqPeriodComplete.pending(i) := irqPeriodCompleteCtrl.io.pendings(i)
+    }
+
+    // Channel shadow registers (shared with error module for configError detection)
+    val channelCfg = Reg(ctrl.shadow)
+
+    // Error module: faultIn rising edge (input 0) + per-channel configError (inputs 1..N)
+    val errorCtrl = new InterruptCtrl(1 + p.io.channels)
+    errorCtrl.driveFrom(busCtrl, regOffset + 0x08)
+    errorCtrl.io.inputs(0) := ctrl.faultError
+    for (i <- 0 until p.io.channels) {
+      errorCtrl.io.inputs(1 + i) :=
+        channelCfg(i).fallingEdge.resize(p.channelPeriodWidth) > channelCfg(i).period
+    }
+    ctrl.errorPending := errorCtrl.io.pendings.orR
+
+    // Channel registers: stride 0x28 (40 bytes), starting at regOffset + 0x14
+    for (i <- 0 until p.io.channels) {
+      val channel = regOffset + 0x10 + i * 0x28
 
       channelCfg(i).enable.init(False)
       channelCfg(i).invert.init(False)
+      channelCfg(i).mode.init(False)
       channelCfg(i).period.init(0)
-      channelCfg(i).pulse.init(0)
+      channelCfg(i).risingEdge.init(0)
+      channelCfg(i).fallingEdge.init(0)
+      channelCfg(i).deadTime.init(0)
+      channelCfg(i).phaseOffset.init(0)
+      channelCfg(i).shotCount.init(0)
 
-      busCtrl.readAndWrite(channelCfg(i).enable, address = channel + 0x0, bitOffset = 0x0)
-      busCtrl.readAndWrite(channelCfg(i).invert, address = channel + 0x0, bitOffset = 0x1)
-      busCtrl.readAndWrite(channelCfg(i).period, address = channel + 0x4)
-      busCtrl.readAndWrite(channelCfg(i).pulse, address = channel + 0x8)
+      if (p.init != null && p.init.clockDivider != 0)
+        channelCfg(i).clockDivider.init(p.init.clockDivider)
+      else
+        channelCfg(i).clockDivider.init(0)
+
+      busCtrl.readAndWrite(channelCfg(i).enable, address = channel + 0x00, bitOffset = 0)
+      busCtrl.readAndWrite(channelCfg(i).invert, address = channel + 0x00, bitOffset = 1)
+      busCtrl.readAndWrite(channelCfg(i).mode, address = channel + 0x00, bitOffset = 2)
+
+      if (p.permission != null && p.permission.busCanWriteClockDividerConfig)
+        busCtrl.readAndWrite(channelCfg(i).clockDivider, address = channel + 0x04)
+      else {
+        channelCfg(i).clockDivider.allowUnsetRegToAvoidLatch
+        busCtrl.read(channelCfg(i).clockDivider, address = channel + 0x04)
+      }
+
+      busCtrl.readAndWrite(channelCfg(i).period, address = channel + 0x08)
+      busCtrl.readAndWrite(channelCfg(i).risingEdge, address = channel + 0x0c)
+      busCtrl.readAndWrite(channelCfg(i).fallingEdge, address = channel + 0x10)
+      busCtrl.readAndWrite(channelCfg(i).deadTime, address = channel + 0x14)
+      busCtrl.readAndWrite(channelCfg(i).phaseOffset, address = channel + 0x18)
+      busCtrl.readAndWrite(channelCfg(i).shotCount, address = channel + 0x1c)
+
+      // Status register (read-only): configError[0], shotDone[1]
+      val configError =
+        channelCfg(i).fallingEdge.resize(p.channelPeriodWidth) > channelCfg(i).period
+      busCtrl.read(
+        B(0, 30 bits) ## ctrl.shotDone(i) ## configError,
+        channel + 0x20
+      )
     }
-    ctrl.channels := channelCfg
+    ctrl.shadow := channelCfg
   }
 }

--- a/test/scala/nafarr/peripherals/io/pwm/Apb3PwmTest.scala
+++ b/test/scala/nafarr/peripherals/io/pwm/Apb3PwmTest.scala
@@ -61,8 +61,8 @@ class Apb3PwmTest extends AnyFunSuite {
         "IP Identification 0x0 should return 00080002 - API: 0, Length: 8, ID: 2"
       )
       assert(
-        apb.read(BigInt(4)) == BigInt("01000000", 16),
-        "IP Identification 0x4 should return 01000000 - 1.0.0"
+        apb.read(BigInt(4)) == BigInt("01010000", 16),
+        "IP Identification 0x4 should return 01010000 - 1.1.0"
       )
 
       /* Read channelPulseWidth, channelPeriodWidth, clockDividerWidth, io.channels */
@@ -71,9 +71,15 @@ class Apb3PwmTest extends AnyFunSuite {
         "Unable to read 14141401 from PWM config/channel declaration"
       )
 
+      /* Read dead-time and shot-count widthss */
+      assert(
+        apb.read(BigInt(staticOffset + 4)) == BigInt("00000808", 16),
+        "Unable to read 00000808 from PWM config/channel declaration"
+      )
+
       /* Read permissions */
       assert(
-        apb.read(BigInt(staticOffset + 4)) == BigInt("00000001", 16),
+        apb.read(BigInt(staticOffset + 8)) == BigInt("00000001", 16),
         "Unable to read 00000001 from PWM permission declaration"
       )
     }
@@ -91,19 +97,23 @@ class Apb3PwmTest extends AnyFunSuite {
       val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
       val regOffset = dut.mapper.regOffset
 
+      dut.io.pwm.syncIn #= false
+      dut.io.pwm.faultIn #= false
+
       /* Wait for reset and check initialized state */
       dut.clockDomain.waitSampling(2)
       dut.clockDomain.waitFallingEdge()
 
       /* Init - Set clock divider to 1 us */
-      apb.write(BigInt(regOffset), BigInt("99", 10))
+      apb.write(BigInt(regOffset + 0x14), BigInt("99", 10))
 
-      /* Init channel 0 */
-      apb.write(BigInt(regOffset + 8), BigInt("9", 10))
-      apb.write(BigInt(regOffset + 12), BigInt("5", 10))
+      /* Init channel 0: period=9, active [risingEdge=5, fallingEdge=9] -> 5/10 duty */
+      apb.write(BigInt(regOffset + 0x18), BigInt("9", 10))
+      apb.write(BigInt(regOffset + 0x1c), BigInt("5", 10))
+      apb.write(BigInt(regOffset + 0x20), BigInt("9", 10))
 
       assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
-      apb.write(BigInt(regOffset + 4), BigInt("1", 16))
+      apb.write(BigInt(regOffset + 0x10), BigInt("1", 16))
       dut.clockDomain.waitSampling(100)
 
       assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
@@ -128,20 +138,24 @@ class Apb3PwmTest extends AnyFunSuite {
       val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
       val regOffset = dut.mapper.regOffset
 
+      dut.io.pwm.syncIn #= false
+      dut.io.pwm.faultIn #= false
+
       /* Wait for reset and check initialized state */
       dut.clockDomain.waitSampling(2)
       dut.clockDomain.waitFallingEdge()
 
       /* Init - Set clock divider to 1 us */
-      apb.write(BigInt(regOffset), BigInt("99", 10))
+      apb.write(BigInt(regOffset + 0x14), BigInt("99", 10))
 
-      /* Init channel 0 */
-      apb.write(BigInt(regOffset + 8), BigInt("9", 10))
-      apb.write(BigInt(regOffset + 12), BigInt("5", 10))
+      /* Init channel 0: period=9, active [risingEdge=5, fallingEdge=9] -> 5/10 duty */
+      apb.write(BigInt(regOffset + 0x18), BigInt("9", 10))
+      apb.write(BigInt(regOffset + 0x1c), BigInt("5", 10))
+      apb.write(BigInt(regOffset + 0x20), BigInt("9", 10))
 
       assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
-      apb.write(BigInt(regOffset + 4), BigInt("1", 16))
-      dut.clockDomain.waitSampling(100)
+      apb.write(BigInt(regOffset + 0x10), BigInt("1", 16))
+      dut.clockDomain.waitSampling(10)
 
       assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
       dut.clockDomain.waitSampling(5 * 100)
@@ -149,12 +163,13 @@ class Apb3PwmTest extends AnyFunSuite {
       dut.clockDomain.waitSampling(5 * 100)
       assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
       dut.clockDomain.waitSampling(10)
-      apb.write(BigInt(regOffset + 4), BigInt("0", 16))
-      apb.write(BigInt(regOffset + 8), BigInt("9", 10))
-      apb.write(BigInt(regOffset + 12), BigInt("3", 10))
+      apb.write(BigInt(regOffset + 0x10), BigInt("0", 16))
+      apb.write(BigInt(regOffset + 0x18), BigInt("9", 10))
+      apb.write(BigInt(regOffset + 0x1c), BigInt("7", 10))
+      apb.write(BigInt(regOffset + 0x20), BigInt("9", 10))
 
       dut.clockDomain.waitSampling(90)
-      apb.write(BigInt(regOffset + 4), BigInt("1", 16))
+      apb.write(BigInt(regOffset + 0x10), BigInt("1", 16))
       dut.clockDomain.waitSampling(100)
 
       assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))


### PR DESCRIPTION
Hardware (PwmCtrl.scala):
- Add faultError output to Io: one-cycle pulse on rising edge of faultIn
- Add errorPending input to Io: fed from error InterruptCtrl in Mapper
- Add error InterruptCtrl in Mapper at regOffset+0x0C:
  - Input 0: faultIn rising edge (external hardware fault)
  - Inputs 1..N: per-channel configError (fallingEdge > period)
- Shift channel register base from regOffset+0x10 to regOffset+0x14 to make room for the two new error IP/IE registers

Documentation (pwm.rst):
- Document all new IO signals (compOutput, syncOut, syncIn, faultIn, interrupt) added in the preceding commit
- Rewrite Operation section covering edge-aligned vs center-aligned modes, shadow buffering, dead-time, N-shot, and phase offset
- Update Parameter tables with deadTimeWidth and shotCountWidth
- Rewrite register map reflecting the new layout:
  - Error IP at 0x01C, Error IE at 0x020
  - Channel base updated from 0x020 to 0x024