### PR TITLE
Update UART tests and add Pinmux

### DIFF
--- a/docs/source/hardware/peripherals/index.rst
+++ b/docs/source/hardware/peripherals/index.rst
@@ -7,6 +7,7 @@ The following list offers an overview of all available peripheral IP cores.
    :maxdepth: 1
 
    gpio.rst
+   pinmux.rst
    pio.rst
    pwm.rst
    uart.rst

--- a/docs/source/hardware/peripherals/pinmux.rst
+++ b/docs/source/hardware/peripherals/pinmux.rst
@@ -1,0 +1,189 @@
+.. _hardware-peripherals-pinmux:
+
+Pinmux
+######
+
+A Pin Multiplexer (Pinmux) routes physical IO pins to one of several peripheral
+input/output signals. Each physical pin can be connected to exactly one
+peripheral at a time, selected by a per-pin option register. This allows a
+small number of physical pins to serve many peripherals without requiring
+dedicated pads for each function.
+
+The Pinmux manages three sets of signals:
+
+- **pins** — the physical bidirectional IO pads (tri-state: write, writeEnable, read).
+- **inputs** — the full set of peripheral signals that can be routed to pins.
+  Each peripheral contributes a slice of this bus.
+- **options** — one selector value per pin, choosing which peripheral input
+  slice is currently connected to that pin.
+
+For each pin, the selected peripheral's ``write`` and ``writeEnable`` signals
+are forwarded to the pad. The pad's ``read`` signal is forwarded back to the
+selected peripheral only. Unselected peripherals see their ``read`` input held
+low.
+
+The mapping between physical pins and the subset of peripheral inputs they can
+reach is fixed at elaboration time via the ``mapping`` parameter. A pin can
+only select from the inputs listed for it in the mapping; attempting to set an
+option value that falls outside the valid range for a pin results in undefined
+behaviour (the output defaults to driven-low).
+
+Configuration
+*************
+
+Available bus architectures:
+
+- APB3
+- TileLink
+- Wishbone
+
+By default, all buses are defined with 12 bit address and 32 bit data width.
+
+Parameter
+=========
+
+``Pinmux.Parameter`` defines the physical pin interface.
+
+.. list-table:: Pinmux.Parameter
+   :widths: 25 25 25 25
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+     - Default
+   * - width
+     - Int
+     - Number of physical IO pins. Must be greater than 0 and fit in 8 bits.
+     -
+
+``PinmuxCtrl.Parameter`` configures the Pinmux controller.
+
+.. list-table:: PinmuxCtrl.Parameter
+   :widths: 25 25 25 25
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+     - Default
+   * - io
+     - Pinmux.Parameter
+     - Physical pin parameters.
+     -
+   * - inputs
+     - Int
+     - Total number of peripheral input signals across all peripherals.
+     -
+   * - options
+     - Int
+     - Number of selectable inputs per pin. Determines the width of each option
+       register. Must be greater than 0 and fit in 8 bits.
+     -
+
+The ``mapping`` argument passed to the constructor is an
+``ArrayBuffer[(Int, List[Int])]`` that associates each physical pin index with
+the list of peripheral input indices it can be connected to. The position of
+an input index in the list determines the option value that selects it.
+
+.. code-block:: scala
+
+   // 12 pins, each connectable to 2 peripheral inputs.
+   // Pin 0 → input 0 (option 0) or input 1 (option 1)
+   // Pin 1 → input 2 (option 0) or input 3 (option 1), etc.
+   val mapping = (0 until 12).map(i => (i, List(i * 2, i * 2 + 1))).to[ArrayBuffer]
+
+   Apb3Pinmux(
+     PinmuxCtrl.Parameter(Pinmux.Parameter(12), inputs = 24, options = 2),
+     mapping
+   )
+
+.. note::
+
+   ``inputs`` does not need to equal ``width × options``. It can be smaller,
+   and the same input index may appear in the mapping list of multiple pins.
+   This allows a single peripheral signal to be reachable from more than one
+   physical pin simultaneously.
+
+Register Mapping
+****************
+
+.. |ip-identification-id-value| replace:: 0xD
+.. |ip-identification-major-version| replace:: 0x1
+.. |ip-identification-minor-version| replace:: 0x0
+.. |ip-identification-patch-version| replace:: 0x0
+
+.. include:: ../ipidentification.rsti
+
+**Self Disclosure:**
+
+This block discloses the pin and option counts to software drivers.
+
+.. flat-table:: Self Disclosure Registers
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - :rspan:`2` 0x008
+     - 31 - 16
+     - Reserved
+     - 0x0
+     - Rx
+     - Reserved. Reads as zero.
+   * - 15 - 8
+     - Options
+     -
+     - Rx
+     - Number of selectable inputs per pin (``options`` parameter).
+   * - 7 - 0
+     - Width
+     -
+     - Rx
+     - Number of physical IO pins (``Pinmux.Parameter.width``).
+
+**Option Registers:**
+
+One 32-bit register per physical pin, starting at 0x010. Each register holds
+an 8-bit option selector; only the lower ``ceil(log2(options))`` bits are used
+by the hardware. The remaining bits are stored but ignored.
+
+.. flat-table:: Option Registers
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - 0x010
+     - 7 - 0
+     - Option[0]
+     - 0x0
+     - RW
+     - Selects which peripheral input is connected to pin 0. Value N connects
+       the N-th entry in the mapping list for pin 0.
+   * - 0x014
+     - 7 - 0
+     - Option[1]
+     - 0x0
+     - RW
+     - Selects which peripheral input is connected to pin 1.
+   * - ...
+     -
+     -
+     -
+     -
+     -
+   * - 0x010 + pin × 0x4
+     - 7 - 0
+     - Option[pin]
+     - 0x0
+     - RW
+     - Selects which peripheral input is connected to the given pin.

