### PR TITLE
Improve GPIO Tests

### DIFF
--- a/test/scala/nafarr/IpIdentificationTest.scala
+++ b/test/scala/nafarr/IpIdentificationTest.scala
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr
+
+import spinal.core._
+import spinal.lib.bus.amba3.apb.sim.Apb3Driver
+
+object IpIdentificationTest {
+
+  object V0 {
+    def checkApi(bus: Apb3Driver, id: SpinalEnumElement[IpIdentification.Ids.type]) {
+      val result = bus.read(0)
+      val resultApi = (result >> 24) & 0xFF
+      val resultLength = (result >> 16) & 0xFF
+      val resultId = IpIdentification.Ids.elements((result & 0xFFFF).toInt)
+      val expectedApi = 0
+      val expectedLength = 8
+      val expectedId = id
+      val expected = expectedApi << 24 | expectedLength << 16 | id.position
+      assert(
+        result == expected,
+        s"IP Identification Header check failed at 0x0:\n" +
+        s"    Expected: API=$expectedApi  Length=$expectedLength  ID=$expectedId\n" +
+        s"    Received: API=$resultApi  Length=$resultLength  ID=$resultId"
+      )
+    }
+
+    def checkVersion(bus: Apb3Driver, major: Int, minor: Int, patchlevel: Int) {
+      val result = bus.read(4)
+      val resultMajor = (result >> 24) & 0xFF
+      val resultMinor = (result >> 16) & 0xFF
+      val resultPatchlevel = result & 0xFFFF
+      val expected = (major & 0xFF) << 24 | (minor & 0xFF) << 16 | (patchlevel & 0xFFFF)
+      assert(
+        result == expected,
+        s"IP identification Version check failed at 0x4:\n" +
+        s"    Expected: Major=$major  Minor=$minor  Patchlevel=$patchlevel\n" +
+        s"    Received: Major=$resultMajor  Minor=$resultMinor  Patchlevel=$resultPatchlevel"
+      )
+    }
+  }
+}

--- a/test/scala/nafarr/SimTest.scala
+++ b/test/scala/nafarr/SimTest.scala
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr
+
+import spinal.core._
+import spinal.lib.bus.amba3.apb.sim.Apb3Driver
+
+object SimTest {
+
+  def checkPins(
+    signal: => BigInt,
+    expected: BigInt,
+    description: String
+  ): Unit = {
+    val result = signal
+    assert(
+      result == expected,
+      s"""Pin mismatch - $description
+         |    Expected: 0x${expected.toString(16).toUpperCase}
+         |    Received: 0x${result.toString(16).toUpperCase}""".stripMargin
+    )
+  }
+
+  def read(
+    bus: Apb3Driver,
+    address: BigInt,
+    expected: BigInt,
+    description: String
+  ): Unit = {
+    val result = bus.read(address)
+    assert(
+      result == expected,
+      s"""Register mismatch - $description
+         |    Address:  0x${address.toString(16)}
+         |    Expected: 0x${expected.toString(16).toUpperCase}
+         |    Received: 0x${result.toString(16).toUpperCase}""".stripMargin
+    )
+  }
+
+  def readField(
+    bus: Apb3Driver,
+    address: BigInt,
+    high: Int,
+    low: Int,
+    expected: BigInt,
+    description: String
+  ): Unit = {
+    val raw   = bus.read(address)
+    val mask  = (BigInt(1) << (high - low + 1)) - 1
+    val field = (raw >> low) & mask
+    assert(
+      field == expected,
+      s"""Field mismatch - $description
+         |    Address:  0x${address.toString(16)}  bits[$high:$low]
+         |    Expected: 0x${expected.toString(16).toUpperCase}
+         |    Received: 0x${field.toString(16).toUpperCase}  (raw: 0x${raw.toString(16).toUpperCase})""".stripMargin
+    )
+  }
+}

--- a/test/scala/nafarr/peripherals/io/gpio/GpioTest.scala
+++ b/test/scala/nafarr/peripherals/io/gpio/GpioTest.scala
@@ -9,8 +9,12 @@ import org.scalatest.funsuite.AnyFunSuite
 import spinal.sim._
 import spinal.core._
 import spinal.core.sim._
-import nafarr.CheckTester._
 import spinal.lib.bus.amba3.apb.sim.Apb3Driver
