### PR TITLE
hardware: nafarr: peripherals: io: gpio: Add TileLink

### DIFF
--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -46,7 +46,7 @@ If you need to test a specific component, use the `testOnly` command:
 
 .. code-block:: bash
 
-    sbt "testOnly *Apb3GpioTest"
+    sbt "testOnly *GpioTest"
 
 Documentation
 *************

--- a/docs/source/hardware/peripherals/gpio.rst
+++ b/docs/source/hardware/peripherals/gpio.rst
@@ -32,8 +32,8 @@ Configuration
 Available bus architectures:
 
 - APB3
+- TileLink
 - Wishbone
-- AvalonMM
 
 By default, all buses are defined with 12 bit address and 32 bit data width.
 

--- a/hardware/scala/nafarr/peripherals/io/gpio/Gpio.scala
+++ b/hardware/scala/nafarr/peripherals/io/gpio/Gpio.scala
@@ -8,8 +8,12 @@ import spinal.core._
 import spinal.lib._
 import spinal.lib.bus.misc._
 import spinal.lib.bus.amba3.apb._
-import spinal.lib.bus.avalon._
 import spinal.lib.bus.wishbone._
+import spinal.lib.bus.tilelink.{
+  Bus => TileLinkBus,
+  BusParameter => TileLinkParameter,
+  SlaveFactory => TileLinkSlaveFactory
+}
 import spinal.lib.io.{TriStateArray, TriState}
 import nafarr.peripherals.PeripheralsComponent
 
@@ -49,9 +53,8 @@ object Gpio {
       val regSize = "%04x".format(size.toInt)
       var dt = s"""
 \t\t$name: $name@$baseAddress {
-\t\t\tcompatible = "elements,gpio";
-\t\t\treg = <0x$baseAddress 0x$regSize>;
-\t\t\tstatus = "okay";"""
+\t\t\tcompatible = "aesc,gpio";
+\t\t\treg = <0x$baseAddress 0x$regSize>;"""
       if (irqNumber.isDefined) {
         dt += s"""
 \t\t\tinterrupt-parent = <&plic>;
@@ -60,6 +63,7 @@ object Gpio {
       dt += s"""
 \t\t\tgpio-controller;
 \t\t\t#gpio-cells = <2>;
+\t\t\tstatus = "okay";
 \t\t};"""
       dt
     }
@@ -95,11 +99,11 @@ case class WishboneGpio(
       Wishbone(busConfig.copy(addressWidth = 10)),
       WishboneSlaveFactory(_)
     )
-case class AvalonMMGpio(
+case class TileLinkGpio(
     parameter: GpioCtrl.Parameter,
-    busConfig: AvalonMMConfig = AvalonMMConfig.fixed(12, 32, 1)
-) extends Gpio.Core[AvalonMM](
+    busConfig: TileLinkParameter = TileLinkParameter.simple(12, 32, 32, 4)
+) extends Gpio.Core[TileLinkBus](
       parameter,
-      AvalonMM(busConfig),
-      AvalonMMSlaveFactory(_)
+      TileLinkBus(busConfig),
+      new TileLinkSlaveFactory(_, false)
     )

--- a/test/scala/nafarr/peripherals/io/gpio/GpioTest.scala
+++ b/test/scala/nafarr/peripherals/io/gpio/GpioTest.scala
@@ -12,8 +12,8 @@ import spinal.core.sim._
 import nafarr.CheckTester._
 import spinal.lib.bus.amba3.apb.sim.Apb3Driver
 
-class Apb3GpioTest extends AnyFunSuite {
-  test("parameters") {
+class GpioTest extends AnyFunSuite {
+  test("Apb3GpioParameters") {
     generationShouldPass(Apb3Gpio(GpioCtrl.Parameter.default()))
     generationShouldPass(Apb3Gpio(GpioCtrl.Parameter.noInterrupt()))
     generationShouldPass(Apb3Gpio(GpioCtrl.Parameter.onlyOutput()))
@@ -22,6 +22,28 @@ class Apb3GpioTest extends AnyFunSuite {
     generationShouldFail(Apb3Gpio(GpioCtrl.Parameter.default(0)))
     generationShouldPass(Apb3Gpio(GpioCtrl.Parameter.default(1)))
     generationShouldPass(Apb3Gpio(GpioCtrl.Parameter.default(33)))
+  }
+
+  test("TileLinkGpioParameters") {
+    generationShouldPass(TileLinkGpio(GpioCtrl.Parameter.default()))
+    generationShouldPass(TileLinkGpio(GpioCtrl.Parameter.noInterrupt()))
+    generationShouldPass(TileLinkGpio(GpioCtrl.Parameter.onlyOutput()))
+    generationShouldPass(TileLinkGpio(GpioCtrl.Parameter.onlyInput()))
+
+    generationShouldFail(TileLinkGpio(GpioCtrl.Parameter.default(0)))
+    generationShouldPass(TileLinkGpio(GpioCtrl.Parameter.default(1)))
+    generationShouldPass(TileLinkGpio(GpioCtrl.Parameter.default(33)))
+  }
+
+  test("WishboneGpioParameters") {
+    generationShouldPass(WishboneGpio(GpioCtrl.Parameter.default()))
+    generationShouldPass(WishboneGpio(GpioCtrl.Parameter.noInterrupt()))
+    generationShouldPass(WishboneGpio(GpioCtrl.Parameter.onlyOutput()))
+    generationShouldPass(WishboneGpio(GpioCtrl.Parameter.onlyInput()))
+
+    generationShouldFail(WishboneGpio(GpioCtrl.Parameter.default(0)))
+    generationShouldPass(WishboneGpio(GpioCtrl.Parameter.default(1)))
+    generationShouldPass(WishboneGpio(GpioCtrl.Parameter.default(33)))
   }
 
   test("basic") {


### PR DESCRIPTION
Remove AvalonMM and add TileLink as SlaveFactory. Also update the documenation to match this change and add Wishbone+TileLink as parametrized builds to the test.