### PR TITLE
Update PWM tests and documentation titles

### DIFF
--- a/docs/source/hardware/peripherals/gpio.rst
+++ b/docs/source/hardware/peripherals/gpio.rst
@@ -1,7 +1,7 @@
 .. _hardware-peripherals-gpio:
 
-GPIO
-####
+General-Purpose I/O (GPIO)
+##########################
 
 A GPIO (General-Purpose Input/Output) controller with tri-state pins is a versatile digital interface that allows each pin to be configured as either an input or an output, with additional control for setting the direction of data flow. Here's a breakdown of its functionality:
 

--- a/docs/source/hardware/peripherals/i2c-controller.rst
+++ b/docs/source/hardware/peripherals/i2c-controller.rst
@@ -1,7 +1,7 @@
 .. _hardware-peripherals-i2c-controller:
 
-I2C Controller
-##############
+Inter-Integrated Circuit (I2C) Controller
+#########################################
 
 This IP core is a highly configurable module designed for efficient communication with I2C devices. This controller integrates advanced features to manage data transmission, handle device interactions, and respond to various operational conditions.
 

--- a/docs/source/hardware/peripherals/i2c-device.rst
+++ b/docs/source/hardware/peripherals/i2c-device.rst
@@ -1,7 +1,7 @@
 .. _hardware-peripherals-i2c-device:
 
-I2C Device
-##########
+Inter-Integrated Circuit (I2C) Device
+#####################################
 
 The I2C (Inter-Integrated Circuit) Device IP core is a flexible interface designed to handle and process I2C transmissions. It features an internal clock divider, automatic timeout detection for stalled transmissions, and a configurable sampling bit count.
 

--- a/docs/source/hardware/peripherals/pio.rst
+++ b/docs/source/hardware/peripherals/pio.rst
@@ -1,7 +1,7 @@
 .. _hardware-peripherals-pio:
 
-Programmable IO
-###############
+Programmable I/O (PIO)
+######################
 
 The Programmable IO (PIO) IP Core is a versatile and highly configurable module designed for generating and controlling low-speed digital interfaces. It features an internal state machine that executes a user-defined program stored in on-chip memory to drive IO signals in precise sequences. This allows the IP core to support a wide range of protocols and custom interfaces by bit-banging signals according to the programmed commands, without requiring continuous CPU intervention.
 

--- a/docs/source/hardware/peripherals/pwm.rst
+++ b/docs/source/hardware/peripherals/pwm.rst
@@ -1,7 +1,7 @@
 .. _hardware-peripherals-pwm:
 
-Pulse-Width Modulation
-######################
+Pulse-Width Modulation (PWM)
+############################
 
 The Pulse-Width Modulation (PWM) IP Core is a multi-channel controller for generating
 precise PWM signals. Each channel operates independently with its own clock divider and

--- a/docs/source/hardware/peripherals/uart.rst
+++ b/docs/source/hardware/peripherals/uart.rst
@@ -1,7 +1,7 @@
 .. _hardware-peripherals-uart:
 
-UART
-####
+Universal Asynchronous Receiver-Transmitter (UART)
+##################################################
 
 The UART (Universal Asynchronous Receiver-Transmitter) IP Core is a configurable serial communication interface designed to handle data transmission and reception. The core includes an internal clock divider and supports flexible frame configurations, allowing for variable data length, parity, and stop bit settings.
 