+
+import nafarr.CheckTester._
+import nafarr.IpIdentification
+import nafarr.IpIdentificationTest
+import nafarr.SimTest
 
 class GpioTest extends AnyFunSuite {
   test("Apb3GpioParameters") {
@@ -46,6 +50,35 @@ class GpioTest extends AnyFunSuite {
     generationShouldPass(WishboneGpio(GpioCtrl.Parameter.default(33)))
   }
 
+  def init(dut: Apb3Gpio): (Apb3Driver, BigInt, BigInt) = {
+    dut.clockDomain.forkStimulus(10)
+    fork {
+      dut.clockDomain.fallingEdge()
+      sleep(10)
+      while (true) {
+        dut.clockDomain.clockToggle()
+        sleep(5)
+      }
+    }
+
+    val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
+
+    /* Init */
+    dut.io.gpio.pins.read #= 0
+
+    /* Wait for reset and check initialized state */
+    dut.clockDomain.waitSampling(2)
+    dut.clockDomain.waitFallingEdge()
+    assert(
+      dut.io.interrupt.toBigInt == 0,
+      f"Interrupt pending (0x${dut.io.interrupt.toBigInt}%08x)"
+    )
+
+    return (apb, dut.mapper.staticOffset, dut.mapper.regOffset)
+  }
+
+  def seqToBigInt(seq: Seq[Int]): BigInt = seq.foldLeft(BigInt(0))((acc, bit) => acc | (BigInt(1) << bit))
+
   test("basic") {
     val compiled = SimConfig.withWave.compile {
       val dut = Apb3Gpio(GpioCtrl.Parameter(
@@ -59,210 +92,198 @@ class GpioTest extends AnyFunSuite {
       dut.ctrl.io.value.simPublic()
       dut
     }
-    compiled.doSim("testIO") { dut =>
-      dut.clockDomain.forkStimulus(10)
-      fork {
-        dut.clockDomain.fallingEdge()
-        sleep(10)
-        while (true) {
-          dut.clockDomain.clockToggle()
-          sleep(5)
-        }
-      }
 
-      val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
-      val staticOffset = dut.mapper.staticOffset
-      val regOffset = dut.mapper.regOffset
-
-      /* Init */
-      dut.io.gpio.pins.read #= 0
-      /* Wait for reset and check initialized state */
-      dut.clockDomain.waitSampling(2)
-      dut.clockDomain.waitFallingEdge()
-      assert(
-        dut.io.interrupt.toBigInt == 0,
-        f"Interrupt pending (0x${dut.io.interrupt.toBigInt}%08x)"
-      )
+    compiled.doSim("registerMap") { dut =>
+      val (apb, staticOffset, _) = init(dut)
 
       /* Check IP identification */
-      assert(
-        apb.read(BigInt(0)) == BigInt("00080000", 16),
-        "IP Identification 0x0 should return 00080000 - API: 0, Length: 8, ID: 0"
-      )
-      assert(
-        apb.read(BigInt(4)) == BigInt("01000000", 16),
-        "IP Identification 0x4 should return 01000000 - 1.0.0"
-      )
+      IpIdentificationTest.V0.checkApi(apb, IpIdentification.Ids.Gpio)
+      IpIdentificationTest.V0.checkVersion(apb, 1, 0, 0)
 
       /* Read bank and pin count */
-      assert(
-        apb.read(BigInt(staticOffset)) == BigInt("00010020", 16),
-        "Unable to read 00010020 from GPIO bank/pin declaration"
-      )
+      SimTest.readField(apb, staticOffset, 31, 16, 1,  "GPIO bank count")
+      SimTest.readField(apb, staticOffset, 15,  0, 32, "GPIO pin count")
+    }
+
+    compiled.doSim("testIO") { dut =>
+      val (apb, _, regOffset) = init(dut)
+
+      val inputMask = seqToBigInt(dut.parameter.input.get)
+      val outputMask = seqToBigInt(dut.parameter.output.get)
 
       /* Check if input synchronization works */
-      dut.io.gpio.pins.read #= BigInt("FFFFFFFF", 16)
-      dut.clockDomain.waitFallingEdge(dut.ctrl.p.readBufferDepth)
-      assert(
-        dut.ctrl.io.value.toBigInt == BigInt("00000000", 16),
-        "Input is not 0x00000000"
-      )
+      dut.io.gpio.pins.read #= BigInt("ffffffff", 16)
+      dut.clockDomain.waitFallingEdge(dut.ctrl.p.readBufferDepth - 1)
+      SimTest.checkPins(dut.ctrl.io.value.toBigInt, BigInt("00000000", 16), "GPIO output all low")
       dut.clockDomain.waitFallingEdge(1)
-      assert(
-        dut.ctrl.io.value.toBigInt == BigInt("FFFFFFFF", 16),
-        "Input is not 0xFFFFFFFF"
-      )
-      /* Check if value is accessible by APB */
-      assert(
-        apb.read(BigInt(regOffset)) == BigInt("800000AF", 16),
-        "Unable to read 800000AF from GPIO read"
-      )
+      SimTest.checkPins(dut.ctrl.io.value.toBigInt, BigInt("ffffffff", 16), "GPIO output all high")
+
+      /* Check if input filter is working */
+      SimTest.read(apb, regOffset, inputMask, f"Unable to get 0x${inputMask}%08x from GPIO read")
 
       /* Check if GPIO write works */
       dut.clockDomain.waitFallingEdge()
-      apb.write(BigInt(regOffset + 4), BigInt("FFFFFFFF", 16))
+      apb.write(regOffset + 4, BigInt("ffffffff", 16))
       dut.clockDomain.waitFallingEdge(1)
-      assert(dut.io.gpio.pins.write.toBigInt == BigInt("800000F9", 16))
-      assert(
-        apb.read(BigInt(regOffset + 4)) == BigInt("800000F9", 16),
-        "Unable to read 800000F9 from GPIO write"
-      )
+      SimTest.checkPins(dut.io.gpio.pins.write.toBigInt, outputMask, f"GPIO output doesn't match 0x${outputMask}%08x")
+      SimTest.read(apb, regOffset + 4, outputMask, f"Unable to get 0x${outputMask}%08x from GPIO write")
 
       /* Check if GPIO direction works */
       dut.clockDomain.waitFallingEdge()
-      apb.write(BigInt(regOffset + 8), BigInt("FFFFFFFF", 16))
+      apb.write(regOffset + 8, BigInt("ffffffff", 16))
       dut.clockDomain.waitFallingEdge(1)
-      assert(dut.io.gpio.pins.writeEnable.toBigInt == BigInt("800000F9", 16))
-      assert(
-        apb.read(BigInt(regOffset + 8)) == BigInt("800000F9", 16),
-        "Unable to read 800000F9 from GPIO write"
-      )
 
+      SimTest.checkPins(dut.io.gpio.pins.writeEnable.toBigInt, outputMask, f"GPIO output enable doesn't match 0x${outputMask}%08x")
+      SimTest.read(apb, regOffset + 8, outputMask, f"Unable to get 0x${outputMask}%08x from GPIO write")
     }
-    compiled.doSim("testIRQ") { dut =>
-      dut.clockDomain.forkStimulus(10)
-      fork {
-        dut.clockDomain.fallingEdge()
-        sleep(10)
-        while (true) {
-          dut.clockDomain.clockToggle()
-          sleep(5)
-        }
-      }
 
-      val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
-      val regOffset = dut.mapper.regOffset
+    compiled.doSim("testIRQ - Level High") { dut =>
+      val (apb, _, regOffset) = init(dut)
 
-      /* Init */
-      dut.io.gpio.pins.read #= 0
-      /* Wait for reset and check initialized state */
-      dut.clockDomain.waitSampling(2)
-      dut.clockDomain.waitFallingEdge()
-      assert(
-        dut.io.interrupt.toBigInt == 0,
-        f"Interrupt pending (0x${dut.io.interrupt.toBigInt}%08x)"
-      )
+      val irqMask = seqToBigInt(dut.parameter.interrupt.get)
+      val irqPendingReg = regOffset + 12
+      val irqMaskReg = regOffset + 16
 
       /* Test interrupt on high signal */
-      apb.write(BigInt(regOffset + 12), BigInt("FFFFFFFF", 16))
-      apb.write(BigInt(regOffset + 16), BigInt("FFFFFFFF", 16))
-      dut.io.gpio.pins.read #= BigInt("FFFFFFFF", 16)
+      dut.io.gpio.pins.read #= BigInt("00000000", 16)
+      apb.write(irqPendingReg, BigInt("ffffffff", 16))
+      apb.write(irqMaskReg, BigInt("ffffffff", 16))
+      dut.io.gpio.pins.read #= BigInt("ffffffff", 16)
       for (_ <- 0 to dut.ctrl.p.readBufferDepth + 1) {
-        assert(
-          dut.io.interrupt.toBigInt == 0,
-          f"Interrupt pending (0x${dut.io.interrupt.toBigInt}%08x)"
-        )
+        SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt pending")
         dut.clockDomain.waitFallingEdge()
       }
-      assert(
-        dut.io.interrupt.toBigInt == 1,
-        f"Interrupt not pending (0x${dut.io.interrupt.toBigInt}%08x)"
-      )
-      apb.write(BigInt(regOffset + 16), BigInt("00000000", 16))
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt not pending")
+      SimTest.read(apb, irqPendingReg, irqMask, f"Wrong input pins triggered interrupt enable bits")
+
+      /* Clear interrupt */
+      dut.io.gpio.pins.read #= BigInt("00000000", 16)
       dut.clockDomain.waitFallingEdge()
-      assert(
-        dut.io.interrupt.toBigInt == 0,
-        f"Interrupt pending (0x${dut.io.interrupt.toBigInt}%08x)"
-      )
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt not pending")
+      apb.write(irqPendingReg, BigInt("ffffffff", 16))
+      dut.clockDomain.waitFallingEdge()
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt pending")
+      /* Enable interrupt again */
+      dut.io.gpio.pins.read #= BigInt("ffffffff", 16)
+      dut.clockDomain.waitFallingEdge(dut.ctrl.p.readBufferDepth + 1)
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt not pending")
+      /* Clear interrupt mask */
+      apb.write(irqMaskReg, BigInt("00000000", 16))
+      dut.clockDomain.waitFallingEdge()
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt pending")
+    }
+
+    compiled.doSim("testIRQ - Level Low") { dut =>
+      val (apb, _, regOffset) = init(dut)
+
+      val irqMask = seqToBigInt(dut.parameter.interrupt.get)
+      val irqPendingReg = regOffset + 20
+      val irqMaskReg = regOffset + 24
 
       /* Test interrupt on low signal */
-      apb.write(BigInt(regOffset + 20), BigInt("FFFFFFFF", 16))
-      apb.write(BigInt(regOffset + 24), BigInt("FFFFFFFF", 16))
+      dut.io.gpio.pins.read #= BigInt("ffffffff", 16)
+      apb.write(irqPendingReg, BigInt("ffffffff", 16))
+      apb.write(irqMaskReg, BigInt("ffffffff", 16))
       dut.io.gpio.pins.read #= BigInt("00000000", 16)
       for (_ <- 0 to dut.ctrl.p.readBufferDepth + 1) {
-        assert(
-          dut.io.interrupt.toBigInt == 0,
-          f"Interrupt pending (0x${dut.io.interrupt.toBigInt}%08x)"
-        )
+        SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt pending")
         dut.clockDomain.waitFallingEdge()
       }
-      assert(
-        dut.io.interrupt.toBigInt == 1,
-        f"Interrupt not pending (0x${dut.io.interrupt.toBigInt}%08x)"
-      )
-      apb.write(BigInt(regOffset + 24), BigInt("00000000", 16))
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt not pending")
+      SimTest.read(apb, irqPendingReg, irqMask, f"Wrong input pins triggered interrupt enable bits")
+
+      /* Clear interrupt */
+      dut.io.gpio.pins.read #= BigInt("ffffffff", 16)
       dut.clockDomain.waitFallingEdge()
-      assert(
-        dut.io.interrupt.toBigInt == 0,
-        f"Interrupt pending (0x${dut.io.interrupt.toBigInt}%08x)"
-      )
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt not pending")
+      apb.write(irqPendingReg, BigInt("ffffffff", 16))
+      dut.clockDomain.waitFallingEdge()
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt pending")
+      /* Enable interrupt again */
+      dut.io.gpio.pins.read #= BigInt("00000000", 16)
+      dut.clockDomain.waitFallingEdge(dut.ctrl.p.readBufferDepth + 1)
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt not pending")
+      /* Clear interrupt mask */
+      apb.write(irqMaskReg, BigInt("00000000", 16))
+      dut.clockDomain.waitFallingEdge()
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt pending")
+    }
+
+    compiled.doSim("testIRQ - Rising Edge") { dut =>
+      val (apb, _, regOffset) = init(dut)
+
+      val irqMask = seqToBigInt(dut.parameter.interrupt.get)
+      val irqPendingReg = regOffset + 28
+      val irqMaskReg = regOffset + 32
 
       /* Test interrupt on rising signal */
-      apb.write(BigInt(regOffset + 28), BigInt("FFFFFFFF", 16))
-      apb.write(BigInt(regOffset + 32), BigInt("FFFFFFFF", 16))
       dut.io.gpio.pins.read #= BigInt("00000000", 16)
-      assert(
-        dut.io.interrupt.toBigInt == 0,
-        f"Interrupt pending (0x${dut.io.interrupt.toBigInt}%08x)"
-      )
+      apb.write(irqPendingReg, BigInt("ffffffff", 16))
+      apb.write(irqMaskReg, BigInt("ffffffff", 16))
+      dut.io.gpio.pins.read #= BigInt("00000000", 16)
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt pending")
       dut.clockDomain.waitFallingEdge()
-      dut.io.gpio.pins.read #= BigInt("FFFFFFFF", 16)
+      dut.io.gpio.pins.read #= BigInt("ffffffff", 16)
       for (_ <- 0 to dut.ctrl.p.readBufferDepth) {
-        assert(
-          dut.io.interrupt.toBigInt == 0,
-          f"Interrupt pending (0x${dut.io.interrupt.toBigInt}%08x)"
-        )
+        SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt pending")
         dut.clockDomain.waitFallingEdge()
       }
-      assert(
-        dut.io.interrupt.toBigInt == 1,
-        f"Interrupt not pending (0x${dut.io.interrupt.toBigInt}%08x)"
-      )
-      apb.write(BigInt(regOffset + 32), BigInt("00000000", 16))
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt not pending")
+
+      /* Clear interrupt */
+      apb.write(irqPendingReg, BigInt("ffffffff", 16))
       dut.clockDomain.waitFallingEdge()
-      assert(
-        dut.io.interrupt.toBigInt == 0,
-        f"Interrupt pending (0x${dut.io.interrupt.toBigInt}%08x)"
-      )
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt pending")
+      /* Enable interrupt again */
+      dut.io.gpio.pins.read #= BigInt("00000000", 16)
+      dut.clockDomain.waitFallingEdge()
+      dut.io.gpio.pins.read #= BigInt("ffffffff", 16)
+      dut.clockDomain.waitFallingEdge(dut.ctrl.p.readBufferDepth + 1)
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt not pending")
+
+      /* Clear interrupt mask */
+      apb.write(irqMaskReg, BigInt("00000000", 16))
+      dut.clockDomain.waitFallingEdge()
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt pending")
+    }
+
+    compiled.doSim("testIRQ - Falling Edge") { dut =>
+      val (apb, _, regOffset) = init(dut)
+
+      val irqMask = seqToBigInt(dut.parameter.interrupt.get)
+      val irqPendingReg = regOffset + 36
+      val irqMaskReg = regOffset + 40
 
       /* Test interrupt on falling signal */
-      apb.write(BigInt(regOffset + 36), BigInt("FFFFFFFF", 16))
-      apb.write(BigInt(regOffset + 40), BigInt("FFFFFFFF", 16))
-      dut.io.gpio.pins.read #= BigInt("FFFFFFFF", 16)
-      assert(
-        dut.io.interrupt.toBigInt == 0,
-        f"Interrupt pending (0x${dut.io.interrupt.toBigInt}%08x)"
-      )
+      dut.io.gpio.pins.read #= BigInt("ffffffff", 16)
+      apb.write(irqPendingReg, BigInt("ffffffff", 16))
+      apb.write(irqMaskReg, BigInt("ffffffff", 16))
+      dut.io.gpio.pins.read #= BigInt("ffffffff", 16)
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt pending")
       dut.clockDomain.waitFallingEdge()
       dut.io.gpio.pins.read #= BigInt("00000000", 16)
       for (_ <- 0 to dut.ctrl.p.readBufferDepth) {
-        assert(
-          dut.io.interrupt.toBigInt == 0,
-          f"Interrupt pending (0x${dut.io.interrupt.toBigInt}%08x)"
-        )
+        SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt pending")
         dut.clockDomain.waitFallingEdge()
       }
-      assert(
-        dut.io.interrupt.toBigInt == 1,
-        f"Interrupt not pending (0x${dut.io.interrupt.toBigInt}%08x)"
-      )
-      apb.write(BigInt(regOffset + 40), BigInt("00000000", 16))
-      dut.clockDomain.waitFallingEdge()
-      assert(
-        dut.io.interrupt.toBigInt == 0,
-        f"Interrupt pending (0x${dut.io.interrupt.toBigInt}%08x)"
-      )
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt not pending")
 
+      /* Clear interrupt */
+      apb.write(irqPendingReg, BigInt("ffffffff", 16))
+      dut.clockDomain.waitFallingEdge()
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt pending")
+      /* Enable interrupt again */
+      dut.io.gpio.pins.read #= BigInt("ffffffff", 16)
+      dut.clockDomain.waitFallingEdge()
+      dut.io.gpio.pins.read #= BigInt("00000000", 16)
+      dut.clockDomain.waitFallingEdge(dut.ctrl.p.readBufferDepth + 1)
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt not pending")
+
+      /* Clear interrupt mask */
+      apb.write(irqMaskReg, BigInt("00000000", 16))
+      dut.clockDomain.waitFallingEdge()
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt pending")
     }
+
   }
 }


### PR DESCRIPTION
Add simulation/test helper to verify the IP Identification and easily read+check signals/registers. Also update the GPIO tests by using those new helper.