--- a/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.scala
+++ b/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.scala
@@ -14,6 +14,26 @@ import nafarr.library.ClockDivider
 object UartCtrl {
   def apply(p: Parameter = Parameter.default) = UartCtrl(p)
 
+  object Regs {
+    def apply(base: BigInt) = new Regs(base)
+  }
+
+  class Regs(base: BigInt) {
+    val dataWidth = base + 0x00
+    val samplingSize = base + 0x04
+    val fifoDepth = base + 0x08
+    val permissions = base + 0x0c
+    val readWrite = base + 0x10
+    val fifoStatus = base + 0x14
+    val clockDivider = base + 0x18
+    val frameConfig = base + 0x1c
+    val transmitTrigger = base + 0x20
+    val interruptPending = base + 0x24
+    val interruptEnable = base + 0x28
+    val errorPending = base + 0x2c
+    val errorEnable = base + 0x30
+  }
+
   case class InitParameter(
       baudrate: Int = 0,
       dataLength: Int = 0,
@@ -175,37 +195,36 @@ object UartCtrl {
   ) extends Area {
     val idCtrl = IpIdentification(IpIdentification.Ids.Uart, 1, 1, 0)
     idCtrl.driveFrom(busCtrl)
-    val staticOffset = idCtrl.length
+    val regs = Regs(idCtrl.length)
 
     busCtrl.read(
       B(0, 8 bits) ## B(p.dataWidthMin, 8 bits) ## B(p.dataWidthMax, 8 bits) ##
         B(p.clockDividerWidth, 8 bits),
-      staticOffset
+      regs.dataWidth
     )
 
     busCtrl.read(
       B(0, 8 bits) ## B(p.preSamplingSize, 8 bits) ## B(p.samplingSize, 8 bits) ##
         B(p.postSamplingSize, 8 bits),
-      staticOffset + 0x4
+      regs.samplingSize
     )
 
     busCtrl.read(
       B(0, 16 bits) ## B(p.memory.txFifoDepth, 8 bits) ## B(p.memory.rxFifoDepth, 8 bits),
-      staticOffset + 0x8
+      regs.fifoDepth
     )
 
     val permissionBits =
       Bool(p.permission.busCanWriteFrameConfig) ## Bool(p.permission.busCanWriteClockDividerConfig)
-    busCtrl.read(B(0, 32 - permissionBits.getWidth bits) ## permissionBits, staticOffset + 0xc)
-    val regOffset = staticOffset + 0x10
+    busCtrl.read(B(0, 32 - permissionBits.getWidth bits) ## permissionBits, regs.permissions)
 
     val tx = new Area {
       val streamUnbuffered =
-        busCtrl.createAndDriveFlow(Bits(p.dataWidthMax bits), address = regOffset + 0x00).toStream
+        busCtrl.createAndDriveFlow(Bits(p.dataWidthMax bits), address = regs.readWrite).toStream
       val (stream, fifoOccupancy) =
         streamUnbuffered.queueWithOccupancy(p.memory.txFifoDepth)
       val fifoVacancy = p.memory.txFifoDepth - fifoOccupancy
-      busCtrl.read(fifoVacancy, address = regOffset + 0x04, bitOffset = 16)
+      busCtrl.read(fifoVacancy, address = regs.fifoStatus, bitOffset = 16)
       ctrl.write << stream
       streamUnbuffered.ready.allowPruning()
     }
@@ -216,11 +235,11 @@ object UartCtrl {
       ctrl.readIsFull := fifoOccupancy >= p.memory.rxFifoDepth - 1
       busCtrl.readStreamNonBlocking(
         stream,
-        address = regOffset + 0x0,
+        address = regs.readWrite,
         validBitOffset = 16,
         payloadBitOffset = 0
       )
-      busCtrl.read(fifoOccupancy, address = regOffset + 0x04, bitOffset = 24)
+      busCtrl.read(fifoOccupancy, address = regs.fifoStatus, bitOffset = 24)
     }
 
     val config = new Area {
@@ -229,11 +248,11 @@ object UartCtrl {
       if (p.init != null && p.init.baudrate != 0)
         cfg.clockDivider.init(p.getClockDivider(p.init.baudrate))
       if (p.permission != null && p.permission.busCanWriteClockDividerConfig)
-        busCtrl.write(cfg.clockDivider, address = regOffset + 0x08)
-      busCtrl.read(cfg.clockDivider, regOffset + 0x08)
+        busCtrl.write(cfg.clockDivider, address = regs.clockDivider)
+      busCtrl.read(cfg.clockDivider, regs.clockDivider)
 
       cfg.clockDividerReload := False
-      busCtrl.onWrite(regOffset + 0x08) {
+      busCtrl.onWrite(regs.clockDivider) {
         cfg.clockDividerReload := True
       }
 
@@ -247,13 +266,13 @@ object UartCtrl {
         frameCfg.stop.init(p.init.stop)
 
       if (p.permission != null && p.permission.busCanWriteFrameConfig) {
-        busCtrl.write(frameCfg.dataLength, address = regOffset + 0x0c, bitOffset = 0)
-        busCtrl.write(frameCfg.parity, address = regOffset + 0x0c, bitOffset = 8)
-        busCtrl.write(frameCfg.stop, address = regOffset + 0x0c, bitOffset = 16)
+        busCtrl.write(frameCfg.dataLength, address = regs.frameConfig, bitOffset = 0)
+        busCtrl.write(frameCfg.parity, address = regs.frameConfig, bitOffset = 8)
+        busCtrl.write(frameCfg.stop, address = regs.frameConfig, bitOffset = 16)
       }
-      busCtrl.read(frameCfg.dataLength, address = regOffset + 0x0c, bitOffset = 0)
-      busCtrl.read(frameCfg.parity, address = regOffset + 0x0c, bitOffset = 8)
-      busCtrl.read(frameCfg.stop, address = regOffset + 0x0c, bitOffset = 16)
+      busCtrl.read(frameCfg.dataLength, address = regs.frameConfig, bitOffset = 0)
+      busCtrl.read(frameCfg.parity, address = regs.frameConfig, bitOffset = 8)
+      busCtrl.read(frameCfg.stop, address = regs.frameConfig, bitOffset = 16)
 
       ctrl.config <> cfg
       ctrl.frameConfig <> frameCfg
@@ -263,12 +282,12 @@ object UartCtrl {
       if (p.interrupt) {
         val txOccupancyTrigger = Reg(cloneOf(tx.fifoOccupancy))
         val txPreviousOccupancy = RegNext(tx.fifoOccupancy)
-        busCtrl.readAndWrite(txOccupancyTrigger, regOffset + 0x10)
+        busCtrl.readAndWrite(txOccupancyTrigger, regs.transmitTrigger)
         val txTrigger =
           tx.fifoOccupancy === txOccupancyTrigger && txPreviousOccupancy === (txOccupancyTrigger + 1)
 
         val irqCtrl = new InterruptCtrl(3)
-        irqCtrl.driveFrom(busCtrl, regOffset + 0x14)
+        irqCtrl.driveFrom(busCtrl, regs.interruptPending.toInt)
         irqCtrl.io.inputs(0) := txTrigger
         irqCtrl.io.inputs(1) := ctrl.read.valid
         irqCtrl.io.inputs(2) := ctrl.txIdle.rise(initAt = True)
@@ -281,7 +300,7 @@ object UartCtrl {
     val error = new Area {
       if (p.error) {
         val errorCtrl = new InterruptCtrl(3)
-        errorCtrl.driveFrom(busCtrl, regOffset + 0x1c)
+        errorCtrl.driveFrom(busCtrl, regs.errorPending.toInt)
         errorCtrl.io.inputs(0) := ctrl.framingError
         errorCtrl.io.inputs(1) := ctrl.parityError
         errorCtrl.io.inputs(2) := ctrl.readIsFull && ctrl.read.valid

--- a/hardware/scala/nafarr/peripherals/pinmux/PinmuxCtrl.scala
+++ b/hardware/scala/nafarr/peripherals/pinmux/PinmuxCtrl.scala
@@ -17,6 +17,16 @@ import scala.collection.mutable.ArrayBuffer
 object PinmuxCtrl {
   def apply(p: Parameter, mapping: ArrayBuffer[(Int, List[Int])]) = PinmuxCtrl(p, mapping)
 
+  object Regs {
+    def apply(base: BigInt) = new Regs(base)
+  }
+
+  class Regs(base: BigInt) {
+    val info = base + 0x00
+    private def optionBase(pin: Int): BigInt = base + 0x04 + pin * 0x04
+    def option(pin: Int) = optionBase(pin) + 0x04
+  }
+
   case class Parameter(io: Pinmux.Parameter, inputs: Int, options: Int) {
     require(io.width <= 255, "Pin width must fit in 8 bits for the width register.")
   }
@@ -32,23 +42,43 @@ object PinmuxCtrl {
   case class PinmuxCtrl(p: Parameter, mapping: ArrayBuffer[(Int, List[Int])]) extends Component {
     val io = Io(p)
 
-    for (index <- 0 until p.inputs) {
-      io.inputs(index).read := False
-    }
+    // Intermediate Vecs to collect combinatorial outputs with safe defaults.
+    // Working directly on Bits avoids TriStateArray.apply(i) which creates a
+    // new TriState bundle each call — whose undriven `read` field causes latches.
+    val pinsWrite       = Vec(Bool(), p.io.width)
+    val pinsWriteEnable = Vec(Bool(), p.io.width)
+    val inputsRead      = Vec(Bool(), p.inputs)
 
-    for ((pin, inputs) <- mapping) {
-      val option = io
-        .options(pin)
-        .muxList(for (index <- 0 until inputs.size) yield (index, io.inputs(inputs(index))))
-      io.pins(pin).write := option.write
-      io.pins(pin).writeEnable := option.writeEnable
+    // inputsRead defaults to False; when() overrides are conditional so no overlap.
+    inputsRead.foreach(_ := False)
 
-      for ((input, index) <- inputs.zipWithIndex) {
-        when(io.options(pin) === U(index)) {
-          io.inputs(input).read := io.pins(pin).read
-        }
+    // Assign each pin exactly once to avoid ASSIGNMENT OVERLAP.
+    // Use when() instead of muxList(): muxList() generates a switch that only
+    // covers option indices 0..N-1, but io.options(pin) is log2Up(options) bits
+    // wide, so uncovered values (e.g. value 3 for options=3) leave the muxList
+    // result undriven → latch.  The unconditional default below covers all gaps.
+    val mappingMap = mapping.toMap
+    for (pin <- 0 until p.io.width) {
+      mappingMap.get(pin) match {
+        case Some(inputs) =>
+          pinsWrite(pin)       := False
+          pinsWriteEnable(pin) := False
+          for ((inputIdx, optionIdx) <- inputs.zipWithIndex) {
+            when(io.options(pin) === U(optionIdx)) {
+              pinsWrite(pin)       := io.inputs.write(inputIdx)
+              pinsWriteEnable(pin) := io.inputs.writeEnable(inputIdx)
+              inputsRead(inputIdx) := io.pins.read(pin)
+            }
+          }
+        case None =>
+          pinsWrite(pin)       := False
+          pinsWriteEnable(pin) := False
       }
     }
+
+    io.pins.write       := pinsWrite.asBits
+    io.pins.writeEnable := pinsWriteEnable.asBits
+    io.inputs.read      := inputsRead.asBits
   }
 
   case class Mapper(
@@ -58,15 +88,13 @@ object PinmuxCtrl {
   ) extends Area {
     val idCtrl = IpIdentification(IpIdentification.Ids.Pinmux, 1, 0, 0)
     idCtrl.driveFrom(busCtrl)
-    val staticOffset = idCtrl.length
+    val regs = Regs(idCtrl.length)
 
-    busCtrl.read(B(0, 24 bits) ## B(p.io.width, 8 bits), staticOffset)
-    val regOffset = idCtrl.length + 0x4
+    busCtrl.read(B(0, 16 bits) ## B(p.options, 8 bits) ## B(p.io.width, 8 bits), regs.info)
 
     for (pin <- 0 until p.io.width) {
       val option = Reg(UInt(8 bits)).init(U(0))
-      val muxAddress = pin * 4
-      busCtrl.readAndWrite(option, muxAddress + regOffset)
+      busCtrl.readAndWrite(option, regs.option(pin))
       ctrl.options(pin) := option(0, log2Up(p.options) bits)
     }
   }

--- a/test/scala/nafarr/peripherals/com/uart/UartTest.scala
+++ b/test/scala/nafarr/peripherals/com/uart/UartTest.scala
@@ -11,8 +11,13 @@ import spinal.core._
 import spinal.core.sim._
 import nafarr.CheckTester._
 import spinal.lib._
+import spinal.lib.bus.amba3.apb.{Apb3, Apb3Config}
 import spinal.lib.bus.amba3.apb.sim.Apb3Driver
 
+import nafarr.CheckTester._
+import nafarr.IpIdentification
+import nafarr.IpIdentificationTest
+import nafarr.SimTest
 
 class UartTest extends AnyFunSuite {
   def genCore[T <: spinal.core.Data with IMasterSlave](
@@ -101,260 +106,339 @@ class UartTest extends AnyFunSuite {
     }
   }
 
+  def init(dut: Uart.Core[Apb3]): (Apb3Driver, UartCtrl.Regs) = {
+    dut.clockDomain.forkStimulus(10 * 1000)
+    fork {
+      dut.clockDomain.fallingEdge()
+      sleep(10 * 1000)
+      while (true) {
+        dut.clockDomain.clockToggle()
+        sleep(5 * 1000)
+      }
+    }
+
+    val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
+    val regs = UartCtrl.Regs(dut.mapper.idCtrl.length)
+
+    /* Init */
+    dut.io.uart.rxd #= true
+    dut.io.uart.cts #= false
+
+    /* Wait for reset and check initialized state */
+    dut.clockDomain.waitSampling(2)
+    dut.clockDomain.waitFallingEdge()
+
+    return (apb, regs)
+  }
+
+
   test("basic") {
     val compiled = SimConfig.withWave.compile(genCore(UartCtrl.Parameter.default, Apb3Uart(_)))
 
     compiled.doSim("basicRegisters") { dut =>
-      dut.clockDomain.forkStimulus(10)
-      fork {
-        dut.clockDomain.fallingEdge()
-        sleep(10)
-        while (true) {
-          dut.clockDomain.clockToggle()
-          sleep(5)
-        }
-      }
-
-      val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
-      val staticOffset = dut.mapper.staticOffset
-      val regOffset = dut.mapper.regOffset
-
-      /* Wait for reset and check initialized state */
-      dut.clockDomain.waitSampling(2)
-      dut.clockDomain.waitFallingEdge()
+      val (apb, regs) = init(dut)
 
       /* Check IP identification */
-      assert(
-        apb.read(BigInt(0)) == BigInt("00080003", 16),
-        "IP Identification 0x0 should return 00080001 - API: 0, Length: 8, ID: 3"
-      )
-      assert(
-        apb.read(BigInt(4)) == BigInt("01010000", 16),
-        "IP Identification 0x4 should return 01010000 - 1.1.0"
-      )
+      IpIdentificationTest.V0.checkApi(apb, IpIdentification.Ids.Uart)
+      IpIdentificationTest.V0.checkVersion(apb, 1, 1, 0)
 
       /* Read dataWidthMin, dataWidthMax, clockDividerWidth */
-      assert(
-        apb.read(BigInt(staticOffset)) == BigInt("00050914", 16),
-        "Unable to read 00050914 from UART data/clockDivider width declaration"
-      )
+      SimTest.readField(apb, regs.dataWidth, 23, 16, 5, "UART minimal data width")
+      SimTest.readField(apb, regs.dataWidth, 15, 8, 9, "UART maximal data width")
+      SimTest.readField(apb, regs.dataWidth, 7, 0, 20, "UART clock divider width")
 
       /* Read preSamplingSize, samplingSize, postSamplingSize */
-      assert(
-        apb.read(BigInt(staticOffset + 4)) == BigInt("00010502", 16),
-        "Unable to read 00010502 from UART sampling size declaration"
-      )
+      SimTest.readField(apb, regs.samplingSize, 23, 16, 1, "UART pre-sampling size")
+      SimTest.readField(apb, regs.samplingSize, 15, 8, 5, "UART sampling size")
+      SimTest.readField(apb, regs.samplingSize, 7, 0, 2, "UART post-sampling size")
 
       /* Read rx/tx FIFO depth */
-      assert(
-        apb.read(BigInt(staticOffset + 8)) == BigInt("00001010", 16),
-        "Unable to read 00001010 from UART FIFO depth declaration"
-      )
+      SimTest.readField(apb, regs.fifoDepth, 15, 8, 16, "UART TX FIFO depth")
+      SimTest.readField(apb, regs.fifoDepth, 7, 0, 16, "UART RX FIFO depth")
 
       /* Read permissions */
-      assert(
-        apb.read(BigInt(staticOffset + 12)) == BigInt("00000003", 16),
-        "Unable to read 00000003 from UART permission declaration"
-      )
+      SimTest.readField(apb, regs.permissions, 1, 1, 1, "UART permissions - frame config")
+      SimTest.readField(apb, regs.permissions, 0, 0, 1, "UART permissions - clock divider")
 
       /* Read FIFO status */
-      assert(
-        apb.read(BigInt(regOffset + 4)) == BigInt("00100000", 16),
-        "Unable to read 00100000 from UART FIFO status"
-      )
+      SimTest.readField(apb, regs.fifoStatus, 31, 24, 0, "UART RX occupancy")
+      SimTest.readField(apb, regs.fifoStatus, 23, 16, 16, "UART TX vacany")
     }
 
     compiled.doSim("testIO") { dut =>
-      dut.clockDomain.forkStimulus(10 * 1000)
-      fork {
-        dut.clockDomain.fallingEdge()
-        sleep(10 * 1000)
-        while (true) {
-          dut.clockDomain.clockToggle()
-          sleep(5 * 1000)
-        }
-      }
-
-      val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
-      val staticOffset = dut.mapper.staticOffset
-      val regOffset = dut.mapper.regOffset
-
-      dut.io.uart.rxd #= true
-      dut.io.uart.cts #= false
-
-      /* Wait for reset and check initialized state */
-      dut.clockDomain.waitSampling(2 * 1000)
-      dut.clockDomain.waitFallingEdge()
+      val (apb, regs) = init(dut)
 
       /* Init IP-Core */
-      apb.write(BigInt(regOffset + 8), BigInt("0000006B", 16))
-      apb.write(BigInt(regOffset + 12), BigInt("00000007", 16))
+      apb.write(regs.clockDivider, BigInt("0000006B", 16))
+      apb.write(regs.frameConfig, BigInt("00000007", 16))
 
       val receive = UartEncoder(dut.io.uart.rxd, 8640, BigInt("47", 16))
       receive.join()
-      assert(
-        apb.read(BigInt(regOffset + 0)) == BigInt("00010047", 16),
-        "Didn't received 0x47/'G'"
-      )
+      SimTest.read(apb, regs.readWrite, BigInt("00010047", 16), "Didn't received 0x47/'G'")
 
       /* Transmit 'G' */
-      apb.write(BigInt(regOffset + 0), BigInt("00000047", 16))
+      apb.write(regs.readWrite, BigInt("00000047", 16))
       val transmit = UartDecoder(dut.io.uart.txd, 8640, BigInt("47", 16))
       transmit.join()
-    }
-
-    compiled.doSim("testIRQ-RX") { dut =>
-      dut.clockDomain.forkStimulus(10 * 1000)
-      fork {
-        dut.clockDomain.fallingEdge()
-        sleep(10 * 1000)
-        while (true) {
-          dut.clockDomain.clockToggle()
-          sleep(5 * 1000)
-        }
-      }
-
-      val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
-      val staticOffset = dut.mapper.staticOffset
-      val regOffset = dut.mapper.regOffset
-
-      dut.io.uart.rxd #= true
-      dut.io.uart.cts #= false
-
-      /* Wait for reset and check initialized state */
-      dut.clockDomain.waitSampling(2 * 1000)
-      dut.clockDomain.waitFallingEdge()
-
-      /* Init IP-Core */
-      apb.write(BigInt(regOffset + 8), BigInt("0000006B", 16))
-      apb.write(BigInt(regOffset + 12), BigInt("00000007", 16))
-
-      apb.write(BigInt(regOffset + 20), BigInt("00000002", 16))
-      apb.write(BigInt(regOffset + 24), BigInt("00000002", 16))
-
-      val receive = UartEncoder(dut.io.uart.rxd, 8640, BigInt("47", 16))
-      receive.join()
-      assert(
-        apb.read(BigInt(regOffset + 0)) == BigInt("00010047", 16),
-        "Doesn't received 0x47/'G'"
-      )
-      assert(
-        apb.read(BigInt(regOffset + 20)) == BigInt("00000002", 16),
-        "RX interrupt isn't pending"
-      )
-      assert(dut.io.interrupt.toBoolean == true, "UART interrupt isn't pending")
-      apb.write(BigInt(regOffset + 24), BigInt("00000000", 16))
-      apb.write(BigInt(regOffset + 20), BigInt("00000002", 16))
-      apb.write(BigInt(regOffset + 24), BigInt("00000002", 16))
-      assert(dut.io.interrupt.toBoolean == false, "UART interrupt isn't pending")
     }
 
     compiled.doSim("testIRQ-TX") { dut =>
-      dut.clockDomain.forkStimulus(10 * 1000)
-      fork {
-        dut.clockDomain.fallingEdge()
-        sleep(10 * 1000)
-        while (true) {
-          dut.clockDomain.clockToggle()
-          sleep(5 * 1000)
-        }
-      }
-
-      val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
-      val staticOffset = dut.mapper.staticOffset
-      val regOffset = dut.mapper.regOffset
-
-      dut.io.uart.rxd #= true
-      dut.io.uart.cts #= false
-
-      /* Wait for reset and check initialized state */
-      dut.clockDomain.waitSampling(2 * 1000)
-      dut.clockDomain.waitFallingEdge()
+      val (apb, regs) = init(dut)
 
       /* Init IP-Core */
-      apb.write(BigInt(regOffset + 8), BigInt("0000006B", 16))
-      apb.write(BigInt(regOffset + 12), BigInt("00000007", 16))
+      apb.write(regs.clockDivider, BigInt("0000006B", 16))
+      apb.write(regs.frameConfig, BigInt("00000007", 16))
 
-      apb.write(BigInt(regOffset + 20), BigInt("00000001", 16))
-      apb.write(BigInt(regOffset + 24), BigInt("00000001", 16))
+      apb.write(regs.interruptPending, BigInt("00000001", 16))
+      apb.write(regs.interruptEnable, BigInt("00000001", 16))
 
-      apb.write(BigInt(regOffset + 16), BigInt("00000002", 16))
+      apb.write(regs.transmitTrigger, BigInt("00000002", 16))
 
-      assert(
-        apb.read(BigInt(regOffset + 20)) == BigInt("00000000", 16),
-        "RX interrupt is pending"
-      )
-      assert(dut.io.interrupt.toBoolean == false, "UART interrupt is pending")
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt is pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000000", 16), "RX interrupt is pending")
 
-      apb.write(BigInt(regOffset + 0), BigInt("00000047", 16))
-      apb.write(BigInt(regOffset + 0), BigInt("00000047", 16))
-      apb.write(BigInt(regOffset + 0), BigInt("00000047", 16))
-      apb.write(BigInt(regOffset + 0), BigInt("00000047", 16))
+      apb.write(regs.readWrite, BigInt("00000047", 16))
+      apb.write(regs.readWrite, BigInt("00000047", 16))
+      apb.write(regs.readWrite, BigInt("00000047", 16))
+      apb.write(regs.readWrite, BigInt("00000047", 16))
 
-      assert(
-        apb.read(BigInt(regOffset + 20)) == BigInt("00000000", 16),
-        "RX interrupt is pending"
-      )
-      assert(dut.io.interrupt.toBoolean == false, "UART interrupt is pending")
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt is pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000000", 16), "RX interrupt is pending")
+
       val transmit = UartDecoder(dut.io.uart.txd, 8640, BigInt("47", 16))
       transmit.join()
 
-      assert(
-        apb.read(BigInt(regOffset + 20)) == BigInt("00000000", 16),
-        "RX interrupt is pending"
-      )
-      assert(dut.io.interrupt.toBoolean == false, "UART interrupt is pending")
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt is pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000000", 16), "RX interrupt is pending")
+
       val transmit2 = UartDecoder(dut.io.uart.txd, 8640, BigInt("47", 16))
       transmit2.join()
 
-      assert(
-        apb.read(BigInt(regOffset + 20)) == BigInt("00000001", 16),
-        "RX interrupt isn't pending"
-      )
-      assert(dut.io.interrupt.toBoolean == true, "UART interrupt isn't pending")
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt isn't pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000001", 16), "RX interrupt isn't pending")
+
       val transmit3 = UartDecoder(dut.io.uart.txd, 8640, BigInt("47", 16))
       transmit3.join()
 
-      assert(
-        apb.read(BigInt(regOffset + 20)) == BigInt("00000001", 16),
-        "RX interrupt isn't pending"
-      )
-      assert(dut.io.interrupt.toBoolean == true, "UART interrupt isn't pending")
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt isn't pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000001", 16), "RX interrupt isn't pending")
+
       val transmit4 = UartDecoder(dut.io.uart.txd, 8640, BigInt("47", 16))
       transmit4.join()
 
-      apb.write(BigInt(regOffset + 24), BigInt("00000000", 16))
-      apb.write(BigInt(regOffset + 20), BigInt("00000001", 16))
-      apb.write(BigInt(regOffset + 24), BigInt("00000001", 16))
-      assert(dut.io.interrupt.toBoolean == false, "UART interrupt is pending")
+      apb.write(regs.interruptEnable, BigInt("00000000", 16))
+      apb.write(regs.interruptPending, BigInt("00000001", 16))
+      apb.write(regs.interruptEnable, BigInt("00000001", 16))
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt is pending")
 
+      apb.write(regs.readWrite, BigInt("00000047", 16))
+      apb.write(regs.readWrite, BigInt("00000047", 16))
+      apb.write(regs.readWrite, BigInt("00000047", 16))
+      apb.write(regs.readWrite, BigInt("00000047", 16))
 
-      apb.write(BigInt(regOffset + 0), BigInt("00000047", 16))
-      apb.write(BigInt(regOffset + 0), BigInt("00000047", 16))
-      apb.write(BigInt(regOffset + 0), BigInt("00000047", 16))
-      apb.write(BigInt(regOffset + 0), BigInt("00000047", 16))
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt is pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000000", 16), "RX interrupt is pending")
 
-      assert(
-        apb.read(BigInt(regOffset + 20)) == BigInt("00000000", 16),
-        "RX interrupt is pending"
-      )
-      assert(dut.io.interrupt.toBoolean == false, "UART interrupt is pending")
       val transmit5 = UartDecoder(dut.io.uart.txd, 8640, BigInt("47", 16))
       transmit5.join()
 
-      assert(
-        apb.read(BigInt(regOffset + 20)) == BigInt("00000000", 16),
-        "RX interrupt is pending"
-      )
-      assert(dut.io.interrupt.toBoolean == false, "UART interrupt is pending")
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt is pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000000", 16), "RX interrupt is pending")
+
       val transmit6 = UartDecoder(dut.io.uart.txd, 8640, BigInt("47", 16))
       transmit6.join()
 
-      assert(
-        apb.read(BigInt(regOffset + 20)) == BigInt("00000001", 16),
-        "RX interrupt isn't pending"
-      )
-      assert(dut.io.interrupt.toBoolean == true, "UART interrupt isn't pending")
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt isn't pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000001", 16), "RX interrupt isn't pending")
     }
+
+    compiled.doSim("testIRQ-RX") { dut =>
+      val (apb, regs) = init(dut)
+
+      /* Init IP-Core */
+      apb.write(regs.clockDivider, BigInt("0000006B", 16))
+      apb.write(regs.frameConfig, BigInt("00000007", 16))
+
+      apb.write(regs.interruptPending, BigInt("00000002", 16))
+      apb.write(regs.interruptEnable, BigInt("00000002", 16))
+
+      val receive = UartEncoder(dut.io.uart.rxd, 8640, BigInt("47", 16))
+      receive.join()
+      SimTest.read(apb, regs.readWrite, BigInt("00010047", 16), "Didn't received 0x47/'G'")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000002", 16), "RX interrupt isn't pending")
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt isn't pending")
+      apb.write(regs.interruptEnable, BigInt("00000000", 16))
+      apb.write(regs.interruptPending, BigInt("00000002", 16))
+      apb.write(regs.interruptEnable, BigInt("00000002", 16))
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt isn't pending")
+    }
+
+    compiled.doSim("testIRQ-TX Idle") { dut =>
+      val (apb, regs) = init(dut)
+
+      /* Init IP-Core */
+      apb.write(regs.clockDivider, BigInt("0000006B", 16))
+      apb.write(regs.frameConfig, BigInt("00000007", 16))
+
+      apb.write(regs.interruptPending, BigInt("00000004", 16))
+      apb.write(regs.interruptEnable, BigInt("00000004", 16))
+
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt is pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000000", 16), "TX idle interrupt is pending")
+
+      apb.write(regs.readWrite, BigInt("00000047", 16))
+      apb.write(regs.readWrite, BigInt("00000047", 16))
+
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt is pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000000", 16), "TX idle interrupt is pending")
+
+      val transmit = UartDecoder(dut.io.uart.txd, 8640, BigInt("47", 16))
+      transmit.join()
+
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt is pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000000", 16), "TX idle interrupt is pending")
+
+      val transmit2 = UartDecoder(dut.io.uart.txd, 8640, BigInt("47", 16))
+      transmit2.join()
+
+      dut.clockDomain.waitSampling(1000)
+
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt isn't pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000004", 16), "TX idle interrupt isn't pending")
+
+      apb.write(regs.interruptEnable, BigInt("00000000", 16))
+      apb.write(regs.interruptPending, BigInt("00000004", 16))
+      apb.write(regs.interruptEnable, BigInt("00000004", 16))
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt is pending")
+
+      apb.write(regs.readWrite, BigInt("00000047", 16))
+      apb.write(regs.readWrite, BigInt("00000047", 16))
+
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt is pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000000", 16), "TX idle interrupt is pending")
+
+      val transmit3 = UartDecoder(dut.io.uart.txd, 8640, BigInt("47", 16))
+      transmit3.join()
+
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 0, f"Interrupt is pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000000", 16), "TX idle interrupt is pending")
+
+      val transmit4 = UartDecoder(dut.io.uart.txd, 8640, BigInt("47", 16))
+      transmit4.join()
+
+      dut.clockDomain.waitSampling(1000)
+
+      SimTest.checkPins(dut.io.interrupt.toBigInt, 1, f"Interrupt isn't pending")
+      SimTest.read(apb, regs.interruptPending, BigInt("00000004", 16), "TX idle interrupt isn't pending")
+    }
+
+    compiled.doSim("test error - frame") { dut =>
+      val (apb, regs) = init(dut)
+
+      /* Init IP-Core */
+      apb.write(regs.clockDivider, BigInt("0000006B", 16))
+      apb.write(regs.frameConfig, BigInt("00000107", 16))
+
+      apb.write(regs.errorPending, BigInt("00000001", 16))
+      apb.write(regs.errorEnable, BigInt("00000001", 16))
+
+      SimTest.read(apb, regs.errorPending, BigInt("00000000", 16), "Framing error detected")
+
+      val receive = UartEncoder(dut.io.uart.rxd, 8640, BigInt("047", 16))
+      receive.join()
+      val receive2 = UartEncoder(dut.io.uart.rxd, 8640, BigInt("047", 16))
+      receive2.join()
+
+      SimTest.read(apb, regs.errorPending, BigInt("00000001", 16), "No framing error detected")
+
+      apb.write(regs.errorEnable, BigInt("00000000", 16))
+      apb.write(regs.errorPending, BigInt("00000001", 16))
+      apb.write(regs.errorEnable, BigInt("00000001", 16))
+      SimTest.read(apb, regs.errorPending, BigInt("00000000", 16), "Parity error detected")
+
+      val receive3 = UartEncoder(dut.io.uart.rxd, 8640, BigInt("047", 16))
+      receive3.join()
+      val receive4 = UartEncoder(dut.io.uart.rxd, 8640, BigInt("047", 16))
+      receive4.join()
+
+      SimTest.read(apb, regs.errorPending, BigInt("00000001", 16), "No parity error detected")
+    }
+
+    compiled.doSim("test error - parity") { dut =>
+      val (apb, regs) = init(dut)
+
+      /* Init IP-Core */
+      apb.write(regs.clockDivider, BigInt("0000006B", 16))
+      apb.write(regs.frameConfig, BigInt("00000107", 16))
+
+      apb.write(regs.errorPending, BigInt("00000002", 16))
+      apb.write(regs.errorEnable, BigInt("00000002", 16))
+
+      SimTest.read(apb, regs.errorPending, BigInt("00000000", 16), "Parity error detected")
+
+      val receive = UartEncoder(dut.io.uart.rxd, 8640, BigInt("047", 16))
+      receive.join()
+
+      dut.clockDomain.waitSampling(100)
+
+      SimTest.read(apb, regs.errorPending, BigInt("00000002", 16), "No parity error detected")
+
+      apb.write(regs.errorEnable, BigInt("00000000", 16))
+      apb.write(regs.errorPending, BigInt("00000002", 16))
+      apb.write(regs.errorEnable, BigInt("00000002", 16))
+      SimTest.read(apb, regs.errorPending, BigInt("00000000", 16), "Parity error detected")
+
+      val receive2 = UartEncoder(dut.io.uart.rxd, 8640, BigInt("047", 16))
+      receive2.join()
+
+      dut.clockDomain.waitSampling(100)
+
+      SimTest.read(apb, regs.errorPending, BigInt("00000002", 16), "No parity error detected")
+    }
+
+    compiled.doSim("test error - RX FIFO full") { dut =>
+      val (apb, regs) = init(dut)
+
+      /* Init IP-Core */
+      apb.write(regs.clockDivider, BigInt("0000006B", 16))
+      apb.write(regs.frameConfig, BigInt("00000007", 16))
+
+      apb.write(regs.errorPending, BigInt("00000004", 16))
+      apb.write(regs.errorEnable, BigInt("00000004", 16))
+
+      SimTest.read(apb, regs.errorPending, BigInt("00000000", 16), "RX FIFO is full")
+
+      for (_ <- 0 until dut.ctrl.p.memory.rxFifoDepth - 1) {
+        val receive = UartEncoder(dut.io.uart.rxd, 8640, BigInt("47", 16))
+        receive.join()
+        SimTest.read(apb, regs.errorPending, BigInt("00000000", 16), "RX FIFO is full")
+      }
+
+      val receive2 = UartEncoder(dut.io.uart.rxd, 8640, BigInt("47", 16))
+      receive2.join()
+      dut.clockDomain.waitSampling(100)
+      SimTest.read(apb, regs.errorPending, BigInt("00000004", 16), "RX FIFO isn't full")
+
+      for (_ <- 0 until dut.ctrl.p.memory.rxFifoDepth) {
+        SimTest.read(apb, regs.readWrite, BigInt("00010047", 16), "Didn't received 0x47/'G'")
+      }
+
+      apb.write(regs.errorEnable, BigInt("00000000", 16))
+      apb.write(regs.errorPending, BigInt("00000004", 16))
+      apb.write(regs.errorEnable, BigInt("00000004", 16))
+      SimTest.read(apb, regs.errorPending, BigInt("00000000", 16), "RX FIFO is full")
+
+      for (_ <- 0 until dut.ctrl.p.memory.rxFifoDepth - 1) {
+        val receive3 = UartEncoder(dut.io.uart.rxd, 8640, BigInt("47", 16))
+        receive3.join()
+        SimTest.read(apb, regs.errorPending, BigInt("00000000", 16), "RX FIFO is full")
+      }
+
+      val receive4 = UartEncoder(dut.io.uart.rxd, 8640, BigInt("47", 16))
+      receive4.join()
+      dut.clockDomain.waitSampling(100)
+      SimTest.read(apb, regs.errorPending, BigInt("00000004", 16), "RX FIFO isn't full")
+    }
+
   }
 }

--- a/test/scala/nafarr/peripherals/pinmux/PinmuxTest.scala
+++ b/test/scala/nafarr/peripherals/pinmux/PinmuxTest.scala
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.peripherals.pinmux
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import spinal.sim._
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib.bus.amba3.apb.sim.Apb3Driver
+
+import nafarr.CheckTester._
+import nafarr.IpIdentification
+import nafarr.IpIdentificationTest
+import nafarr.SimTest
+
+import scala.collection.mutable.ArrayBuffer
+
+class PinmuxTest extends AnyFunSuite {
+  test("Apb3GpioParameters") {
+    generationShouldPass(Apb3Pinmux(
+      PinmuxCtrl.Parameter(Pinmux.Parameter(12), 24, 2),
+      (0 until 12).map(i => (i, List(i * 2, i * 2 + 1))).to[ArrayBuffer]
+    ))
+
+    generationShouldPass(Apb3Pinmux(
+      PinmuxCtrl.Parameter(Pinmux.Parameter(12), 36, 3),
+      (0 until 12).map(i => (i, List(i * 3, i * 3 + 1, i * 3 + 2))).to[ArrayBuffer]
+    ))
+
+    generationShouldPass(Apb3Pinmux(
+      PinmuxCtrl.Parameter(Pinmux.Parameter(12), 48, 4),
+      (0 until 12).map(i => (i, List(i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3))).to[ArrayBuffer]
+    ))
+
+    generationShouldPass(Apb3Pinmux(
+      PinmuxCtrl.Parameter(Pinmux.Parameter(255), 510, 2),
+      (0 until 255).map(i => (i, List(i * 2, i * 2 + 1))).to[ArrayBuffer]
+    ))
+    generationShouldFail(Apb3Pinmux(
+      PinmuxCtrl.Parameter(Pinmux.Parameter(256), 512, 2),
+      (0 until 256).map(i => (i, List(i * 2, i * 2 + 1))).to[ArrayBuffer]
+    ))
+  }
+
+  test("TileLinkGpioParameters") {
+    generationShouldPass(TileLinkPinmux(
+      PinmuxCtrl.Parameter(Pinmux.Parameter(12), 24, 2),
+      (0 until 12).map(i => (i, List(i * 2, i * 2 + 1))).to[ArrayBuffer]
+    ))
+
+    generationShouldPass(TileLinkPinmux(
+      PinmuxCtrl.Parameter(Pinmux.Parameter(12), 36, 3),
+      (0 until 12).map(i => (i, List(i * 3, i * 3 + 1, i * 3 + 2))).to[ArrayBuffer]
+    ))
+
+    generationShouldPass(TileLinkPinmux(
+      PinmuxCtrl.Parameter(Pinmux.Parameter(12), 48, 4),
+      (0 until 12).map(i => (i, List(i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3))).to[ArrayBuffer]
+    ))
+
+    generationShouldPass(TileLinkPinmux(
+      PinmuxCtrl.Parameter(Pinmux.Parameter(255), 510, 2),
+      (0 until 255).map(i => (i, List(i * 2, i * 2 + 1))).to[ArrayBuffer]
+    ))
+    generationShouldFail(TileLinkPinmux(
+      PinmuxCtrl.Parameter(Pinmux.Parameter(256), 512, 2),
+      (0 until 256).map(i => (i, List(i * 2, i * 2 + 1))).to[ArrayBuffer]
+    ))
+  }
+
+  test("WishboneGpioParameters") {
+    generationShouldPass(WishbonePinmux(
+      PinmuxCtrl.Parameter(Pinmux.Parameter(12), 24, 2),
+      (0 until 12).map(i => (i, List(i * 2, i * 2 + 1))).to[ArrayBuffer]
+    ))
+
+    generationShouldPass(WishbonePinmux(
+      PinmuxCtrl.Parameter(Pinmux.Parameter(12), 36, 3),
+      (0 until 12).map(i => (i, List(i * 3, i * 3 + 1, i * 3 + 2))).to[ArrayBuffer]
+    ))
+
+    generationShouldPass(WishbonePinmux(
+      PinmuxCtrl.Parameter(Pinmux.Parameter(12), 48, 4),
+      (0 until 12).map(i => (i, List(i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3))).to[ArrayBuffer]
+    ))
+
+    generationShouldPass(WishbonePinmux(
+      PinmuxCtrl.Parameter(Pinmux.Parameter(255), 510, 2),
+      (0 until 255).map(i => (i, List(i * 2, i * 2 + 1))).to[ArrayBuffer]
+    ))
+    generationShouldFail(WishbonePinmux(
+      PinmuxCtrl.Parameter(Pinmux.Parameter(256), 512, 2),
+      (0 until 256).map(i => (i, List(i * 2, i * 2 + 1))).to[ArrayBuffer]
+    ))
+  }
+
+  def init(dut: Apb3Pinmux): (Apb3Driver, PinmuxCtrl.Regs) = {
+    dut.clockDomain.forkStimulus(10)
+    fork {
+      dut.clockDomain.fallingEdge()
+      sleep(10)
+      while (true) {
+        dut.clockDomain.clockToggle()
+        sleep(5)
+      }
+    }
+
+    val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
+    val regs = PinmuxCtrl.Regs(dut.mapper.idCtrl.length)
+
+    /* Init */
+    dut.io.pins.pins.read #= 0
+    dut.io.inputs.write #= 0
+    dut.io.inputs.writeEnable #= 0
+
+    /* Wait for reset and check initialized state */
+    dut.clockDomain.waitSampling(2)
+    dut.clockDomain.waitFallingEdge()
+
+    return (apb, regs)
+  }
+
+  test("basic") {
+    val compiled = SimConfig.withWave.compile {
+      val dut = Apb3Pinmux(
+        PinmuxCtrl.Parameter(Pinmux.Parameter(12), 24, 2),
+        (0 until 12).map(i => (i, List(i * 2, i * 2 + 1))).to[ArrayBuffer]
+      )
+      dut
+    }
+
+    compiled.doSim("registerMap") { dut =>
+      val (apb, regs) = init(dut)
+
+      /* Check IP identification */
+      IpIdentificationTest.V0.checkApi(apb, IpIdentification.Ids.Pinmux)
+      IpIdentificationTest.V0.checkVersion(apb, 1, 0, 0)
+
+      /* Read mux options and input pins */
+      SimTest.readField(apb, regs.info, 15, 8, 2, "Number of input to output options")
+      SimTest.readField(apb, regs.info, 7, 0, 12, "Number of input pins")
+    }
+
+    compiled.doSim("mux options - input") { dut =>
+      val (apb, regs) = init(dut)
+
+      SimTest.checkPins(dut.io.inputs.read.toBigInt, 0, "Internal read pins should be low")
+      SimTest.checkPins(dut.io.pins.pins.write.toBigInt, 0, "Output pin value should be low")
+      SimTest.checkPins(dut.io.pins.pins.writeEnable.toBigInt, 0, "Output pin direction should be low")
+
+      dut.clockDomain.waitFallingEdge()
+
+      dut.io.pins.pins.read #= BigInt("00000001", 16)
+
+      dut.clockDomain.waitFallingEdge()
+
+      SimTest.checkPins(dut.io.inputs.read.toBigInt, BigInt("00000001", 16), "Internal read pins have wrong value")
+      SimTest.checkPins(dut.io.pins.pins.write.toBigInt, BigInt("00000000", 16), "Output pin value should be low")
+      SimTest.checkPins(dut.io.pins.pins.writeEnable.toBigInt, BigInt("00000000", 16), "Default output pin direction should be low")
+
+      dut.io.pins.pins.read #= BigInt("00000fff", 16)
+
+      dut.clockDomain.waitFallingEdge()
+
+      SimTest.checkPins(dut.io.inputs.read.toBigInt, BigInt("00555555", 16), "Internal read pins have wrong value")
+      SimTest.checkPins(dut.io.pins.pins.write.toBigInt, BigInt("00000000", 16), "Output pin value should be low")
+      SimTest.checkPins(dut.io.pins.pins.writeEnable.toBigInt, BigInt("00000000", 16), "Default output pin direction should be low")
+
+      dut.clockDomain.waitFallingEdge()
+
+      for (i <- 0 to dut.parameter.io.width) {
+        apb.write(regs.option(i), BigInt("1", 16))
+      }
+
+      dut.clockDomain.waitFallingEdge()
+
+      SimTest.checkPins(dut.io.inputs.read.toBigInt, BigInt("00aaaaaa", 16), "Internal read pins have wrong value")
+      SimTest.checkPins(dut.io.pins.pins.write.toBigInt, BigInt("00000000", 16), "Output pin value should be low")
+      SimTest.checkPins(dut.io.pins.pins.writeEnable.toBigInt, BigInt("00000000", 16), "Default output pin direction should be low")
+    }
+
+    compiled.doSim("mux options - output") { dut =>
+      val (apb, regs) = init(dut)
+
+      SimTest.checkPins(dut.io.inputs.read.toBigInt, 0, "Internal read pins should be low")
+      SimTest.checkPins(dut.io.pins.pins.write.toBigInt, 0, "Output pin value should be low")
+      SimTest.checkPins(dut.io.pins.pins.writeEnable.toBigInt, 0, "Output pin direction should be low")
+
+      dut.clockDomain.waitFallingEdge()
+
+      dut.io.inputs.write #= BigInt("00000000", 16)
+      dut.io.inputs.writeEnable #= BigInt("00000000", 16)
+
+      dut.clockDomain.waitFallingEdge()
+
+      SimTest.checkPins(dut.io.inputs.read.toBigInt, BigInt("00000000", 16), "Internal read pins have wrong value")
+      SimTest.checkPins(dut.io.pins.pins.write.toBigInt, BigInt("00000000", 16), "Output pin value should be low")
+      SimTest.checkPins(dut.io.pins.pins.writeEnable.toBigInt, BigInt("00000000", 16), "Default output pin direction should be low")
+
+      dut.io.inputs.write #= BigInt("00555555", 16)
+      dut.io.inputs.writeEnable #= BigInt("00555555", 16)
+
+      dut.clockDomain.waitFallingEdge()
+
+      SimTest.checkPins(dut.io.inputs.read.toBigInt, BigInt("00000000", 16), "Internal read pins have wrong value")
+      SimTest.checkPins(dut.io.pins.pins.write.toBigInt, BigInt("00000fff", 16), "Output pin value should be low")
+      SimTest.checkPins(dut.io.pins.pins.writeEnable.toBigInt, BigInt("00000fff", 16), "Default output pin direction should be low")
+
+      dut.clockDomain.waitFallingEdge()
+
+      for (i <- 0 to dut.parameter.io.width) {
+        apb.write(regs.option(i), BigInt("1", 16))
+      }
+
+      dut.clockDomain.waitFallingEdge()
+
+      SimTest.checkPins(dut.io.inputs.read.toBigInt, BigInt("00000000", 16), "Internal read pins have wrong value")
+      SimTest.checkPins(dut.io.pins.pins.write.toBigInt, BigInt("00000000", 16), "Output pin value should be low")
+      SimTest.checkPins(dut.io.pins.pins.writeEnable.toBigInt, BigInt("00000000", 16), "Default output pin direction should be low")
+
+      dut.clockDomain.waitFallingEdge()
+
+      dut.io.inputs.write #= BigInt("00aaaaaa", 16)
+      dut.io.inputs.writeEnable #= BigInt("00aaaaaa", 16)
+
+      dut.clockDomain.waitFallingEdge()
+
+      SimTest.checkPins(dut.io.inputs.read.toBigInt, BigInt("00000000", 16), "Internal read pins have wrong value")
+      SimTest.checkPins(dut.io.pins.pins.write.toBigInt, BigInt("00000fff", 16), "Output pin value should be high")
+      SimTest.checkPins(dut.io.pins.pins.writeEnable.toBigInt, BigInt("00000fff", 16), "Default output pin direction should be high")
+    }
+
+  }
+}


### PR DESCRIPTION
Add a register map class to the UART and Pinmux controllers. Update UART tests to use this class and create tests for the Pinmux controller. Fix a bug in the pinmux controller to allow uneven numbers as option.