--- a/hardware/scala/nafarr/peripherals/io/pwm/PwmCtrl.scala
+++ b/hardware/scala/nafarr/peripherals/io/pwm/PwmCtrl.scala
@@ -14,6 +14,30 @@ import nafarr.library.ClockDivider
 object PwmCtrl {
   def apply(p: Parameter = Parameter.default()) = PwmCtrl(p)
 
+  object Regs {
+    def apply(base: BigInt) = new Regs(base)
+  }
+
+  class Regs(base: BigInt) {
+    val channelConfig = base + 0x00
+    val timingConfig = base + 0x04
+    val permissions = base + 0x08
+    val interruptPending = base + 0x0c
+    val interruptMask = base + 0x10
+    val errorPending = base + 0x14
+    val errorMask = base + 0x18
+    private def channelBase(channel: Int): BigInt = base + 0x1c + channel * 0x24
+    def control(channel: Int) = channelBase(channel) + 0x00
+    def clockDivider(channel: Int) = channelBase(channel) + 0x04
+    def period(channel: Int) = channelBase(channel) + 0x08
+    def risingEdge(channel: Int) = channelBase(channel) + 0x0c
+    def fallingEdge(channel: Int) = channelBase(channel) + 0x10
+    def deadTime(channel: Int) = channelBase(channel) + 0x14
+    def phaseOffset(channel: Int) = channelBase(channel) + 0x18
+    def shotCount(channel: Int) = channelBase(channel) + 0x1c
+    def status(channel: Int) = channelBase(channel) + 0x20
+  }
+
   case class InitParameter(clockDivider: Int) {}
   object InitParameter {
     def disabled = InitParameter(0)
@@ -125,7 +149,15 @@ object PwmCtrl {
           periodLive := s.period
           risingEdgeLive := s.risingEdge
           fallingEdgeLive := s.fallingEdge
-          periodCounter := s.phaseOffset
+          when(s.mode) {
+            periodCounter := s.phaseOffset
+          } otherwise {
+            when(s.phaseOffset === 0) {
+              periodCounter := s.period
+            } otherwise {
+              periodCounter := s.phaseOffset
+            }
+          }
           direction := False
           shotDoneReg := False
           shotRemaining := s.shotCount
@@ -219,32 +251,30 @@ object PwmCtrl {
   ) extends Area {
     val idCtrl = IpIdentification(IpIdentification.Ids.Pwm, 1, 1, 0)
     idCtrl.driveFrom(busCtrl)
-    val staticOffset = idCtrl.length
+    val regs = Regs(idCtrl.length)
 
     // Static word 1: implementation widths and channel count
     busCtrl.read(
       B(p.channelPeriodWidth, 8 bits) ## B(p.channelPulseWidth, 8 bits) ##
         B(p.clockDividerWidth, 8 bits) ## B(p.io.channels, 8 bits),
-      staticOffset
+      regs.channelConfig
     )
 
     // Static word 2: dead-time and shot-count widths
     busCtrl.read(
       B(0, 16 bits) ## B(p.shotCountWidth, 8 bits) ## B(p.deadTimeWidth, 8 bits),
-      staticOffset + 0x4
+      regs.timingConfig
     )
 
     if (p.permission != null) {
       val permissionBits = Bool(p.permission.busCanWriteClockDividerConfig)
-      busCtrl.read(B(0, 32 - 1 bits) ## permissionBits, staticOffset + 0x8)
+      busCtrl.read(B(0, 32 - 1 bits) ## permissionBits, regs.permissions)
     } else {
-      busCtrl.read(B(0), staticOffset + 0x8)
+      busCtrl.read(B(0), regs.permissions)
     }
 
-    val regOffset = staticOffset + 0xc
-
     val irqPeriodCompleteCtrl = new InterruptCtrl(p.io.channels)
-    irqPeriodCompleteCtrl.driveFrom(busCtrl, regOffset + 0x00)
+    irqPeriodCompleteCtrl.driveFrom(busCtrl, regs.interruptPending.toInt)
     for (i <- 0 until p.io.channels) {
       irqPeriodCompleteCtrl.io.inputs(i) := ctrl.irqPeriodComplete.valid(i)
       ctrl.irqPeriodComplete.pending(i) := irqPeriodCompleteCtrl.io.pendings(i)
@@ -255,7 +285,7 @@ object PwmCtrl {
 
     // Error module: faultIn rising edge (input 0) + per-channel configError (inputs 1..N)
     val errorCtrl = new InterruptCtrl(1 + p.io.channels)
-    errorCtrl.driveFrom(busCtrl, regOffset + 0x08)
+    errorCtrl.driveFrom(busCtrl, regs.errorPending.toInt)
     errorCtrl.io.inputs(0) := ctrl.faultError
     for (i <- 0 until p.io.channels) {
       errorCtrl.io.inputs(1 + i) :=
@@ -263,10 +293,8 @@ object PwmCtrl {
     }
     ctrl.errorPending := errorCtrl.io.pendings.orR
 
-    // Channel registers: stride 0x28 (40 bytes), starting at regOffset + 0x14
+    // Channel registers
     for (i <- 0 until p.io.channels) {
-      val channel = regOffset + 0x10 + i * 0x28
-
       channelCfg(i).enable.init(False)
       channelCfg(i).invert.init(False)
       channelCfg(i).mode.init(False)
@@ -282,30 +310,30 @@ object PwmCtrl {
       else
         channelCfg(i).clockDivider.init(0)
 
-      busCtrl.readAndWrite(channelCfg(i).enable, address = channel + 0x00, bitOffset = 0)
-      busCtrl.readAndWrite(channelCfg(i).invert, address = channel + 0x00, bitOffset = 1)
-      busCtrl.readAndWrite(channelCfg(i).mode, address = channel + 0x00, bitOffset = 2)
+      busCtrl.readAndWrite(channelCfg(i).enable, address = regs.control(i), bitOffset = 0)
+      busCtrl.readAndWrite(channelCfg(i).invert, address = regs.control(i), bitOffset = 1)
+      busCtrl.readAndWrite(channelCfg(i).mode, address = regs.control(i), bitOffset = 2)
 
       if (p.permission != null && p.permission.busCanWriteClockDividerConfig)
-        busCtrl.readAndWrite(channelCfg(i).clockDivider, address = channel + 0x04)
+        busCtrl.readAndWrite(channelCfg(i).clockDivider, address = regs.clockDivider(i))
       else {
         channelCfg(i).clockDivider.allowUnsetRegToAvoidLatch
-        busCtrl.read(channelCfg(i).clockDivider, address = channel + 0x04)
+        busCtrl.read(channelCfg(i).clockDivider, address = regs.clockDivider(i))
       }
 
-      busCtrl.readAndWrite(channelCfg(i).period, address = channel + 0x08)
-      busCtrl.readAndWrite(channelCfg(i).risingEdge, address = channel + 0x0c)
-      busCtrl.readAndWrite(channelCfg(i).fallingEdge, address = channel + 0x10)
-      busCtrl.readAndWrite(channelCfg(i).deadTime, address = channel + 0x14)
-      busCtrl.readAndWrite(channelCfg(i).phaseOffset, address = channel + 0x18)
-      busCtrl.readAndWrite(channelCfg(i).shotCount, address = channel + 0x1c)
+      busCtrl.readAndWrite(channelCfg(i).period, address = regs.period(i))
+      busCtrl.readAndWrite(channelCfg(i).risingEdge, address = regs.risingEdge(i))
+      busCtrl.readAndWrite(channelCfg(i).fallingEdge, address = regs.fallingEdge(i))
+      busCtrl.readAndWrite(channelCfg(i).deadTime, address = regs.deadTime(i))
+      busCtrl.readAndWrite(channelCfg(i).phaseOffset, address = regs.phaseOffset(i))
+      busCtrl.readAndWrite(channelCfg(i).shotCount, address = regs.shotCount(i))
 
       // Status register (read-only): configError[0], shotDone[1]
       val configError =
         channelCfg(i).fallingEdge.resize(p.channelPeriodWidth) > channelCfg(i).period
       busCtrl.read(
         B(0, 30 bits) ## ctrl.shotDone(i) ## configError,
-        channel + 0x20
+        regs.status(i)
       )
     }
     ctrl.shadow := channelCfg

--- a/test/scala/nafarr/peripherals/io/pwm/PwmTest.scala
+++ b/test/scala/nafarr/peripherals/io/pwm/PwmTest.scala
@@ -9,8 +9,12 @@ import org.scalatest.funsuite.AnyFunSuite
 import spinal.sim._
 import spinal.core._
 import spinal.core.sim._
-import nafarr.CheckTester._
 import spinal.lib.bus.amba3.apb.sim.Apb3Driver
+
+import nafarr.CheckTester._
+import nafarr.IpIdentification
+import nafarr.IpIdentificationTest
+import nafarr.SimTest
 
 class PwmTest extends AnyFunSuite {
   test("Apb3PwmParameters") {
@@ -67,130 +71,358 @@ class PwmTest extends AnyFunSuite {
     generationShouldFail(WishbonePwm(PwmCtrl.Parameter.default(0)))
   }
 
+  def init(dut: Apb3Pwm): (Apb3Driver, PwmCtrl.Regs) = {
+    dut.clockDomain.forkStimulus(10)
+    fork {
+      dut.clockDomain.fallingEdge()
+      sleep(10)
+      while (true) {
+        dut.clockDomain.clockToggle()
+        sleep(5)
+      }
+    }
+
+    val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
+    val regs = PwmCtrl.Regs(dut.mapper.idCtrl.length)
+
+    /* Init */
+    dut.io.pwm.syncIn #= false
+    dut.io.pwm.faultIn #= false
+
+    /* Wait for reset and check initialized state */
+    dut.clockDomain.waitSampling(2)
+    dut.clockDomain.waitFallingEdge()
+
+    return (apb, regs)
+  }
+
   test("basic") {
     val compiled = SimConfig.withWave.compile {
       val dut = Apb3Pwm(PwmCtrl.Parameter.default(1))
       dut
     }
     compiled.doSim("basicRegisters") { dut =>
-      dut.clockDomain.forkStimulus(10)
-      fork {
-        dut.clockDomain.fallingEdge()
-        sleep(10)
-        while (true) {
-          dut.clockDomain.clockToggle()
-          sleep(5)
-        }
-      }
-
-      val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
-      val staticOffset = dut.mapper.staticOffset
-      val regOffset = dut.mapper.regOffset
-
-      /* Wait for reset and check initialized state */
-      dut.clockDomain.waitSampling(2)
-      dut.clockDomain.waitFallingEdge()
+      val (apb, regs) = init(dut)
 
       /* Check IP identification */
-      assert(
-        apb.read(BigInt(0)) == BigInt("00080002", 16),
-        "IP Identification 0x0 should return 00080002 - API: 0, Length: 8, ID: 2"
-      )
-      assert(
-        apb.read(BigInt(4)) == BigInt("01010000", 16),
-        "IP Identification 0x4 should return 01010000 - 1.1.0"
-      )
+      IpIdentificationTest.V0.checkApi(apb, IpIdentification.Ids.Pwm)
+      IpIdentificationTest.V0.checkVersion(apb, 1, 1, 0)
 
       /* Read channelPulseWidth, channelPeriodWidth, clockDividerWidth, io.channels */
-      assert(
-        apb.read(BigInt(staticOffset)) == BigInt("14141401", 16),
-        "Unable to read 14141401 from PWM config/channel declaration"
-      )
+      SimTest.readField(apb, regs.channelConfig, 31, 24, 20,  "Channel period width")
+      SimTest.readField(apb, regs.channelConfig, 23, 16, 20,  "Channel pulse width")
+      SimTest.readField(apb, regs.channelConfig, 15, 8, 20,  "Clock divider width")
+      SimTest.readField(apb, regs.channelConfig, 7, 0, 1,  "IO channels")
 
       /* Read dead-time and shot-count widthss */
-      assert(
-        apb.read(BigInt(staticOffset + 4)) == BigInt("00000808", 16),
-        "Unable to read 00000808 from PWM config/channel declaration"
-      )
+      SimTest.readField(apb, regs.timingConfig, 15, 8, 8,  "Shot count width")
+      SimTest.readField(apb, regs.timingConfig, 7, 0, 8,  "Dead time width")
 
       /* Read permissions */
-      assert(
-        apb.read(BigInt(staticOffset + 8)) == BigInt("00000001", 16),
-        "Unable to read 00000001 from PWM permission declaration"
-      )
+      SimTest.readField(apb, regs.permissions, 1, 0, 1, "Permissions")
     }
-    compiled.doSim("channel1dutyCycle") { dut =>
-      dut.clockDomain.forkStimulus(10)
-      fork {
-        dut.clockDomain.fallingEdge()
-        sleep(10)
-        while (true) {
-          dut.clockDomain.clockToggle()
-          sleep(5)
-        }
-      }
 
-      val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
-      val regOffset = dut.mapper.regOffset
-
-      dut.io.pwm.syncIn #= false
-      dut.io.pwm.faultIn #= false
-
-      /* Wait for reset and check initialized state */
-      dut.clockDomain.waitSampling(2)
-      dut.clockDomain.waitFallingEdge()
+    compiled.doSim("channel0 - duty cycle") { dut =>
+      val (apb, regs) = init(dut)
+      val channel = 0
 
       /* Init - Set clock divider to 1 us */
-      apb.write(BigInt(regOffset + 0x14), BigInt("99", 10))
+      apb.write(regs.clockDivider(channel), BigInt("99", 10))
 
       /* Init channel 0: period=9, active [risingEdge=5, fallingEdge=9] -> 5/10 duty */
-      apb.write(BigInt(regOffset + 0x18), BigInt("9", 10))
-      apb.write(BigInt(regOffset + 0x1c), BigInt("5", 10))
-      apb.write(BigInt(regOffset + 0x20), BigInt("9", 10))
+      apb.write(regs.period(channel), BigInt("9", 10))
+      apb.write(regs.risingEdge(channel), BigInt("5", 10))
+      apb.write(regs.fallingEdge(channel), BigInt("9", 10))
+
+      apb.write(regs.control(channel), BigInt("1", 16))
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(2)
+
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(491)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(1)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(400)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000001", 16))
+
+      dut.clockDomain.waitSampling(1)
+
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(498)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling()
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(400)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000001", 16))
+    }
+
+    compiled.doSim("channel0 - duty cycle show count 2") { dut =>
+      val (apb, regs) = init(dut)
+      val channel = 0
+
+      /* Init - Set clock divider to 1 us */
+      apb.write(regs.clockDivider(channel), BigInt("99", 10))
+
+      /* Init channel 0: period=9, active [risingEdge=5, fallingEdge=9] -> 5/10 duty */
+      apb.write(regs.period(channel), BigInt("9", 10))
+      apb.write(regs.risingEdge(channel), BigInt("5", 10))
+      apb.write(regs.fallingEdge(channel), BigInt("9", 10))
+      apb.write(regs.shotCount(channel), BigInt("2", 10))
+
+      apb.write(regs.control(channel), BigInt("1", 16))
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(2)
+
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(489)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(1)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(400)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000001", 16))
+
+      SimTest.readField(apb, regs.status(channel), 1, 1, 0,  "Channel shot done set")
+
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(497)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling()
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(400)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000001", 16))
+
+      SimTest.readField(apb, regs.status(channel), 1, 1, 1,  "Channel shot done not set")
 
       assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
-      apb.write(BigInt(regOffset + 0x10), BigInt("1", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+    }
+
+    compiled.doSim("channel0 - duty cycle phase offset") { dut =>
+      val (apb, regs) = init(dut)
+      val channel = 0
+
+      /* Init - Set clock divider to 1 us */
+      apb.write(regs.clockDivider(channel), BigInt("99", 10))
+
+      /* Init channel 0: period=9, active [risingEdge=5, fallingEdge=9] -> 5/10 duty */
+      apb.write(regs.period(channel), BigInt("9", 10))
+      apb.write(regs.risingEdge(channel), BigInt("5", 10))
+      apb.write(regs.fallingEdge(channel), BigInt("9", 10))
+      apb.write(regs.phaseOffset(channel), BigInt("1", 10))
+
+      apb.write(regs.control(channel), BigInt("1", 16))
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
       dut.clockDomain.waitSampling(100)
 
       assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
-      dut.clockDomain.waitSampling(5 * 100)
-      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
-      dut.clockDomain.waitSampling(5 * 100)
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(491)
       assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
-      dut.clockDomain.waitSampling(5 * 100)
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(1)
       assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(400)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000001", 16))
+
+      dut.clockDomain.waitSampling(1)
+
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(498)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling()
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(400)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000001", 16))
     }
-    compiled.doSim("channel1StartStopStart") { dut =>
-      dut.clockDomain.forkStimulus(10)
-      fork {
-        dut.clockDomain.fallingEdge()
-        sleep(10)
-        while (true) {
-          dut.clockDomain.clockToggle()
-          sleep(5)
-        }
-      }
 
-      val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
-      val regOffset = dut.mapper.regOffset
-
-      dut.io.pwm.syncIn #= false
-      dut.io.pwm.faultIn #= false
-
-      /* Wait for reset and check initialized state */
-      dut.clockDomain.waitSampling(2)
-      dut.clockDomain.waitFallingEdge()
+    compiled.doSim("channel0 - dead time") { dut =>
+      val (apb, regs) = init(dut)
+      val channel = 0
 
       /* Init - Set clock divider to 1 us */
-      apb.write(BigInt(regOffset + 0x14), BigInt("99", 10))
+      apb.write(regs.clockDivider(channel), BigInt("99", 10))
 
       /* Init channel 0: period=9, active [risingEdge=5, fallingEdge=9] -> 5/10 duty */
-      apb.write(BigInt(regOffset + 0x18), BigInt("9", 10))
-      apb.write(BigInt(regOffset + 0x1c), BigInt("5", 10))
-      apb.write(BigInt(regOffset + 0x20), BigInt("9", 10))
+      apb.write(regs.period(channel), BigInt("9", 10))
+      apb.write(regs.risingEdge(channel), BigInt("5", 10))
+      apb.write(regs.fallingEdge(channel), BigInt("9", 10))
+      apb.write(regs.deadTime(channel), BigInt("1", 10))
+
+      apb.write(regs.control(channel), BigInt("1", 16))
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(2)
+
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(489)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(1)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(100)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(300)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000001", 16))
+
+      dut.clockDomain.waitSampling(1)
 
       assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
-      apb.write(BigInt(regOffset + 0x10), BigInt("1", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(100)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(398)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(1)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(100)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(300)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000001", 16))
+    }
+
+    compiled.doSim("channel0 - duty cycle inverted") { dut =>
+      val (apb, regs) = init(dut)
+      val channel = 0
+
+      /* Init - Set clock divider to 1 us */
+      apb.write(regs.clockDivider(channel), BigInt("99", 10))
+
+      /* Init channel 0: period=9, active [risingEdge=5, fallingEdge=9] -> 5/10 duty */
+      apb.write(regs.period(channel), BigInt("9", 10))
+      apb.write(regs.risingEdge(channel), BigInt("5", 10))
+      apb.write(regs.fallingEdge(channel), BigInt("9", 10))
+
+      apb.write(regs.control(channel), BigInt("3", 16))
+      dut.clockDomain.waitSampling(1)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(1)
+
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(491)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(1)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(400)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000001", 16))
+
+      dut.clockDomain.waitSampling(1)
+
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(498)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling()
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(400)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000001", 16))
+    }
+
+    compiled.doSim("channel0 - start stop start") { dut =>
+      val (apb, regs) = init(dut)
+      val channel = 0
+
+      /* Init - Set clock divider to 1 us */
+      apb.write(regs.clockDivider(channel), BigInt("99", 10))
+
+      /* Init channel 0: period=9, active [risingEdge=5, fallingEdge=9] -> 5/10 duty */
+      apb.write(regs.period(channel), BigInt("9", 10))
+      apb.write(regs.risingEdge(channel), BigInt("5", 10))
+      apb.write(regs.fallingEdge(channel), BigInt("9", 10))
+
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      apb.write(regs.control(channel), BigInt("1", 16))
       dut.clockDomain.waitSampling(10)
 
       assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
@@ -199,13 +431,13 @@ class PwmTest extends AnyFunSuite {
       dut.clockDomain.waitSampling(5 * 100)
       assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
       dut.clockDomain.waitSampling(10)
-      apb.write(BigInt(regOffset + 0x10), BigInt("0", 16))
-      apb.write(BigInt(regOffset + 0x18), BigInt("9", 10))
-      apb.write(BigInt(regOffset + 0x1c), BigInt("7", 10))
-      apb.write(BigInt(regOffset + 0x20), BigInt("9", 10))
+      apb.write(regs.control(channel), BigInt("0", 16))
+      apb.write(regs.period(channel), BigInt("9", 10))
+      apb.write(regs.risingEdge(channel), BigInt("7", 10))
+      apb.write(regs.fallingEdge(channel), BigInt("9", 10))
 
       dut.clockDomain.waitSampling(90)
-      apb.write(BigInt(regOffset + 0x10), BigInt("1", 16))
+      apb.write(regs.control(channel), BigInt("1", 16))
       dut.clockDomain.waitSampling(100)
 
       assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
@@ -214,5 +446,210 @@ class PwmTest extends AnyFunSuite {
       dut.clockDomain.waitSampling(7 * 100)
       assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
     }
+
+    compiled.doSim("channel0 - center-aligned mode") { dut =>
+      val (apb, regs) = init(dut)
+      val channel = 0
+
+      /* Init - Set clock divider to 1 us */
+      apb.write(regs.clockDivider(channel), BigInt("99", 10))
+
+      /* Init channel 0: period=9, active [risingEdge=5, fallingEdge=9] -> 5/10 duty */
+      apb.write(regs.period(channel), BigInt("9", 10))
+      apb.write(regs.risingEdge(channel), BigInt("5", 10))
+      apb.write(regs.fallingEdge(channel), BigInt("9", 10))
+
+      apb.write(regs.control(channel), BigInt("5", 16))
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(2)
+
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(491)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(1)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(400)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000001", 16))
+
+      dut.clockDomain.waitSampling(1)
+
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(498)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling()
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(400)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+    }
+
+    compiled.doSim("channel0 - sync in") { dut =>
+      val (apb, regs) = init(dut)
+      val channel = 0
+
+      /* Init - Set clock divider to 1 us */
+      apb.write(regs.clockDivider(channel), BigInt("99", 10))
+
+      /* Init channel 0: period=9, active [risingEdge=5, fallingEdge=9] -> 5/10 duty */
+      apb.write(regs.period(channel), BigInt("9", 10))
+      apb.write(regs.risingEdge(channel), BigInt("5", 10))
+      apb.write(regs.fallingEdge(channel), BigInt("9", 10))
+
+      apb.write(regs.control(channel), BigInt("1", 16))
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(2)
+
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(491)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(1)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(100)
+
+      dut.io.pwm.syncIn #= true
+      dut.clockDomain.waitSampling(1)
+      dut.io.pwm.syncIn #= false
+      dut.clockDomain.waitSampling(2)
+
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(496)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(1)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(400)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000001", 16))
+
+      dut.clockDomain.waitSampling(1)
+
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(498)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling()
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000000", 16))
+      dut.clockDomain.waitSampling(400)
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.syncOut.toBigInt == BigInt("00000001", 16))
+    }
+
+    compiled.doSim("channel0 - interrupt completed") { dut =>
+      val (apb, regs) = init(dut)
+      val channel = 0
+
+      /* Init - Set clock divider to 1 us */
+      apb.write(regs.clockDivider(channel), BigInt("99", 10))
+
+      /* Init channel 0: period=9, active [risingEdge=5, fallingEdge=9] -> 5/10 duty */
+      apb.write(regs.period(channel), BigInt("9", 10))
+      apb.write(regs.risingEdge(channel), BigInt("5", 10))
+      apb.write(regs.fallingEdge(channel), BigInt("9", 10))
+      apb.write(regs.interruptMask, BigInt("1", 16))
+      apb.write(regs.control(channel), BigInt("1", 16))
+
+      dut.clockDomain.waitSampling(2)
+
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000000", 16), "Period completed interrupt is pending")
+
+      dut.clockDomain.waitSampling(899)
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt isn't pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000001", 16), "Period completed interrupt not pending")
+      apb.write(regs.interruptPending, BigInt("1", 16))
+      dut.clockDomain.waitSampling(1)
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000000", 16), "Period completed interrupt is pending")
+
+      dut.clockDomain.waitSampling(898)
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt isn't pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000001", 16), "Period completed interrupt not pending")
+    }
+
+    compiled.doSim("channel0 - fault input") { dut =>
+      val (apb, regs) = init(dut)
+      val channel = 0
+
+      /* Init - Set clock divider to 1 us */
+      apb.write(regs.clockDivider(channel), BigInt("99", 10))
+
+      apb.write(regs.period(channel), BigInt("9", 10))
+      apb.write(regs.risingEdge(channel), BigInt("5", 10))
+      apb.write(regs.fallingEdge(channel), BigInt("9", 10))
+      apb.write(regs.errorMask, BigInt("1", 16))
+      apb.write(regs.control(channel), BigInt("1", 16))
+
+      dut.clockDomain.waitSampling(2)
+
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000001", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+      SimTest.read(apb, regs.errorPending, BigInt("00000000", 16), "Fault input error is pending")
+      dut.io.pwm.faultIn #= true
+      SimTest.read(apb, regs.errorPending, BigInt("00000001", 16), "Fault input error isn't pending")
+      assert(dut.io.pwm.output.toBigInt == BigInt("00000000", 16))
+      assert(dut.io.pwm.compOutput.toBigInt == BigInt("00000000", 16))
+    }
+
+    compiled.doSim("channel0 - config error - falling edge") { dut =>
+      val (apb, regs) = init(dut)
+      val channel = 0
+
+      /* Init - Set clock divider to 1 us */
+      apb.write(regs.clockDivider(channel), BigInt("99", 10))
+
+      apb.write(regs.errorMask, BigInt("2", 16))
+      SimTest.read(apb, regs.errorPending, BigInt("00000000", 16), "Config error pending")
+
+      /* Init channel 0: period=9, active [risingEdge=5, fallingEdge=9] -> 5/10 duty */
+      apb.write(regs.period(channel), BigInt("9", 10))
+      apb.write(regs.risingEdge(channel), BigInt("5", 10))
+      apb.write(regs.fallingEdge(channel), BigInt("9", 10))
+
+      SimTest.read(apb, regs.errorPending, BigInt("00000000", 16), "Config error pending")
+
+      apb.write(regs.period(channel), BigInt("9", 10))
+      apb.write(regs.risingEdge(channel), BigInt("5", 10))
+      apb.write(regs.fallingEdge(channel), BigInt("10", 10))
+
+      SimTest.read(apb, regs.errorPending, BigInt("00000002", 16), "Config error isn't pending")
+    }
+
   }
 }


### PR DESCRIPTION
Use a register class in the `PwmCtrl` and convert the test to use this class. Additionally, use test helper and extend by more tests to increase coverage.

Update documentation titles to match full name (ACRONYM)" style.