### PR TITLE
hardware: nafarr: Add misc system and crypto IPs

### DIFF
--- a/.claude/skills/create-ip/SKILL.md
+++ b/.claude/skills/create-ip/SKILL.md
@@ -1,0 +1,400 @@
+---
+name: create-ip
+description: This skill should be used when the user asks to "create a new IP core", "add a new peripheral", "add a new system IP", "create an IP similar to X", "update an existing IP", "add a new register to an IP", or wants to add hardware to the nafarr library. Covers hardware (SpinalHDL), tests, documentation, software drivers, and IpIdentification registration.
+version: 0.1.0
+---
+
+# IP Core Creation and Update Guide
+
+This skill covers creating or updating IP cores in the nafarr library. Every IP core follows
+a consistent structure across hardware, tests, documentation, and software.
+
+## Repository Layout
+
+```
+hardware/scala/nafarr/<category>/<name>/
+    <Name>.scala          # Bus wrappers (Apb3<Name>, TileLink<Name>, Wishbone<Name>) + Core
+    <Name>Ctrl.scala      # Parameter, Regs, Mapper, inner Component
+
+test/scala/nafarr/<category>/<name>/
+    <Name>Test.scala      # SpinalHDL simulation tests
+
+docs/source/hardware/<category>/
+    <name>.rst            # RST documentation page
+    index.rst             # Add entry here
+
+software/include/
+    <name>.h              # C register layout and driver struct
+
+software/driver/
+    <name>.c              # C driver functions
+```
+
+Categories are `peripherals/com/`, `peripherals/io/`, `system/`, etc.
+
+## 1. IpIdentification
+
+Every IP must have a unique ID. Never change existing entries.
+
+Add an entry to `hardware/scala/nafarr/IpIdentification.scala`:
+
+```scala
+object Ids extends SpinalEnum {
+  val ExistingId = newElement() // 0
+  // ...
+  val NewIpName = newElement()  // N  ← add at the end
+}
+```
+
+One `val X = newElement() // N` per line. The comment is the ordinal (binarySequential).
+
+## 2. Hardware — `<Name>Ctrl.scala`
+
+Structure inside `object <Name>Ctrl`:
+
+```scala
+object FooCtrl {
+  def apply(p: Parameter = Parameter.default()) = FooCtrl(p)
+
+  // --- Register address map ---
+  object Regs {
+    def apply(base: BigInt) = new Regs(base)
+  }
+  class Regs(base: BigInt) {
+    val reg0 = base + 0x00
+    val reg1 = base + 0x04
+    // ...
+  }
+
+  // --- Parameter ---
+  case class Parameter(/* fields */) {
+    require(/* validation */, "message")
+    // SpinalError(...) for checks that must fire during elaboration
+  }
+  object Parameter {
+    // Provide named presets for common resource sizes, e.g.:
+    def small()  = Parameter(...)
+    def medium() = Parameter(...)
+    def large()  = Parameter(...)
+  }
+
+  // --- Core component (no bus logic) ---
+  case class FooCtrl(p: Parameter) extends Component {
+    val io = new Bundle { ... }
+    // pure hardware
+  }
+
+  // --- Bus mapper (BusSlaveFactory frontend) ---
+  case class Mapper(
+      busCtrl: BusSlaveFactory,
+      ctrl: /* Io or FooCtrl */,
+      p: Parameter
+  ) extends Area {
+    val idCtrl = IpIdentification(IpIdentification.Ids.FooName, major, minor, patch)
+    idCtrl.driveFrom(busCtrl)
+    val regs = Regs(idCtrl.length)   // registers start after the 8-byte IP ID header
+
+    // busCtrl.read / busCtrl.write / busCtrl.onRead / busCtrl.onWrite
+  }
+}
+```
+
+Key rules:
+- `IpIdentification` always occupies the first 8 bytes (`idCtrl.length = 8`). Register map starts at `idCtrl.length`.
+- Use `require(...)` in `Parameter` for compile-time Scala checks.
+- Use `SpinalError(...)` inside the `Component` body for elaboration-time checks (e.g. cross-field validation that references `ClockDomain`).
+- Release takes priority over simultaneous claim for stateful resources (see Semaphore pattern).
+- Prefer `when() / elsewhen() / otherwise()` over `Mux()` for conditional signal assignment.
+- Do not align assignments across multiple lines with extra whitespace. Each line uses a single space around `:=` and `=`.
+- Prefer multi-lines for simple `when()` or `if()` even when there is only one statement in the block.
+- Every `for` loop that generates hardware inside a `Component` or `Area` **must** wrap its body in a named `Area` so that the signals inside are visible in simulation with a meaningful prefix:
+  ```scala
+  for (i <- 0 until p.count) {
+    val myArea = new Area {
+      val myReg = Reg(UInt(8 bits)) init(0)
+      // ...
+    }.setName(s"block_${i}")
+  }
+  ```
+  Without `.setName(...)`, SpinalHDL collapses the signals into the parent scope and the simulator cannot distinguish signals from different iterations.
+- **Never** use an inline Scala `if` expression after a SpinalHDL `:=` assignment operator. `signal := if (cond) a else b` is illegal and causes "illegal start of simple expression". Use explicit `if/else` blocks instead:
+  ```scala
+  // WRONG — does not compile
+  signal := if (p.locked) lockReg else False
+
+  // CORRECT
+  if (p.locked) {
+    signal := lockReg
+  } else {
+    signal := False
+  }
+  ```
+
+## 3. Hardware — `<Name>.scala`
+
+Thin bus-wrapper file. Three variants: APB3, TileLink, Wishbone.
+
+```scala
+package nafarr.<category>.<name>
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.BusSlaveFactory
+import spinal.lib.bus.amba3.apb._
+import spinal.lib.bus.tilelink.{
+  Bus => TileLinkBus,
+  BusParameter => TileLinkParameter,
+  SlaveFactory => TileLinkSlaveFactory
+}
+import spinal.lib.bus.wishbone._
+
+object FooName {
+  class Core[T <: spinal.core.Data with IMasterSlave](
+      p: FooNameCtrl.Parameter,
+      busType: HardType[T],
+      factory: T => BusSlaveFactory
+  ) extends Component {
+    val io = new Bundle {
+      val bus = slave(busType())
+      // additional IO ports if needed
+    }
+    val busCtrl = factory(io.bus)
+    val ctrl = FooNameCtrl(p)
+    val mapper = FooNameCtrl.Mapper(busCtrl, ctrl, p)
+  }
+}
+
+case class Apb3FooName(
+    p: FooNameCtrl.Parameter,
+    busConfig: Apb3Config = Apb3Config(8, 32)   // pick addressWidth to cover register map
+) extends FooName.Core[Apb3](p, Apb3(busConfig), Apb3SlaveFactory(_))
+
+case class TileLinkFooName(
+    p: FooNameCtrl.Parameter,
+    busConfig: TileLinkParameter = TileLinkParameter.simple(8, 32, 4, 1)
+) extends FooName.Core[TileLinkBus](p, TileLinkBus(busConfig), new TileLinkSlaveFactory(_, false))
+
+case class WishboneFooName(
+    p: FooNameCtrl.Parameter,
+    busConfig: WishboneConfig = WishboneConfig(8, 32)
+) extends FooName.Core[Wishbone](p, Wishbone(busConfig), WishboneSlaveFactory(_))
+```
+
+**TileLinkParameter.simple(addressWidth, dataWidth, sourceWidth, sinkWidth):**
+- `addressWidth`: match APB3 addressWidth (covers register map).
+- `dataWidth`: always 32.
+- `sourceWidth`: 4 for small IPs with few in-flight transactions; 32 for high-throughput IPs (UART).
+- `sinkWidth`: 1 (minimal).
+
+**APB3/Wishbone addressWidth guidance:**
+- Small register maps (< 256 bytes): 8 bits.
+- Medium (< 4 KB): 12 bits (default for most peripherals like UART, GPIO).
+- Pinmux / large option arrays: 12 bits.
+
+## 4. Tests — `<Name>Test.scala`
+
+```scala
+package nafarr.<category>.<name>
+
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.amba3.apb.{Apb3, Apb3Config}
+import spinal.sim._
+import spinal.core.sim._
+import spinal.lib.bus.amba3.apb.sim.Apb3Driver
+
+class FooNameTest extends AnyFunSuite {
+
+  def generationShouldPass(p: FooNameCtrl.Parameter) = {
+    SpinalVhdl(Apb3FooName(p))
+  }
+
+  def generationShouldFail(p: FooNameCtrl.Parameter) = {
+    intercept[Throwable] { SpinalVhdl(Apb3FooName(p)) }
+  }
+
+  def init(dut: Apb3FooName) = {
+    val driver = Apb3Driver(dut.io.bus, dut.clockDomain)
+    dut.clockDomain.forkStimulus(10)
+    driver
+  }
+
+  test("Parameter - valid") { generationShouldPass(FooNameCtrl.Parameter.default()) }
+  test("Parameter - invalid <reason>") { generationShouldFail(FooNameCtrl.Parameter(...)) }
+
+  test("Feature X") {
+    SimConfig.withWave.compile(Apb3FooName(FooNameCtrl.Parameter.default())).doSim { dut =>
+      val driver = init(dut)
+      // use driver.read(address) / driver.write(address, value)
+      // dut.clockDomain.waitSampling(N)
+    }
+  }
+}
+```
+
+Rules:
+- Use `Apb3<Name>` directly — no wrapper class needed.
+- Use `intercept[Throwable]` (not `intercept[Exception]`) for `generationShouldFail`;
+  SpinalHDL may throw `SpinalExit` which is not an `Exception`.
+- Use `SpinalError(...)` in Component body (not just `require`) when the check must cause
+  `generationShouldFail` — `require` (IllegalArgumentException) may be swallowed by
+  SpinalVerilog internally but not SpinalVhdl.
+- For BOOT-reset registers in Verilator simulations, add
+  `SimConfig.withWave.addSimulatorFlag("--x-initial 0")`.
+- Pass a name to `doSim("name")` to give each simulation directory a meaningful name instead of `Apb3Foo_x`. The name argument goes on `doSim`, not on `SimConfig`:
+  ```scala
+  SimConfig.withWave.compile(Apb3FooName(p))
+    .doSim("foo_feature_x") { dut => ... }
+  ```
+
+## 5. Documentation — `<name>.rst`
+
+File: `docs/source/hardware/<category>/<name>.rst`
+
+```rst
+.. _hardware-<category>-<name>:
+
+Full Name (ACRONYM)
+###################
+
+One-paragraph description of what the IP does.
+
+Configuration
+*************
+
+Available bus architectures:
+
+- APB3
+- TileLink
+- Wishbone
+
+By default, all buses are defined with N bit address and 32 bit data width.
+
+Parameter
+=========
+
+.. list-table:: FooNameCtrl.Parameter
+   :widths: 25 25 25 25
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+     - Default
+   * - fieldName
+     - Int
+     - What it controls.
+     - default value
+
+Register Mapping
+****************
+
+.. |ip-identification-id-value| replace:: 0xN
+.. |ip-identification-major-version| replace:: 0x1
+.. |ip-identification-minor-version| replace:: 0x0
+.. |ip-identification-patch-version| replace:: 0x0
+
+.. include:: ../ipidentification.rsti
+
+.. flat-table:: Register Name
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - 0x008
+     - 7 - 0
+     - fieldName
+     - 0x0
+     - RW
+     - Description.
+```
+
+Title format: **"Full Name (ACRONYM)"** — spell out first, abbreviation in parentheses.
+The `|ip-identification-id-value|` is the decimal ordinal of the `Ids` enum entry.
+
+Register permission codes: `RW` (read/write), `Rx` (read-only), `xW` (write-only).
+Use `:rspan:`N`` for cells that span N+1 rows in `flat-table`.
+
+Add the new file to `docs/source/hardware/<category>/index.rst`:
+
+```rst
+.. toctree::
+   :maxdepth: 1
+
+   existing.rst
+   <name>.rst    ← add here
+```
+
+## 6. Software — `<name>.h` and `<name>.c`
+
+Header `software/include/<name>.h`:
+
+```c
+/* SPDX-FileCopyrightText: 2026 aesc silicon
+ * SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef <NAME>_H
+#define <NAME>_H
+
+#include <stdint.h>
+
+#define <NAME>_REG0_OFFSET  0x008
+
+struct <name>_regs {
+    uint32_t ip_header;   /* 0x000 */
+    uint32_t ip_version;  /* 0x004 */
+    uint32_t reg0;        /* 0x008 */
+    /* ... */
+};
+
+struct <name>_driver {
+    volatile struct <name>_regs *regs;
+};
+
+int  <name>_init(struct <name>_driver *driver, unsigned int base_address);
+/* function declarations */
+
+#endif
+```
+
+Driver `software/driver/<name>.c`:
+
+```c
+/* SPDX-FileCopyrightText: 2026 aesc silicon
+ * SPDX-License-Identifier: Apache-2.0 */
+
+#include "<name>.h"
+
+int <name>_init(struct <name>_driver *driver, unsigned int base_address)
+{
+    driver->regs = (struct <name>_regs *)base_address;
+    return 1;
+}
+```
+
+## Checklist
+
+When creating a new IP:
+
+- [ ] `IpIdentification.Ids` entry added (one per line with ordinal comment)
+- [ ] `<Name>Ctrl.scala`: Parameter + Regs + Component + Mapper
+- [ ] `<Name>.scala`: Core[T] + Apb3, TileLink, Wishbone case classes
+- [ ] `<Name>Test.scala`: local wrapper, generationShouldPass/Fail, simulation tests
+- [ ] `<name>.rst`: title "Full Name (ACRONYM)", parameter table, register map table
+- [ ] `index.rst` updated with new `.rst` entry
+- [ ] `software/include/<name>.h`: register struct + driver struct + declarations
+- [ ] `software/driver/<name>.c`: driver implementation
+
+When updating an existing IP (new register, new parameter):
+
+- [ ] Update `<Name>Ctrl.scala` Regs + Mapper
+- [ ] Update Parameter and its validation
+- [ ] Add/update test cases
+- [ ] Update `.rst` register map and parameter table
+- [ ] Update software header and driver if register layout changed

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
 
   build:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,20 @@ on:
       - 'main'
 
 jobs:
+  software-tests:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          path: nafarr
+
+      - name: Build and run software driver tests
+        run: |
+          cd nafarr/test/software
+          make run
+
   build:
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tmp/
 docs/build
 oss-cad-suite
 cs
+test/software/build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+<!-- SPDX-FileCopyrightText: 2026 aesc silicon -->
+<!-- SPDX-License-Identifier: CERN-OHL-W-2.0 -->
+
+# Coding Rules
+
+## Assignment Operator Formatting
+
+Never pad `=` or `:=` with extra spaces to align them vertically across multiple lines.
+Use exactly one space on each side. This applies to both Scala `=` and SpinalHDL `:=`.
+
+**Wrong:**
+```scala
+val foo     = 1
+val longVar = 2
+
+io.interrupt   := ctrl.io.interrupt
+io.error       := ctrl.io.error
+```
+
+**Correct:**
+```scala
+val foo = 1
+val longVar = 2
+
+io.interrupt := ctrl.io.interrupt
+io.error := ctrl.io.error
+```
+
+## Creating or Updating IP Cores
+
+When creating a new IP core, adding a peripheral, or modifying an existing IP, use the
+`.claude/skills/create-ip/` skill. It covers hardware (SpinalHDL), tests, documentation,
+software drivers, and IpIdentification registration.

--- a/docs/source/hardware/crypto/crc32.rst
+++ b/docs/source/hardware/crypto/crc32.rst
@@ -1,0 +1,141 @@
+.. _hardware-crypto-crc:
+
+CRC32 Accelerator
+#################
+
+The CRC32 accelerator offloads cyclic redundancy check computation from the
+CPU. It processes one 32-bit word per clock cycle using a combinational CRC
+engine (SpinalCrypto ``CRCCombinational``). There is no internal FIFO; the CPU
+writes words one at a time and reads the result when finished.
+
+The polynomial, input/output reflection, and optional XOR-out value are fixed
+at elaboration time through the ``Parameter`` class. A self-disclosure
+register allows software to detect the compiled configuration at runtime.
+
+Features
+********
+
+* CRC32 in one clock cycle per 32-bit word
+* Configurable polynomial via ``InitParameter`` (default: CRC32/ISO-HDLC)
+* Configurable input and output bit-reflection
+* Optional runtime-writable ``xorOut`` register for the final XOR step
+* Self-disclosure ``info`` register (polynomial width, reflect flags,
+  xorOut present)
+* No FIFO — DMA support is reserved for a future high-performance variant
+
+Configuration
+*************
+
+Available bus architectures:
+
+- APB3
+- TileLink
+- Wishbone
+
+By default, all buses are defined with 8 bit address and 32 bit data width.
+
+``Parameter`` fields:
+
+.. list-table::
+   :widths: 20 15 65
+   :header-rows: 1
+
+   * - Field
+     - Default
+     - Description
+   * - ``init``
+     - ``InitParameter.crc32()``
+     - Polynomial selection. ``InitParameter.crc32()`` selects CRC32/ISO-HDLC
+       (Ethernet, zlib); ``InitParameter.crc32xfer()`` selects CRC32/XFER.
+   * - ``inputReflect``
+     - ``true``
+     - Reflect each input word bit-by-bit before processing.
+   * - ``outputReflect``
+     - ``true``
+     - Reflect the CRC state bit-by-bit before output.
+   * - ``xorOut``
+     - ``false``
+     - When ``true``, expose a writable ``xorOut`` register initialised to the
+       polynomial's standard final-XOR value. The ``result`` register returns
+       ``crc_state XOR xorOut``.
+
+Software Flow
+*************
+
+.. code-block:: c
+
+   crc_init(driver);               /* reset state to polynomial init value */
+   for (i = 0; i < n; i++)
+       crc_write(driver, words[i]);
+   uint32_t checksum = crc_read(driver);
+
+Register Mapping
+****************
+
+.. |ip-identification-id-value| replace:: 0x12
+.. |ip-identification-major-version| replace:: 0x1
+.. |ip-identification-minor-version| replace:: 0x0
+.. |ip-identification-patch-version| replace:: 0x0
+
+.. include:: ../ipidentification.rsti
+
+.. flat-table:: CRC32 Registers
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - 0x008
+     - 7 - 0
+     - poly_order
+     - 32
+     - Rx
+     - Polynomial order in bits (32 for all supported variants).
+   * - 0x008
+     - 8
+     - input_reflect
+     - 1
+     - Rx
+     - 1 if input bit-reflection is enabled at elaboration time.
+   * - 0x008
+     - 9
+     - output_reflect
+     - 1
+     - Rx
+     - 1 if output bit-reflection is enabled at elaboration time.
+   * - 0x008
+     - 10
+     - xorout_present
+     - 0
+     - Rx
+     - 1 if the ``xorOut`` register (0x018) is present and writable.
+   * - 0x00C
+     - 31 - 0
+     - control
+     - —
+     - xW
+     - Write any value to reset the CRC state to the polynomial ``initValue``.
+   * - 0x010
+     - 31 - 0
+     - data
+     - —
+     - xW
+     - Write a 32-bit word to fold it into the CRC state (one cycle).
+   * - 0x014
+     - 31 - 0
+     - result
+     - —
+     - Rx
+     - Current CRC state XOR ``xorOut``. Valid immediately after the write
+       completes (combinational update).
+   * - 0x018
+     - 31 - 0
+     - xor_out
+     - poly finalXor
+     - RW
+     - Final XOR value applied to the CRC state before ``result`` is read.
+       Present only when ``Parameter.xorOut = true``; reads as 0 otherwise.

--- a/docs/source/hardware/crypto/index.rst
+++ b/docs/source/hardware/crypto/index.rst
@@ -6,4 +6,5 @@ The following list offers an overview of all available crypto IP cores.
 .. toctree::
    :maxdepth: 1
 
+   crc32.rst
    prng.rst

--- a/docs/source/hardware/crypto/index.rst
+++ b/docs/source/hardware/crypto/index.rst
@@ -1,0 +1,9 @@
+Crypto
+######
+
+The following list offers an overview of all available crypto IP cores.
+
+.. toctree::
+   :maxdepth: 1
+
+   prng.rst

--- a/docs/source/hardware/crypto/prng.rst
+++ b/docs/source/hardware/crypto/prng.rst
@@ -1,0 +1,94 @@
+.. _hardware-crypto-prng:
+
+Pseudo-Random Number Generator (PRNG)
+######################################
+
+The PRNG provides a free-running 32-bit pseudo-random number stream based on a
+Galois Linear Feedback Shift Register (LFSR). The LFSR uses a maximum-period
+polynomial (x\ :sup:`32` + x\ :sup:`30` + x\ :sup:`26` + x\ :sup:`25` + 1),
+yielding a sequence of 2\ :sup:`32` − 1 unique values before repeating.
+
+The PRNG is not suitable for cryptographic use. It is intended for non-security
+applications such as noise injection, test-pattern generation, traffic
+randomisation, and EMI spread-spectrum.
+
+.. warning::
+
+   The LFSR will lock up permanently if its state reaches all-zeros. The hardware
+   prevents this by rejecting any seed write of zero: the state is left unchanged
+   and an error is raised instead. The initial seed after reset is 1.
+
+Features
+********
+
+* 32-bit Galois LFSR with maximum-period taps
+* Free-running: advances one step per clock cycle when enabled
+* Software reseed via seed register
+* Error signal routable to an Error Signal Module
+* Enable bit to freeze output
+
+Configuration
+*************
+
+Available bus architectures:
+
+- APB3
+- TileLink
+- Wishbone
+
+By default, all buses are defined with 8 bit address and 32 bit data width.
+
+Register Mapping
+****************
+
+.. |ip-identification-id-value| replace:: 0x10
+.. |ip-identification-major-version| replace:: 0x1
+.. |ip-identification-minor-version| replace:: 0x0
+.. |ip-identification-patch-version| replace:: 0x0
+
+.. include:: ../ipidentification.rsti
+
+.. flat-table:: PRNG Registers
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - 0x008
+     - 0
+     - enable
+     - 1
+     - RW
+     - Set to 1 to advance the LFSR every clock cycle. Clear to 0 to freeze the
+       output.
+   * - 0x00C
+     - 0
+     - error_pending
+     - 0
+     - RW
+     - Error pending flag. Bit 0 = zero seed attempted. Write 1 to clear.
+   * - 0x010
+     - 0
+     - error_mask
+     - 0
+     - RW
+     - Error mask. Set bit 0 to route the zero-seed error to the ``error`` output
+       signal.
+   * - 0x014
+     - 31 - 0
+     - seed
+     - —
+     - xW
+     - Write a non-zero value to reseed the LFSR immediately. Writing zero sets
+       error pending bit 0 and leaves the LFSR state unchanged.
+   * - 0x018
+     - 31 - 0
+     - output
+     - 1
+     - Rx
+     - Current 32-bit LFSR state. Advances each clock cycle while ``enable`` is
+       set.

--- a/docs/source/hardware/index.rst
+++ b/docs/source/hardware/index.rst
@@ -8,3 +8,4 @@ The following list offers an overview of all available IP cores.
 
    peripherals/index.rst
    system/index.rst
+   crypto/index.rst

--- a/docs/source/hardware/peripherals/index.rst
+++ b/docs/source/hardware/peripherals/index.rst
@@ -10,6 +10,7 @@ The following list offers an overview of all available peripheral IP cores.
    pinmux.rst
    pio.rst
    pwm.rst
+   timer.rst
    uart.rst
    i2c-device.rst
    i2c-controller.rst

--- a/docs/source/hardware/peripherals/timer.rst
+++ b/docs/source/hardware/peripherals/timer.rst
@@ -1,0 +1,160 @@
+.. _hardware-peripherals-timer:
+
+General-Purpose Timer
+#####################
+
+The general-purpose timer provides configurable counting, periodic interrupt
+generation, and compare-match events. Multiple independent timer instances can
+be instantiated in a single IP block, each with its own prescaler, counter, and
+compare channels.
+
+All timer logic is bus-driven. There are no external IO signals — the IP is
+purely internal.
+
+Features
+********
+
+* Configurable number of independent timer instances (``count``, 1–16)
+* Configurable compare channels per timer (``channelCount``, 1–8)
+* Configurable counter width (``width``, 1–32 bits)
+* Optional clock prescaler per timer (``prescalerWidth``, 0 = no prescaler)
+* Three operating modes: free-run, periodic (auto-reload), one-shot
+* Counter preload: software can write the counter register while stopped
+* Compare-match events: each channel fires independently when counter equals its compare register
+* One-shot mode clears the enable bit automatically on completion
+* Combined InterruptCtrl: single ``interrupt`` output with per-source pending and mask registers
+* Supported buses: APB3, TileLink, Wishbone
+
+Operating Modes
+***************
+
+.. list-table::
+   :widths: 15 85
+   :header-rows: 1
+
+   * - Mode
+     - Behaviour
+   * - ``00`` free-run
+     - Counter counts up from 0 to ``2^width - 1`` then wraps to 0. Overflow event fires on wrap.
+   * - ``01`` periodic
+     - Counter counts up from 0 to ``reload``, fires overflow event, and resets to 0. Repeats indefinitely while enabled.
+   * - ``10`` one-shot
+     - Counter counts up from 0 to ``reload``, fires overflow event, resets to 0, and clears the enable bit.
+
+Parameters
+**********
+
+.. list-table::
+   :widths: 20 15 65
+   :header-rows: 1
+
+   * - Parameter
+     - Default
+     - Description
+   * - ``count``
+     - ``1``
+     - Number of independent timer instances (1–16)
+   * - ``channelCount``
+     - ``1``
+     - Compare channels per timer instance (1–8)
+   * - ``width``
+     - ``32``
+     - Counter and compare register width in bits (1–32)
+   * - ``prescalerWidth``
+     - ``16``
+     - Prescaler counter width in bits. 0 disables the prescaler (counter ticks every clock cycle).
+
+Register Map
+************
+
+.. list-table::
+   :widths: 10 20 70
+   :header-rows: 1
+
+   * - Offset
+     - Name
+     - Description
+   * - 0x000
+     - ``ip_header``
+     - IP Identification header
+   * - 0x004
+     - ``ip_version``
+     - IP Identification version
+   * - 0x008
+     - ``info``
+     - Compile-time parameters (read-only, see below)
+   * - 0x00C
+     - ``irq_pending``
+     - Interrupt pending bits — sticky W1C, one bit per source
+   * - 0x010
+     - ``irq_mask``
+     - Interrupt mask — 1 enables the corresponding source
+   * - 0x014 + t × stride
+     - ``control[t]``
+     - Per-timer control register (see below)
+   * - 0x018 + t × stride
+     - ``prescaler[t]``
+     - Prescaler reload value. Counter decrements; tick fires when it reaches 0 and reloads.
+   * - 0x01C + t × stride
+     - ``counter[t]``
+     - Current counter value (R/W; write preloads the counter while stopped)
+   * - 0x020 + t × stride
+     - ``reload[t]``
+     - Auto-reload value used by periodic and one-shot modes
+   * - 0x024 + t × stride + ch × 4
+     - ``compare[t][ch]``
+     - Compare value for channel ``ch``
+
+``stride = 0x10 + channelCount × 4``
+
+Info Register (0x008)
+=====================
+
+.. list-table::
+   :widths: 15 15 70
+   :header-rows: 1
+
+   * - Bits
+     - Field
+     - Description
+   * - [7:0]
+     - ``count``
+     - Number of timer instances
+   * - [15:8]
+     - ``channelCount``
+     - Compare channels per timer
+   * - [23:16]
+     - ``width``
+     - Counter width in bits
+   * - [31:24]
+     - ``prescalerWidth``
+     - Prescaler width in bits (0 = no prescaler)
+
+Control Register (per timer)
+=============================
+
+.. list-table::
+   :widths: 15 15 70
+   :header-rows: 1
+
+   * - Bits
+     - Field
+     - Description
+   * - [0]
+     - ``enable``
+     - Start/stop the timer. Cleared automatically by hardware in one-shot mode.
+   * - [2:1]
+     - ``mode``
+     - Operating mode: ``00`` = free-run, ``01`` = periodic, ``10`` = one-shot
+
+Interrupt Pending / Mask Layout
+================================
+
+Bits are allocated per timer, with ``1 + channelCount`` bits each:
+
+.. code-block:: text
+
+   bit  t*(1+channelCount) + 0       timer t overflow
+   bit  t*(1+channelCount) + 1       timer t compare channel 0
+   bit  t*(1+channelCount) + 2       timer t compare channel 1
+   ...

--- a/docs/source/hardware/system/esm.rst
+++ b/docs/source/hardware/system/esm.rst
@@ -1,0 +1,290 @@
+.. _hardware-system-esm:
+
+Error Signaling Module (ESM)
+############################
+
+The Error Signaling Module aggregates error outputs from multiple IP cores into one
+central safety-aware hub. Each input is routed to one or more severity levels via a
+single combined enable register per bank. Events are latched until cleared by software,
+and a configurable grace-period counter gives the CPU a last-chance window before a hard
+reset is requested.
+
+The ESM is inspired by Texas Instruments' Error Signaling Module found in their
+safety-critical TMS570 and AM2x microcontroller families.
+
+Features
+********
+
+* Up to 256 independently configurable error inputs
+* Two-FF synchroniser on every input (glitch filter, metastability protection)
+* Four independently maskable severity levels per input: INFO, WARN, ERROR, FATAL
+* An input can be assigned to multiple levels simultaneously
+* Combined enable and pending registers pack all four levels into one 32-bit word
+* Banks of 8 inputs scale the register interface beyond 32 inputs without breaking software
+* Configurable grace-period counter for ERROR level (bypassed by FATAL)
+* Software error injection for functional safety testing (ISO 26262 / IEC 61508)
+* Write-once lock bit: freezes ERROR/FATAL routing and inject at runtime
+* Master enable gate: no events captured while ESM is disabled
+* Self-disclosure register exposing all compile-time parameters
+
+Severity Levels
+***************
+
+.. list-table::
+   :widths: 15 30 55
+   :header-rows: 1
+
+   * - Level
+     - Output
+     - Typical use
+   * - INFO
+     - ``infoInterrupt`` → PLIC low-priority lane
+     - Diagnostic events; can be polled. Examples: correctable ECC, PRNG bad seed.
+   * - WARN
+     - ``warnInterrupt`` → PLIC high-priority lane
+     - Recoverable faults requiring prompt software response.
+   * - ERROR
+     - ``errorSignal`` after grace-period counter
+     - Serious faults; CPU has a configurable window to respond before reset.
+   * - FATAL
+     - ``errorSignal`` immediately
+     - Unrecoverable faults; bypasses the grace-period counter entirely.
+
+Enable/Pending Register Layout
+*******************************
+
+Each bank covers 8 inputs. The ``enable`` and ``pending`` registers share the same
+32-bit layout, packing all four severity levels into one word:
+
+.. list-table::
+   :widths: 20 20 60
+   :header-rows: 1
+
+   * - Bits
+     - Level
+     - Description
+   * - [31:24]
+     - FATAL
+     - One bit per input [7:0] of the bank. Locked after ESM lock.
+   * - [23:16]
+     - ERROR
+     - One bit per input [7:0] of the bank. Locked after ESM lock.
+   * - [15:8]
+     - WARN
+     - One bit per input [7:0] of the bank. Never locked.
+   * - [7:0]
+     - INFO
+     - One bit per input [7:0] of the bank. Never locked.
+
+To route input 2 to WARN and FATAL simultaneously::
+
+    ESM_LEVEL_WARN(1u << 2) | ESM_LEVEL_FATAL(1u << 2)  /* = 0x04000400 */
+
+The last bank may cover fewer than 8 inputs; upper bits within each level byte are
+reserved and always read as zero.
+
+Grace-Period Counter
+********************
+
+When any ERROR-level pending bit becomes set the grace-period counter loads
+``errorCounter`` and starts counting down. If software clears all ERROR pending
+bits before the counter reaches zero the counter resets and ``errorSignal`` is
+never asserted from that event. If the counter expires while any ERROR pending
+bit is still set ``errorSignal`` latches high and remains asserted until all
+ERROR pending bits are cleared.
+
+Setting ``errorCounter = 0`` makes ERROR behave identically to FATAL
+(immediate assertion).
+
+FATAL events assert ``errorSignal`` unconditionally and do not interact with
+the counter.
+
+Interrupt Architecture
+**********************
+
+Pending bits are pre-masked: a pending bit is set only when the corresponding
+enable bit is also set. Pending bits are cleared by writing ``1`` (W1C). The same
+input can contribute to multiple levels simultaneously.
+
+``infoInterrupt`` and ``warnInterrupt`` are asserted while any pending bit in the
+INFO or WARN field (across all banks) is set. ``errorSignal`` is asserted while the
+grace-period counter has expired (ERROR) OR any FATAL pending bit is set.
+
+In an interrupt service routine, software reads each bank's ``pending`` register,
+uses the ``ESM_PENDING_INFO/WARN/ERROR/FATAL()`` macros to identify the level and
+source, services the condition, and writes the mask back to clear the bits.
+
+Error Injection
+***************
+
+Software injection is controlled by ``injectEnable`` (control bit 2). When
+enabled, writing to a bank's inject register sets bits that are OR-ed with the
+synchronised hardware inputs. The inject register can only be written when
+``injectEnable = 1`` and the ESM is not locked.
+
+Locking the ESM (writing control bit 1) atomically clears ``injectEnable``,
+zeroes all inject bank registers, and freezes ERROR/FATAL enable fields and
+``errorCounter``. This ensures injection cannot be accidentally re-enabled in
+production after the safety configuration has been locked.
+
+Configuration
+*************
+
+Available bus architectures:
+
+- APB3
+- TileLink
+- Wishbone
+
+By default, all buses are defined with 12 bit address and 32 bit data width.
+
+Parameter
+=========
+
+.. list-table:: EsmCtrl.Parameter
+   :widths: 25 25 25 25
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+     - Default
+   * - inputCount
+     - Int
+     - Number of error inputs. Must be between 1 and 256.
+     - 32
+   * - counterWidth
+     - Int
+     - Bit width of the grace-period counter. Must be between 1 and 32.
+     - 24
+   * - locked
+     - Boolean
+     - Include write-once lock bit in the control register.
+     - true
+
+.. code-block:: scala
+
+   object Parameter {
+     def default() = Parameter()
+     def small()   = Parameter(counterWidth = 16)
+     def large()   = Parameter(counterWidth = 32)
+   }
+
+Register Mapping
+****************
+
+.. |ip-identification-id-value| replace:: 0x16
+.. |ip-identification-major-version| replace:: 0x1
+.. |ip-identification-minor-version| replace:: 0x0
+.. |ip-identification-patch-version| replace:: 0x0
+
+.. include:: ../ipidentification.rsti
+
+**Self Disclosure:**
+
+.. flat-table:: Info Register (0x008)
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - :rspan:`3` 0x008
+     - 31 - 25
+     - —
+     - 0
+     - Rx
+     - Reserved.
+   * - 24
+     - locked
+     -
+     - Rx
+     - 1 if the lock feature is compiled in.
+   * - 23 - 16
+     - counterWidth
+     -
+     - Rx
+     - Grace-period counter bit width.
+   * - 15 - 9
+     - bankCount
+     -
+     - Rx
+     - Number of banks (= ceil(inputCount / 8)).
+   * - 8 - 0
+     - inputCount
+     -
+     - Rx
+     - Number of error inputs.
+
+**Global Registers:**
+
+.. list-table:: Global Register Map
+   :header-rows: 1
+   :widths: 15 85
+
+   * - Address
+     - Description
+   * - 0x00C
+     - Control register (see below).
+   * - 0x010
+     - Status register (read-only): ``counterActive[0]``, ``errorSignal[1]``.
+   * - 0x014
+     - Error counter — grace-period reload value. Write ignored when locked.
+
+.. flat-table:: Control Register (0x00C)
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - :rspan:`2` 0x00C
+     - 2
+     - injectEnable
+     - 0
+     - RW
+     - Enable software error injection. Cleared on lock.
+   * - 1
+     - lock
+     - 0
+     - RW
+     - Write-once lock bit. Freezes ERROR/FATAL enable, errorCounter, and inject
+       registers. Only present when ``locked = true``; reads 0 otherwise.
+   * - 0
+     - enable
+     - 0
+     - RW
+     - Master enable. When 0, no new events are captured. Writing 0 is ignored when locked.
+
+**Per-Bank Registers:**
+
+Banks are numbered 0 to ``bankCount - 1``. Bank N base address = ``0x028 + N * 0x10``.
+
+.. list-table:: Per-Bank Register Offsets
+   :header-rows: 1
+   :widths: 15 15 70
+
+   * - Offset
+     - Name
+     - Description
+   * - +0x00
+     - enable
+     - Combined routing mask for all four levels (see layout above).
+       ERROR/FATAL fields (bits [31:16]) are frozen when locked.
+   * - +0x04
+     - pending
+     - Combined pending bits for all four levels. Write ``1`` to clear (W1C).
+   * - +0x08
+     - raw
+     - Current active inputs for this bank (read-only). Reflects synchronised
+       hardware inputs OR-ed with inject. Not gated by master enable.
+   * - +0x0C
+     - inject
+     - Bits [7:0]: injected inputs. Writeable only when ``injectEnable = 1``
+       and ESM is not locked. Cleared to zero on lock.

--- a/docs/source/hardware/system/index.rst
+++ b/docs/source/hardware/system/index.rst
@@ -11,4 +11,5 @@ The following list offers an overview of all available system IP cores.
    reset.rst
    semaphore.rst
    esm.rst
+   syscon.rst
    watchdog.rst

--- a/docs/source/hardware/system/index.rst
+++ b/docs/source/hardware/system/index.rst
@@ -8,3 +8,4 @@ The following list offers an overview of all available system IP cores.
 
    clock.rst
    reset.rst
+   semaphore.rst

--- a/docs/source/hardware/system/index.rst
+++ b/docs/source/hardware/system/index.rst
@@ -7,5 +7,6 @@ The following list offers an overview of all available system IP cores.
    :maxdepth: 1
 
    clock.rst
+   mailbox.rst
    reset.rst
    semaphore.rst

--- a/docs/source/hardware/system/index.rst
+++ b/docs/source/hardware/system/index.rst
@@ -10,4 +10,5 @@ The following list offers an overview of all available system IP cores.
    mailbox.rst
    reset.rst
    semaphore.rst
+   esm.rst
    watchdog.rst

--- a/docs/source/hardware/system/index.rst
+++ b/docs/source/hardware/system/index.rst
@@ -10,3 +10,4 @@ The following list offers an overview of all available system IP cores.
    mailbox.rst
    reset.rst
    semaphore.rst
+   watchdog.rst

--- a/docs/source/hardware/system/mailbox.rst
+++ b/docs/source/hardware/system/mailbox.rst
@@ -1,0 +1,207 @@
+.. _hardware-system-mailbox:
+
+Hardware Mailbox
+################
+
+The Hardware Mailbox provides symmetric FIFO-based message queues for inter-CPU
+communication. Each channel carries 32-bit messages independently. CPU A
+conventionally sends on channel 0 and receives on channel 1; CPU B does the
+opposite. Both CPUs access the same register map.
+
+Features
+********
+
+* Configurable number of symmetric channels (default: 2)
+* Configurable FIFO depth per channel (small / medium / large presets)
+* 32-bit message width matching the bus data width
+* Per-channel status flags (empty, full) and occupancy counter
+* Per-channel interrupt sources: not-empty (data arrived) and not-full (space available)
+* Single combined interrupt output — asserted when any enabled channel interrupt fires
+
+Interrupt Architecture
+**********************
+
+Each channel has independent ``irq_pending`` and ``irq_mask`` registers. An interrupt
+source bit is set when its condition is true and the corresponding mask bit is enabled.
+The hardware ORs all masked pending bits across all channels into a single ``interrupt``
+output signal.
+
+In the interrupt service routine, software must read the per-channel ``irq_pending``
+registers to identify which channel fired, service the condition, and write ``1`` to the
+corresponding pending bit to clear it.
+
+Protocol
+********
+
+**Send (push):**
+
+Write the 32-bit message payload to the channel's write register. If the FIFO is full,
+the write is silently dropped. Software should check the full flag in the status register
+before writing to avoid data loss.
+
+**Receive (pop):**
+
+Read the channel's read register to pop one message from the FIFO. The returned value is
+the message payload. If the FIFO is empty, the read returns stale data. Software should
+check the empty flag in the status register before reading.
+
+Configuration
+*************
+
+Available bus architectures:
+
+- APB3
+- TileLink
+- Wishbone
+
+By default, all buses are defined with 8 bit address and 32 bit data width.
+
+Parameter
+=========
+
+.. list-table:: MailboxCtrl.Parameter
+   :widths: 25 25 25 25
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+     - Default
+   * - depth
+     - Int
+     - FIFO depth per channel. Must be between 1 and 255.
+     - 8
+   * - channelCount
+     - Int
+     - Number of channels. Must be at least 2.
+     - 2
+
+``MailboxCtrl.Parameter`` has predefined presets for common use cases.
+
+.. code-block:: scala
+
+   object Parameter {
+     def small()  = Parameter(depth = 4)
+     def medium() = Parameter(depth = 8)
+     def large()  = Parameter(depth = 16)
+   }
+
+Register Mapping
+****************
+
+.. |ip-identification-id-value| replace:: 0xF
+.. |ip-identification-major-version| replace:: 0x1
+.. |ip-identification-minor-version| replace:: 0x0
+.. |ip-identification-patch-version| replace:: 0x0
+
+.. include:: ../ipidentification.rsti
+
+**Self Disclosure:**
+
+.. flat-table:: Self Disclosure Register
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - :rspan:`1` 0x008
+     - 15 - 8
+     - depth
+     -
+     - Rx
+     - FIFO depth per channel.
+   * - 7 - 0
+     - channels
+     - 2
+     - Rx
+     - Number of channels.
+
+**Status Register:**
+
+.. flat-table:: Status Register
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - :rspan:`3` 0x00C
+     - 3
+     - full[1]
+     - 0
+     - Rx
+     - Channel 1 FIFO full.
+   * - 2
+     - full[0]
+     - 0
+     - Rx
+     - Channel 0 FIFO full.
+   * - 1
+     - empty[1]
+     - 1
+     - Rx
+     - Channel 1 FIFO empty.
+   * - 0
+     - empty[0]
+     - 1
+     - Rx
+     - Channel 0 FIFO empty.
+
+The status register layout scales with ``channelCount``. Bits ``[channelCount-1:0]``
+hold the empty flags and bits ``[2*channelCount-1:channelCount]`` hold the full flags.
+
+**Channel Registers:**
+
+Two sets of identical registers, one per channel. Channel 0 starts at 0x010;
+channel 1 starts at 0x024. The stride between channels is 0x14.
+
+.. flat-table:: Channel Registers (per channel, base = 0x010 + channel × 0x14)
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - base + 0x00
+     - 31 - 0
+     - write
+     - —
+     - xW
+     - Push a 32-bit message into the channel FIFO. Dropped silently if full.
+   * - base + 0x04
+     - 31 - 0
+     - read
+     - —
+     - Rx
+     - Pop a 32-bit message from the channel FIFO. Returns stale data if empty.
+   * - base + 0x08
+     - 7 - 0
+     - occupancy
+     - 0
+     - Rx
+     - Number of messages currently stored in the FIFO.
+   * - base + 0x0C
+     - 1 - 0
+     - irq_pending
+     - 0
+     - RW
+     - Interrupt pending flags. Write ``1`` to a bit to clear it.
+       Bit 0 = not-empty, bit 1 = not-full. All enabled pending bits across all
+       channels are ORed into the single hardware interrupt output.
+   * - base + 0x10
+     - 1 - 0
+     - irq_mask
+     - 0
+     - RW
+     - Interrupt enable mask. Set a bit to enable the corresponding interrupt source.
+       Bit 0 = not-empty, bit 1 = not-full.

--- a/docs/source/hardware/system/semaphore.rst
+++ b/docs/source/hardware/system/semaphore.rst
@@ -1,0 +1,160 @@
+.. _hardware-system-semaphore:
+
+Hardware Semaphore
+##################
+
+The Hardware Semaphore provides atomic inter-process or inter-core locking without
+requiring software-level compare-and-swap instructions. Each semaphore slot is claimed
+by reading its register and released by writing to it. The claim flag is set on the same
+bus transaction as the read, so no other bus master can interleave between the test and
+the set.
+
+Features
+********
+
+* Configurable number of semaphore slots (1 to 32)
+* Atomic claim-on-read, release-on-write protocol
+* Read-only STATUS register exposing the full taken bitmask
+* Release takes priority over a simultaneous claim on the same slot
+
+Claim Protocol
+**************
+
+Read the semaphore register for slot *n*:
+
+* Returns **0** — the slot was free; the caller now holds it.
+* Returns **1** — the slot was already taken; the caller must retry.
+
+The returned value reflects the state *before* the read. The taken flag is set
+atomically within the same transaction, so no interleaving is possible.
+
+Release Protocol
+****************
+
+Write any value to the semaphore register for slot *n* to unconditionally release it.
+
+Configuration
+*************
+
+Available bus architectures:
+
+- APB3
+- TileLink
+- Wishbone
+
+By default, all buses are defined with 8 bit address and 32 bit data width.
+
+Parameter
+=========
+
+``SemaphoreCtrl.Parameter`` configures the semaphore controller.
+
+.. list-table:: SemaphoreCtrl.Parameter
+   :widths: 25 25 25 25
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+     - Default
+   * - count
+     - Int
+     - Number of semaphore slots. Must be between 1 and 32.
+     - 8
+
+``SemaphoreCtrl.Parameter`` has predefined presets for common use cases.
+
+.. code-block:: scala
+
+   object Parameter {
+     def small()  = Parameter(count = 4)
+     def medium() = Parameter(count = 8)
+     def large()  = Parameter(count = 16)
+   }
+
+Register Mapping
+****************
+
+.. |ip-identification-id-value| replace:: 0xE
+.. |ip-identification-major-version| replace:: 0x1
+.. |ip-identification-minor-version| replace:: 0x0
+.. |ip-identification-patch-version| replace:: 0x0
+
+.. include:: ../ipidentification.rsti
+
+**Self Disclosure:**
+
+.. flat-table:: Self Disclosure Registers
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - 0x008
+     - 7 - 0
+     - count
+     -
+     - Rx
+     - Number of semaphore slots in this instance.
+
+**Status Register:**
+
+.. flat-table:: Status Register
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - 0x00C
+     - count - 1 .. 0
+     - taken
+     - 0x0
+     - Rx
+     - Bitmask of currently taken slots. Bit *n* is set while slot *n* is held.
+
+**Semaphore Registers:**
+
+One 32-bit register per slot, starting at 0x010. Read to claim; write to release.
+
+.. flat-table:: Semaphore Registers
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - 0x010
+     - 0
+     - SEM_0
+     - 0x0
+     - RW
+     - Read: 0 = claimed successfully, 1 = already taken. Write: release slot 0.
+   * - 0x014
+     - 0
+     - SEM_1
+     - 0x0
+     - RW
+     - Read: 0 = claimed successfully, 1 = already taken. Write: release slot 1.
+   * - ...
+     -
+     -
+     -
+     -
+     -
+   * - 0x010 + slot × 0x4
+     - 0
+     - SEM_n
+     - 0x0
+     - RW
+     - Read: 0 = claimed successfully, 1 = already taken. Write: release slot *n*.

--- a/docs/source/hardware/system/syscon.rst
+++ b/docs/source/hardware/system/syscon.rst
@@ -1,0 +1,197 @@
+.. _hardware-system-syscon:
+
+System Controller (Syscon)
+##########################
+
+The System Controller provides a read-only identification and configuration
+register block. Software can query compile-time SoC parameters at runtime:
+vendor, platform, product, silicon revision, feature flags, reference clock
+frequency, and build timestamp.
+
+All registers are constants derived from elaboration-time ``Parameter`` values.
+No write access is defined; bus writes are silently ignored.
+
+Features
+********
+
+* IP Identification block (header + version at 0x000–0x007)
+* 32-bit identity register: vendor, platform, product, and platform class
+* Independent silicon major/minor revision registers
+* 32-bit feature flag register: bit N set when ``Feature`` element with ordinal N is present
+* Reference clock frequency register (Hz)
+* UNIX build timestamp register (seconds since epoch)
+* Supported buses: APB3, TileLink, Wishbone
+
+Parameters
+**********
+
+.. list-table::
+   :widths: 20 15 65
+   :header-rows: 1
+
+   * - Parameter
+     - Default
+     - Description
+   * - ``vendor``
+     - *(required)*
+     - Vendor identifier (``Vendor`` enum)
+   * - ``platform``
+     - *(required)*
+     - Platform identifier (``Platform`` enum)
+   * - ``platformClass``
+     - *(required)*
+     - Platform class (``PlatformClass`` enum): NonMetal (MCU) or Alkali (MPU)
+   * - ``product``
+     - *(required)*
+     - Product identifier (``Product`` enum)
+   * - ``refClockHz``
+     - *(required)*
+     - Board reference oscillator frequency in Hz
+   * - ``siliconMajor``
+     - ``0``
+     - Silicon major revision
+   * - ``siliconMinor``
+     - ``1``
+     - Silicon minor revision
+   * - ``features``
+     - ``List()``
+     - Feature flags to set in the features register
+   * - ``buildDate``
+     - env ``BUILD_DATE`` or ``now``
+     - UNIX timestamp (seconds). Read from the ``BUILD_DATE`` environment variable if set, otherwise captured at elaboration time
+
+Register Map
+************
+
+.. list-table::
+   :widths: 10 20 70
+   :header-rows: 1
+
+   * - Offset
+     - Name
+     - Description
+   * - 0x000
+     - ``ip_header``
+     - IP Identification header (API, length, IP ID)
+   * - 0x004
+     - ``ip_version``
+     - IP Identification version (major, minor, patch)
+   * - 0x008
+     - ``identity``
+     - SoC identity (see below)
+   * - 0x00C
+     - ``silicon_major``
+     - Silicon major revision
+   * - 0x010
+     - ``silicon_minor``
+     - Silicon minor revision
+   * - 0x014
+     - ``features``
+     - Feature flag bitmask
+   * - 0x018
+     - ``ref_clock``
+     - Reference oscillator frequency (Hz)
+   * - 0x01C
+     - ``build_date``
+     - Build UNIX timestamp (seconds)
+
+Identity Register (0x008)
+=========================
+
+.. list-table::
+   :widths: 15 15 70
+   :header-rows: 1
+
+   * - Bits
+     - Field
+     - Description
+   * - [31:24]
+     - ``platformClass``
+     - Platform class ordinal (0=NonMetal/MCU, 1=Alkali/MPU)
+   * - [23:16]
+     - ``product``
+     - Product ordinal (0=ElemRV)
+   * - [15:8]
+     - ``platform``
+     - Platform ordinal (0=Hydrogen, 1=Carbon, 2=Nitrogen, 3=Oxygen, 4=Phosphorus, 5=Sulfur)
+   * - [7:0]
+     - ``vendor``
+     - Vendor ordinal (0=AescSilicon)
+
+Features Register (0x014)
+=========================
+
+Bit N is set when the ``Feature`` element with ordinal N appears in the
+``features`` parameter list. The SoC builder populates this list automatically
+by collecting ``sysconFeatures`` from each IP on the bus.
+
+.. list-table::
+   :widths: 10 20 70
+   :header-rows: 1
+
+   * - Bit
+     - Feature
+     - Description
+   * - 0
+     - ``I2c``
+     - I2C controller or device present
+   * - 1
+     - ``Spi``
+     - SPI controller or device present
+   * - 2
+     - ``Uart``
+     - UART present
+   * - 3
+     - ``Gpio``
+     - GPIO present
+   * - 4
+     - ``Pio``
+     - Programmable I/O present
+   * - 5
+     - ``Pwm``
+     - PWM present
+   * - 6
+     - ``Pinmux``
+     - Pin multiplexer present
+   * - 7
+     - ``Clock``
+     - Clock controller present
+   * - 8
+     - ``Esm``
+     - Error Signaling Module present
+   * - 9
+     - ``Mailbox``
+     - Mailbox present
+   * - 10
+     - ``Mtimer``
+     - Machine-mode timer present
+   * - 11
+     - ``Plic``
+     - Platform-level interrupt controller present
+   * - 12
+     - ``Reset``
+     - Reset controller present
+   * - 13
+     - ``Semaphore``
+     - Hardware semaphore present
+   * - 14
+     - ``Watchdog``
+     - Watchdog timer present
+   * - 15
+     - ``Aes``
+     - AES accelerator present
+   * - 16
+     - ``Crc``
+     - CRC engine present
+   * - 17
+     - ``Prng``
+     - Pseudo-random number generator present
+   * - 18
+     - ``Hyperbus``
+     - HyperBus interface present
+   * - 19
+     - ``Ocram``
+     - On-chip SRAM controller present
+   * - 20
+     - ``SpiFlash``
+     - SPI flash controller present

--- a/docs/source/hardware/system/watchdog.rst
+++ b/docs/source/hardware/system/watchdog.rst
@@ -1,0 +1,256 @@
+.. _hardware-system-watchdog:
+
+Hardware Watchdog Timer (WDT)
+#############################
+
+The Hardware Watchdog Timer provides one or more independent watchdog instances. Each
+watchdog has a configurable prescaler and down-counter. Software must periodically kick
+a watchdog to prevent it from timing out. An optional windowed mode restricts valid kicks
+to a defined time window, catching both missing kicks (timeout) and runaway loops that
+kick too frequently (window violation).
+
+Features
+********
+
+* Configurable number of independent watchdog instances
+* Per-watchdog configurable counter width and prescaler width
+* Windowed mode: valid kick window defined by ``window_open`` threshold
+* Write-once lock bit: prevents disabling and configuration changes once armed
+* Self-disclosure register exposing all compile-time parameters
+* Per-watchdog interrupt controller with four independently maskable sources (two without windowed mode)
+* Single combined interrupt output — asserted when any enabled source fires
+
+Interrupt Architecture
+**********************
+
+Each watchdog has four interrupt sources (two when ``windowed = false``):
+
+- **Bit 0**: timeout → interrupt (recoverable notification)
+- **Bit 1**: timeout → error (non-recoverable; typically routed to reset controller)
+- **Bit 2**: window violation → interrupt (windowed mode only)
+- **Bit 3**: window violation → error (windowed mode only)
+
+Bits 0 and 1 share the same underlying timeout event; bits 2 and 3 share the window
+violation event. This allows the SoC integrator to route each event independently to the
+interrupt controller, reset controller, or both.
+
+All masked pending bits across all watchdog instances are OR-ed into a single
+``interrupt`` output. In the interrupt service routine, software reads the per-watchdog
+``irq_pending`` registers to identify the source, services the condition, then writes
+``1`` to the pending bit to clear it.
+
+Protocol
+********
+
+**Setup:**
+
+1. Write ``prescaler`` to set the tick frequency: ``f_tick = f_clk / (prescaler + 1)``.
+2. Write ``timeout`` to set the reload value. The watchdog fires after ``(timeout + 1)``
+   ticks.
+3. If windowed mode is compiled in, write ``window_open`` to the counter value below which
+   kicks are valid. A kick is valid when ``counter <= window_open``.
+4. Write ``irq_mask`` to enable the desired interrupt sources.
+5. Optionally write bit 1 of ``control`` to lock the configuration.
+6. Write bit 0 of ``control`` to enable the watchdog. The counter loads with ``timeout``
+   on the rising edge of the enable bit.
+
+**Operation:**
+
+- Write any value to ``kick`` while the counter is within the window to reload the counter.
+- Writing ``kick`` outside the window (windowed mode) generates a window violation.
+- When the counter reaches zero a timeout fires; the counter reloads automatically.
+
+Configuration
+*************
+
+Available bus architectures:
+
+- APB3
+- TileLink
+- Wishbone
+
+By default, all buses are defined with 12 bit address and 32 bit data width.
+
+Parameter
+=========
+
+.. list-table:: WatchdogCtrl.Parameter
+   :widths: 25 25 25 25
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+     - Default
+   * - count
+     - Int
+     - Number of independent watchdog instances. Must be between 1 and 255.
+     - 1
+   * - width
+     - Int
+     - Counter bit width. Must be between 1 and 32.
+     - 32
+   * - prescalerWidth
+     - Int
+     - Prescaler bit width. Must be between 1 and 32.
+     - 16
+   * - windowed
+     - Boolean
+     - Enable windowed mode and ``window_open`` register.
+     - false
+   * - locked
+     - Boolean
+     - Include write-once lock bit in the control register.
+     - true
+
+.. code-block:: scala
+
+   object Parameter {
+     def default()  = Parameter()
+     def small()    = Parameter(width = 16, prescalerWidth = 8)
+     def windowed() = Parameter(windowed = true)
+   }
+
+Register Mapping
+****************
+
+.. |ip-identification-id-value| replace:: 0x15
+.. |ip-identification-major-version| replace:: 0x1
+.. |ip-identification-minor-version| replace:: 0x0
+.. |ip-identification-patch-version| replace:: 0x0
+
+.. include:: ../ipidentification.rsti
+
+**Self Disclosure:**
+
+.. flat-table:: Info Register (0x008)
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - :rspan:`4` 0x008
+     - 31 - 26
+     - —
+     - 0
+     - Rx
+     - Reserved.
+   * - 25
+     - locked
+     -
+     - Rx
+     - 1 if the lock feature is compiled in.
+   * - 24
+     - windowed
+     -
+     - Rx
+     - 1 if windowed mode is compiled in.
+   * - 23 - 16
+     - prescalerWidth
+     -
+     - Rx
+     - Prescaler bit width.
+   * - 15 - 8
+     - width
+     -
+     - Rx
+     - Counter bit width.
+   * - 7 - 0
+     - count
+     -
+     - Rx
+     - Number of watchdog instances.
+
+**Per-Watchdog Registers:**
+
+One set per watchdog instance. Instance 0 starts at 0x00C; stride between instances
+is 0x20.
+
+.. flat-table:: Per-Watchdog Registers (base = 0x00C + instance × 0x20)
+   :widths: 10 10 15 10 10 45
+   :header-rows: 1
+
+   * - Address
+     - Bit
+     - Field
+     - Default
+     - Permission
+     - Description
+   * - :rspan:`1` base + 0x00
+     - 1
+     - lock
+     - 0
+     - RW
+     - Write-once lock bit. Once set, disabling the watchdog and writes to
+       ``prescaler``, ``timeout``, and ``window_open`` are ignored. Only present
+       when ``locked = true``; reads 0 otherwise.
+   * - 0
+     - enable
+     - 0
+     - RW
+     - Enable the watchdog. Rising edge reloads the counter with ``timeout``.
+       Writing 0 is ignored when ``lock`` is set.
+   * - base + 0x04
+     - width - 1 downto 0
+     - prescaler
+     - max
+     - RW
+     - Prescaler reload value. Tick frequency = ``f_clk / (prescaler + 1)``.
+       Write ignored when locked.
+   * - base + 0x08
+     - width - 1 downto 0
+     - timeout
+     - max
+     - RW
+     - Counter reload value. Timeout fires after ``(timeout + 1)`` ticks.
+       Write ignored when locked.
+   * - base + 0x0C
+     - width - 1 downto 0
+     - window_open
+     - 0
+     - RW
+     - Kick valid threshold. A kick is accepted when ``counter <= window_open``.
+       Reads 0 when ``windowed = false``. Write ignored when locked.
+   * - :rspan:`2` base + 0x10
+     - 2
+     - inWindow
+     - 0
+     - Rx
+     - High while the counter is within the kick window (``windowed`` only).
+   * - 1
+     - locked
+     - 0
+     - Rx
+     - Current lock state. Reads 0 when ``locked = false``.
+   * - 0
+     - enabled
+     - 0
+     - Rx
+     - Current enable state.
+   * - base + 0x14
+     - irqCount - 1 downto 0
+     - irq_pending
+     - 0
+     - RW
+     - Interrupt pending flags. Write ``1`` to clear a bit.
+       Bit 0 = timeout interrupt, bit 1 = timeout error,
+       bit 2 = violation interrupt, bit 3 = violation error
+       (bits 2–3 only when ``windowed = true``).
+   * - base + 0x18
+     - irqCount - 1 downto 0
+     - irq_mask
+     - 0
+     - RW
+     - Interrupt enable mask. Set a bit to enable the corresponding source.
+       Same bit layout as ``irq_pending``.
+   * - base + 0x1C
+     - —
+     - kick
+     - —
+     - xW
+     - Write any value to kick the watchdog. Reloads the counter when within the
+       window; raises a window violation when outside the window (windowed mode).

--- a/hardware/scala/nafarr/IpIdentification.scala
+++ b/hardware/scala/nafarr/IpIdentification.scala
@@ -28,6 +28,7 @@ object IpIdentification {
     val Clock = newElement() // 12
     val Pinmux = newElement() // 13
     val Semaphore = newElement() // 14
+    val Mailbox = newElement() // 15
   }
 
   case class IpIdentificationCtrl(

--- a/hardware/scala/nafarr/IpIdentification.scala
+++ b/hardware/scala/nafarr/IpIdentification.scala
@@ -34,6 +34,7 @@ object IpIdentification {
     val Crc8 = newElement() // 18
     val Crc16 = newElement() // 19
     val Crc32 = newElement() // 20
+    val Watchdog = newElement() // 21
   }
 
   case class IpIdentificationCtrl(

--- a/hardware/scala/nafarr/IpIdentification.scala
+++ b/hardware/scala/nafarr/IpIdentification.scala
@@ -27,6 +27,7 @@ object IpIdentification {
     val Reset = newElement() // 11
     val Clock = newElement() // 12
     val Pinmux = newElement() // 13
+    val Semaphore = newElement() // 14
   }
 
   case class IpIdentificationCtrl(

--- a/hardware/scala/nafarr/IpIdentification.scala
+++ b/hardware/scala/nafarr/IpIdentification.scala
@@ -37,6 +37,7 @@ object IpIdentification {
     val Watchdog = newElement() // 21
     val Esm = newElement() // 22
     val Timer = newElement() // 23
+    val Syscon = newElement() // 24
   }
 
   case class IpIdentificationCtrl(

--- a/hardware/scala/nafarr/IpIdentification.scala
+++ b/hardware/scala/nafarr/IpIdentification.scala
@@ -29,6 +29,8 @@ object IpIdentification {
     val Pinmux = newElement() // 13
     val Semaphore = newElement() // 14
     val Mailbox = newElement() // 15
+    val Prng = newElement() // 16
+    val Trng = newElement() // 17
   }
 
   case class IpIdentificationCtrl(

--- a/hardware/scala/nafarr/IpIdentification.scala
+++ b/hardware/scala/nafarr/IpIdentification.scala
@@ -36,6 +36,7 @@ object IpIdentification {
     val Crc32 = newElement() // 20
     val Watchdog = newElement() // 21
     val Esm = newElement() // 22
+    val Timer = newElement() // 23
   }
 
   case class IpIdentificationCtrl(

--- a/hardware/scala/nafarr/IpIdentification.scala
+++ b/hardware/scala/nafarr/IpIdentification.scala
@@ -35,6 +35,7 @@ object IpIdentification {
     val Crc16 = newElement() // 19
     val Crc32 = newElement() // 20
     val Watchdog = newElement() // 21
+    val Esm = newElement() // 22
   }
 
   case class IpIdentificationCtrl(

--- a/hardware/scala/nafarr/IpIdentification.scala
+++ b/hardware/scala/nafarr/IpIdentification.scala
@@ -31,6 +31,9 @@ object IpIdentification {
     val Mailbox = newElement() // 15
     val Prng = newElement() // 16
     val Trng = newElement() // 17
+    val Crc8 = newElement() // 18
+    val Crc16 = newElement() // 19
+    val Crc32 = newElement() // 20
   }
 
   case class IpIdentificationCtrl(

--- a/hardware/scala/nafarr/SocIds.scala
+++ b/hardware/scala/nafarr/SocIds.scala
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr
+
+import spinal.core._
+
+/** Vendor identifier. Never change existing ordinals. */
+object Vendor extends SpinalEnum(binarySequential) {
+  val AescSilicon = newElement() // 0
+}
+
+/** Platform identifier. Never change existing ordinals. */
+object Platform extends SpinalEnum(binarySequential) {
+  val Hydrogen = newElement() // 0
+  val Carbon = newElement() // 1
+  val Nitrogen = newElement() // 2
+  val Oxygen = newElement() // 3
+  val Phosphorus = newElement() // 4
+  val Sulfur = newElement() // 5
+}
+
+/** Product identifier. Never change existing ordinals. */
+object Product extends SpinalEnum(binarySequential) {
+  val ElemRV = newElement() // 0
+}
+
+/** Platform class derived from the chemistry group of the platform element.
+  *
+  * NonMetal — non-metal elements (Hydrogen, Carbon, Nitrogen, Oxygen, Phosphorus, Sulfur):
+  *            MCU class, M-mode only, no MMU.
+  * Alkali   — alkali metal elements (Lithium, Sodium, Potassium, ...):
+  *            MPU class, MMU, OS-capable.
+  *
+  * Never change existing ordinals.
+  */
+object PlatformClass extends SpinalEnum(binarySequential) {
+  val NonMetal = newElement() // 0 — MCU (non-metal elements)
+  val Alkali = newElement() // 1 — MPU (alkali metal elements)
+}
+
+/** SoC feature flags for the syscon feature register.
+  *
+  * Each element maps to a bit position in a 32-bit register via its ordinal.
+  * An IP reports its feature(s) via `sysconFeatures` on its Core class so that
+  * the SoC builder can populate the syscon parameter automatically.
+  *
+  * Never change existing ordinals — software depends on stable bit positions.
+  */
+object Feature extends SpinalEnum(binarySequential) {
+  val I2c = newElement() // 0
+  val Spi = newElement() // 1
+  val Uart = newElement() // 2
+  val Gpio = newElement() // 3
+  val Pio = newElement() // 4
+  val Pwm = newElement() // 5
+  val Pinmux = newElement() // 6
+  val Clock = newElement() // 7
+  val Esm = newElement() // 8
+  val Mailbox = newElement() // 9
+  val Mtimer = newElement() // 10
+  val Timer = newElement() // 11
+  val Plic = newElement() // 12
+  val Reset = newElement() // 13
+  val Semaphore = newElement() // 14
+  val Watchdog = newElement() // 15
+  val Aes = newElement() // 16
+  val Crc = newElement() // 17
+  val Prng = newElement() // 18
+  val Hyperbus = newElement() // 19
+  val Ocram = newElement() // 20
+  val SpiFlash = newElement() // 21
+}

--- a/hardware/scala/nafarr/crypto/aes/AESMaskedAccelerator.scala
+++ b/hardware/scala/nafarr/crypto/aes/AESMaskedAccelerator.scala
@@ -10,29 +10,26 @@ import spinal.lib.bus.misc._
 import spinal.lib.bus.amba3.apb._
 import spinal.lib.bus.avalon._
 import spinal.lib.bus.wishbone._
+import nafarr.Feature
+import nafarr.peripherals.PeripheralsComponent
 
 object AesMaskedAccelerator {
   class Core[T <: spinal.core.Data with IMasterSlave](
       p: AesMaskedAcceleratorCtrl.Parameter,
       busType: HardType[T],
       factory: T => BusSlaveFactory
-  ) extends Component {
+  ) extends PeripheralsComponent {
     val io = new Bundle {
       val bus = slave(busType())
     }
     val ctrl = AesMaskedAcceleratorCtrl(p)
     val mapper = AesMaskedAcceleratorCtrl.Mapper(factory(io.bus), ctrl.io, p)
 
-    def headerBareMetal(
-        name: String,
-        address: BigInt,
-        size: BigInt,
-        irqNumber: Option[Int] = null
-    ) = {
+    override def sysconFeatures = Some(List(Feature.Aes))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
       val baseAddress = "%08x".format(address.toInt)
-      val regSize = "%04x".format(size.toInt)
-      var dt = s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
-      dt
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
     }
   }
 }

--- a/hardware/scala/nafarr/crypto/crc/Crc32.scala
+++ b/hardware/scala/nafarr/crypto/crc/Crc32.scala
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.crypto.crc
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.BusSlaveFactory
+import spinal.lib.bus.amba3.apb._
+import spinal.lib.bus.tilelink.{
+  Bus => TileLinkBus,
+  BusParameter => TileLinkParameter,
+  SlaveFactory => TileLinkSlaveFactory
+}
+import spinal.lib.bus.wishbone._
+import nafarr.peripherals.PeripheralsComponent
+import nafarr.Feature
+
+object Crc32 {
+
+  class Core[T <: spinal.core.Data with IMasterSlave](
+      p: Crc32Ctrl.Parameter,
+      busType: HardType[T],
+      factory: T => BusSlaveFactory
+  ) extends PeripheralsComponent {
+    val io = new Bundle {
+      val bus = slave(busType())
+    }
+    val busCtrl = factory(io.bus)
+    val ctrl = Crc32Ctrl(p)
+    val mapper = Crc32Ctrl.Mapper(busCtrl, ctrl, p)
+
+    override def sysconFeatures = Some(List(Feature.Crc))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
+      val baseAddress = "%08x".format(address.toInt)
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
+    }
+  }
+}
+
+case class Apb3Crc32(
+    p: Crc32Ctrl.Parameter = Crc32Ctrl.Parameter(),
+    busConfig: Apb3Config = Apb3Config(8, 32)
+) extends Crc32.Core[Apb3](
+      p,
+      Apb3(busConfig),
+      Apb3SlaveFactory(_)
+    )
+
+case class TileLinkCrc32(
+    p: Crc32Ctrl.Parameter = Crc32Ctrl.Parameter(),
+    busConfig: TileLinkParameter = TileLinkParameter.simple(8, 32, 4, 1)
+) extends Crc32.Core[TileLinkBus](
+      p,
+      TileLinkBus(busConfig),
+      new TileLinkSlaveFactory(_, false)
+    )
+
+case class WishboneCrc32(
+    p: Crc32Ctrl.Parameter = Crc32Ctrl.Parameter(),
+    busConfig: WishboneConfig = WishboneConfig(8, 32)
+) extends Crc32.Core[Wishbone](
+      p,
+      Wishbone(busConfig),
+      WishboneSlaveFactory(_)
+    )

--- a/hardware/scala/nafarr/crypto/crc/Crc32Ctrl.scala
+++ b/hardware/scala/nafarr/crypto/crc/Crc32Ctrl.scala
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.crypto.crc
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.BusSlaveFactory
+import spinal.crypto.checksum._
+import spinal.crypto._
+
+import nafarr.IpIdentification
+
+object Crc32Ctrl {
+  def apply(p: Parameter = Parameter()) = Crc32Ctrl(p)
+
+  object Regs {
+    def apply(base: BigInt) = new Regs(base)
+  }
+  class Regs(base: BigInt) {
+    val info = base + 0x00
+    val control = base + 0x04
+    val data = base + 0x08
+    val result = base + 0x0c
+    val xorOut = base + 0x10
+  }
+
+  /** Selects the CRC polynomial and its standard parameters.
+    *
+    * polynomial : CRCPolynomial from SpinalCrypto (e.g. CRC32.Standard).
+    */
+  case class InitParameter(
+      polynomial: CRCPolynomial = CRC32.Standard
+  )
+  object InitParameter {
+    def crc32() = InitParameter(CRC32.Standard)
+    def crc32xfer() = InitParameter(CRC32.XFER)
+  }
+
+  case class Parameter(
+      init: InitParameter = InitParameter.crc32(),
+      inputReflect: Boolean = true,
+      outputReflect: Boolean = true,
+      xorOut: Boolean = false
+  )
+  object Parameter {
+    def default() = Parameter()
+    def withXorOut() = Parameter(xorOut = true)
+  }
+
+  /** Build a CRCCombinationalConfig from a Parameter.
+    *
+    * finalXor is always set to 0 here; XOR-out is applied by the Mapper so
+    * that an optional runtime-configurable xorOut register can be used.
+    */
+  def config(p: Parameter) = CRCCombinationalConfig(
+    new CRCPolynomial(
+      polynomial = p.init.polynomial.polynomial,
+      initValue = p.init.polynomial.initValue,
+      inputReflected = p.inputReflect,
+      outputReflected = p.outputReflect,
+      finalXor = 0
+    ),
+    32 bits
+  )
+
+  /** CRC32 accelerator core.
+    *
+    * io.cmd    : slave Flow — INIT reloads the init value; UPDATE folds one
+    *             32-bit word into the CRC state.
+    * io.result : out — current CRC state, without finalXor (handled by Mapper).
+    */
+  case class Crc32Ctrl(p: Parameter) extends Component {
+    val cfg = config(p)
+
+    val io = new Bundle {
+      val cmd = slave Flow (CRCCombinationalCmd(cfg))
+      val result = out Bits (32 bits)
+    }
+
+    val crc = new CRCCombinational(cfg)
+    crc.io.cmd <> io.cmd
+    io.result := crc.io.crc
+  }
+
+  case class Mapper(
+      busCtrl: BusSlaveFactory,
+      ctrl: Crc32Ctrl,
+      p: Parameter
+  ) extends Area {
+    val idCtrl = IpIdentification(IpIdentification.Ids.Crc32, 1, 0, 0)
+    idCtrl.driveFrom(busCtrl)
+    val regs = Regs(idCtrl.length)
+
+    // Info: self-disclosure register.
+    //   bits[ 7: 0] = polynomial order (e.g. 32 for CRC32)
+    //   bit       8  = inputReflect
+    //   bit       9  = outputReflect
+    //   bit      10  = xorOut register present
+    busCtrl.read(
+      B(0, 21 bits) ##
+        Bool(p.xorOut) ##
+        Bool(p.outputReflect) ##
+        Bool(p.inputReflect) ##
+        B(p.init.polynomial.polynomial.order, 8 bits),
+      regs.info
+    )
+
+    // Control: any bus write triggers CRC init (reloads init value into state).
+    val initPulse = Bool()
+    initPulse := False
+    busCtrl.onWrite(regs.control) {
+      initPulse := True
+    }
+
+    // Data: bus write folds one 32-bit word into the CRC state.
+    val dataFlow = busCtrl.createAndDriveFlow(Bits(32 bits), regs.data)
+
+    // Drive CRC command. INIT takes priority; a bus can only issue one write
+    // per cycle so both flags cannot be high simultaneously in practice.
+    ctrl.io.cmd.valid := initPulse || dataFlow.valid
+    ctrl.io.cmd.mode := CRCCombinationalCmdMode.UPDATE
+    when(initPulse) {
+      ctrl.io.cmd.mode := CRCCombinationalCmdMode.INIT
+    }
+    ctrl.io.cmd.data := dataFlow.payload
+
+    // XorOut register (present only when p.xorOut = true).
+    // Initialised from the polynomial's standard finalXor value so that the
+    // default configuration matches the chosen CRC standard out of reset.
+    // When disabled, reads as zero and the result register is not XOR-ed.
+    // Result: current CRC state XOR xorOut (hardware finalises the standard).
+    if (p.xorOut) {
+      val xorOutReg = Reg(Bits(32 bits)) init (B(p.init.polynomial.finalXor, 32 bits))
+      busCtrl.read(ctrl.io.result ^ xorOutReg, regs.result)
+      busCtrl.readAndWrite(xorOutReg, regs.xorOut)
+    } else {
+      busCtrl.read(ctrl.io.result, regs.result)
+      busCtrl.read(B(0, 32 bits), regs.xorOut)
+    }
+  }
+}

--- a/hardware/scala/nafarr/crypto/prng/Prng.scala
+++ b/hardware/scala/nafarr/crypto/prng/Prng.scala
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.crypto.prng
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.BusSlaveFactory
+import spinal.lib.bus.amba3.apb._
+import spinal.lib.bus.tilelink.{
+  Bus => TileLinkBus,
+  BusParameter => TileLinkParameter,
+  SlaveFactory => TileLinkSlaveFactory
+}
+import spinal.lib.bus.wishbone._
+import nafarr.peripherals.PeripheralsComponent
+import nafarr.Feature
+
+object Prng {
+
+  class Core[T <: spinal.core.Data with IMasterSlave](
+      p: PrngCtrl.Parameter,
+      busType: HardType[T],
+      factory: T => BusSlaveFactory
+  ) extends PeripheralsComponent {
+    val io = new Bundle {
+      val bus = slave(busType())
+      val error = out Bool ()
+    }
+    val busCtrl = factory(io.bus)
+    val ctrl = PrngCtrl(p)
+    val mapper = PrngCtrl.Mapper(busCtrl, ctrl, p)
+    io.error := ctrl.io.error
+
+    override def getError = Some(io.error)
+    override def sysconFeatures = Some(List(Feature.Prng))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
+      val baseAddress = "%08x".format(address.toInt)
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
+    }
+  }
+}
+
+case class Apb3Prng(
+    p: PrngCtrl.Parameter = PrngCtrl.Parameter(),
+    busConfig: Apb3Config = Apb3Config(8, 32)
+) extends Prng.Core[Apb3](
+      p,
+      Apb3(busConfig),
+      Apb3SlaveFactory(_)
+    )
+
+case class TileLinkPrng(
+    p: PrngCtrl.Parameter = PrngCtrl.Parameter(),
+    busConfig: TileLinkParameter = TileLinkParameter.simple(8, 32, 4, 1)
+) extends Prng.Core[TileLinkBus](
+      p,
+      TileLinkBus(busConfig),
+      new TileLinkSlaveFactory(_, false)
+    )
+
+case class WishbonePrng(
+    p: PrngCtrl.Parameter = PrngCtrl.Parameter(),
+    busConfig: WishboneConfig = WishboneConfig(8, 32)
+) extends Prng.Core[Wishbone](
+      p,
+      Wishbone(busConfig),
+      WishboneSlaveFactory(_)
+    )

--- a/hardware/scala/nafarr/crypto/prng/PrngCtrl.scala
+++ b/hardware/scala/nafarr/crypto/prng/PrngCtrl.scala
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.crypto.prng
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.BusSlaveFactory
+import spinal.lib.misc.InterruptCtrl
+import spinal.crypto.misc.LFSR
+
+import nafarr.IpIdentification
+
+object PrngCtrl {
+  def apply(p: Parameter = Parameter()) = PrngCtrl(p)
+
+  case class Parameter()
+  object Parameter {
+    def default() = Parameter()
+  }
+
+  object Regs {
+    def apply(base: BigInt) = new Regs(base)
+  }
+  class Regs(base: BigInt) {
+    val control = base + 0x00
+    val errorPending = base + 0x04
+    val errorMask = base + 0x08
+    val seed = base + 0x0c
+    val output = base + 0x10
+  }
+
+  /** Galois LFSR core with enable and external reseed.
+    *
+    * Advances the 32-bit state by one step per enabled clock cycle using the
+    * Galois topology and maximum-period taps (x^32 + x^30 + x^26 + x^25 + 1).
+    *
+    * The caller is responsible for never asserting io.reseed with a zero seed —
+    * a zero state causes the LFSR to lock up permanently.
+    *
+    * io.seed          : in  — new seed value; sampled when io.reseed is asserted.
+    * io.reseed        : in  — pulse to load io.seed into the state register.
+    * io.enable        : in  — advance the LFSR each clock cycle when True.
+    * io.output        : out — current LFSR state.
+    * io.error         : out — combined error signal (OR of masked pending errors).
+    * io.pendingErrors : in  — masked pending error bits driven by the Mapper.
+    */
+  case class PrngCtrl(p: Parameter) extends Component {
+    val io = new Bundle {
+      val seed = in Bits (32 bits)
+      val reseed = in Bool ()
+      val enable = in Bool ()
+      val output = out Bits (32 bits)
+      val error = out Bool ()
+      val pendingErrors = in Bits (1 bits)
+    }
+
+    val state = Reg(Bits(32 bits)) init (1)
+
+    when(io.reseed) {
+      state := io.seed
+    } elsewhen (io.enable) {
+      state := LFSR.Galois(state, LFSR.taps_32bits)
+    }
+
+    io.output := state
+    io.error := io.pendingErrors.orR
+  }
+
+  case class Mapper(
+      busCtrl: BusSlaveFactory,
+      ctrl: PrngCtrl,
+      p: Parameter
+  ) extends Area {
+    val idCtrl = IpIdentification(IpIdentification.Ids.Prng, 1, 0, 0)
+    idCtrl.driveFrom(busCtrl)
+    val regs = Regs(idCtrl.length)
+
+    // Control: bit 0 = enable. PRNG runs freely by default.
+    val enable = Reg(Bool()) init (True)
+    busCtrl.readAndWrite(enable, regs.control)
+
+    // Error: InterruptCtrl with one source — zero seed write attempt.
+    // Pending and mask registers are created at errorPending and errorMask.
+    val errCtrl = new InterruptCtrl(1)
+    errCtrl.driveFrom(busCtrl, regs.errorPending.toInt)
+
+    val seedFlow = busCtrl.createAndDriveFlow(Bits(32 bits), regs.seed)
+
+    errCtrl.io.inputs(0) := seedFlow.valid && (seedFlow.payload === 0)
+    ctrl.io.pendingErrors := errCtrl.io.pendings
+
+    // Output: read-only, returns current LFSR state.
+    busCtrl.read(ctrl.io.output, regs.output)
+
+    ctrl.io.seed := seedFlow.payload
+    ctrl.io.reseed := seedFlow.valid && (seedFlow.payload =/= 0)
+    ctrl.io.enable := enable
+  }
+}

--- a/hardware/scala/nafarr/memory/hyperbus/HyperBus.scala
+++ b/hardware/scala/nafarr/memory/hyperbus/HyperBus.scala
@@ -11,6 +11,8 @@ import spinal.lib.bus.amba3.apb._
 import spinal.lib.bus.avalon._
 import spinal.lib.bus.wishbone._
 import spinal.lib.io.{TriStateArray, TriState}
+import nafarr.Feature
+import nafarr.peripherals.PeripheralsComponent
 
 object HyperBus {
 
@@ -144,7 +146,7 @@ object HyperBus {
       p: HyperBusCtrl.Parameter,
       busType: HardType[T],
       factory: T => BusSlaveFactory
-  ) extends Component {
+  ) extends PeripheralsComponent {
     val io = new Bundle {
       val bus = slave(busType())
       val phy = master(Phy.Interface(p))
@@ -159,18 +161,11 @@ object HyperBus {
 
     val mapper = HyperBusCtrl.Mapper(factory(io.bus), ctrl.io, p)
 
-    def headerBareMetal(
-        name: String,
-        address: BigInt,
-        size: BigInt,
-        irqNumber: Option[Int] = null
-    ) = {
+    override def sysconFeatures = Some(List(Feature.Hyperbus))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
       val baseAddress = "%08x".format(address.toInt)
-      val regSize = "%04x".format(size.toInt)
-      var dt = s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
-      if (irqNumber.isDefined)
-        dt += s"""#define ${name.toUpperCase}_IRQ\t\t${irqNumber.get}\n"""
-      dt
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
     }
   }
 }

--- a/hardware/scala/nafarr/peripherals/Common.scala
+++ b/hardware/scala/nafarr/peripherals/Common.scala
@@ -6,6 +6,7 @@ package nafarr.peripherals
 
 import spinal.core._
 import spinal.lib._
+import nafarr.Feature
 
 abstract class PeripheralsComponent extends Component {
   def deviceTreeZephyr(
@@ -20,4 +21,17 @@ abstract class PeripheralsComponent extends Component {
       size: BigInt,
       irqNumber: Option[Int] = null
   ): String
+
+  /** Returns the SoC feature flags this IP contributes to the syscon feature register.
+    *
+    * Override to report one or more [[Feature]] elements. The SoC builder collects
+    * these across all IPs on each bus and passes the deduplicated list to
+    * `SysconCtrl.Parameter`. Returns `None` by default (no feature advertised).
+    *
+    * Example (an IP that provides both AES and a generic crypto flag):
+    * {{{
+    *   override def sysconFeatures = Some(List(Feature.Aes))
+    * }}}
+    */
+  def sysconFeatures: Option[List[Feature.E]] = None
 }

--- a/hardware/scala/nafarr/peripherals/Common.scala
+++ b/hardware/scala/nafarr/peripherals/Common.scala
@@ -9,18 +9,31 @@ import spinal.lib._
 import nafarr.Feature
 
 abstract class PeripheralsComponent extends Component {
-  def deviceTreeZephyr(
-      name: String,
-      address: BigInt,
-      size: BigInt,
-      irqNumber: Option[Int] = null
-  ): String
-  def headerBareMetal(
-      name: String,
-      address: BigInt,
-      size: BigInt,
-      irqNumber: Option[Int] = null
-  ): String
+
+  /** Generates a C header snippet for this IP's base address and any
+    * IRQ/error number macros.
+    *
+    * Called by [[zibal.misc.BaremetalTools]] during SoC generation.
+    * `name` is the SpinalHDL component name (e.g. `"gpio0Ctrl"`), `address`
+    * is the absolute bus address, and `size` is the mapping size in bytes.
+    *
+    * Each implementation should emit at minimum:
+    * {{{
+    *   #define <NAME>_BASE   0x<address>
+    * }}}
+    * IRQ and error number macros are appended automatically by the tools layer.
+    */
+  def headerBareMetal(name: String, address: BigInt, size: BigInt): String
+
+  /** Returns the interrupt output signal for IRQ-number lookup in header generation.
+    * Override in Core classes that have an interrupt output.
+    */
+  def getInterrupt: Option[Bool] = None
+
+  /** Returns the error output signal for ESM wiring and header generation.
+    * Override in Core classes that have an error output.
+    */
+  def getError: Option[Bool] = None
 
   /** Returns the SoC feature flags this IP contributes to the syscon feature register.
     *

--- a/hardware/scala/nafarr/peripherals/com/i2c/I2cController.scala
+++ b/hardware/scala/nafarr/peripherals/com/i2c/I2cController.scala
@@ -14,6 +14,8 @@ import spinal.lib.bus.tilelink.{
   SlaveFactory => TileLinkSlaveFactory
 }
 import spinal.lib.bus.wishbone._
+import nafarr.Feature
+import nafarr.peripherals.PeripheralsComponent
 
 object I2cController {
   case class Cmd() extends Bundle {
@@ -33,7 +35,7 @@ object I2cController {
       p: I2cControllerCtrl.Parameter,
       busType: HardType[T],
       factory: T => BusSlaveFactory
-  ) extends Component {
+  ) extends PeripheralsComponent {
     val io = new Bundle {
       val bus = slave(busType())
       val i2c = master(I2c.Io(p.io))
@@ -47,44 +49,14 @@ object I2cController {
     val mapper = I2cControllerCtrl.Mapper(factory(io.bus), i2cControllerCtrl.io, p)
 
     val clockSpeed = ClockDomain.current.frequency.getValue.toInt
-    def deviceTreeZephyr(
-        name: String,
-        address: BigInt,
-        size: BigInt,
-        irqNumber: Option[Int] = null
-    ) = {
-      val baseAddress = "%x".format(address.toInt)
-      val regSize = "%04x".format(size.toInt)
-      var dt = s"""
-\t\t$name: $name@$baseAddress {
-\t\t\tcompatible = "elements,i2c";
-\t\t\treg = <0x$baseAddress 0x$regSize>;
-\t\t\tstatus = "okay";"""
-      if (irqNumber.isDefined) {
-        dt += s"""
-\t\t\tinterrupt-parent = <&plic>;
-\t\t\tinterrupts = <${irqNumber.get} 1>;"""
-      }
-      dt += s"""
-\t\t\tinput-frequency = <$clockSpeed>;
-\t\t\tclock-frequency = <100000>;
-\t\t};"""
-      dt
-    }
-    def headerBareMetal(
-        name: String,
-        address: BigInt,
-        size: BigInt,
-        irqNumber: Option[Int] = null
-    ) = {
+    override def getInterrupt = Some(io.interrupt)
+    override def sysconFeatures = Some(List(Feature.I2c))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
       val baseAddress = "%08x".format(address.toInt)
-      val regSize = "%04x".format(size.toInt)
-      var dt = s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}
 #define ${name.toUpperCase}_FREQ\t\t${clockSpeed}
 """
-      if (irqNumber.isDefined)
-        dt += s"""#define ${name.toUpperCase}_IRQ\t\t${irqNumber.get}\n"""
-      dt
     }
   }
 }

--- a/hardware/scala/nafarr/peripherals/com/spi/SpiController.scala
+++ b/hardware/scala/nafarr/peripherals/com/spi/SpiController.scala
@@ -14,6 +14,7 @@ import spinal.lib.bus.tilelink.{
   SlaveFactory => TileLinkSlaveFactory
 }
 import spinal.lib.bus.wishbone._
+import nafarr.Feature
 import nafarr.peripherals.PeripheralsComponent
 
 object SpiController {
@@ -79,40 +80,12 @@ object SpiController {
     SpiControllerCtrl.Mapper(busFactory, spiControllerCtrl.io, p)
     SpiControllerCtrl.StreamMapper(busFactory, spiControllerCtrl.io, p)
 
-    def deviceTreeZephyr(
-        name: String,
-        address: BigInt,
-        size: BigInt,
-        irqNumber: Option[Int] = null
-    ) = {
-      val baseAddress = "%x".format(address.toInt)
-      val regSize = "%04x".format(size.toInt)
-      var dt = s"""
-\t\t$name: $name@$baseAddress {
-\t\t\tcompatible = "elements,spi";
-\t\t\treg = <0x$baseAddress 0x$regSize>;
-\t\t\tstatus = "okay";"""
-      if (irqNumber.isDefined) {
-        dt += s"""
-\t\t\tinterrupt-parent = <&plic>;
-\t\t\tinterrupts = <$irqNumber 1>;"""
-      }
-      dt += s"""
-\t\t};"""
-      dt
-    }
-    def headerBareMetal(
-        name: String,
-        address: BigInt,
-        size: BigInt,
-        irqNumber: Option[Int] = null
-    ) = {
+    override def getInterrupt = Some(io.interrupt)
+    override def sysconFeatures = Some(List(Feature.Spi))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
       val baseAddress = "%08x".format(address.toInt)
-      val regSize = "%04x".format(size.toInt)
-      var dt = s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
-      if (irqNumber.isDefined)
-        dt += s"""#define ${name.toUpperCase}_IRQ\t\t${irqNumber.get}\n"""
-      dt
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
     }
   }
 }

--- a/hardware/scala/nafarr/peripherals/com/uart/Uart.scala
+++ b/hardware/scala/nafarr/peripherals/com/uart/Uart.scala
@@ -14,6 +14,8 @@ import spinal.lib.bus.tilelink.{
   SlaveFactory => TileLinkSlaveFactory
 }
 import spinal.lib.bus.wishbone._
+import nafarr.Feature
+import nafarr.peripherals.PeripheralsComponent
 
 object Uart {
   case class Io(p: UartCtrl.Parameter) extends Bundle with IMasterSlave {
@@ -49,60 +51,32 @@ object Uart {
       p: UartCtrl.Parameter,
       busType: HardType[T],
       factory: T => BusSlaveFactory
-  ) extends Component {
+  ) extends PeripheralsComponent {
     val io = new Bundle {
       val bus = slave(busType())
       val uart = master(Io(p))
       val interrupt = out(Bool)
+      val error = out(Bool)
     }
 
     val ctrl = UartCtrl(p)
     ctrl.io.uart <> io.uart
     io.interrupt := ctrl.io.interrupt
+    io.error := ctrl.io.error
 
     val mapper = UartCtrl.Mapper(factory(io.bus), ctrl.io, p)
 
     val clockSpeed = ClockDomain.current.frequency.getValue.toInt
-    def deviceTreeZephyr(
-        name: String,
-        address: BigInt,
-        size: BigInt,
-        irqNumber: Option[Int] = null
-    ) = {
-      val baseAddress = "%x".format(address.toInt)
-      val regSize = "%04x".format(size.toInt)
-      val baudrate = this.p.init.baudrate
-      var dt = s"""
-\t\t$name: $name@$baseAddress {
-\t\t\tcompatible = "elements,uart";
-\t\t\treg = <0x$baseAddress 0x$regSize>;
-\t\t\tstatus = "okay";"""
-      if (irqNumber.isDefined) {
-        dt += s"""
-\t\t\tinterrupt-parent = <&plic>;
-\t\t\tinterrupts = <${irqNumber.get} 1>;"""
-      }
-      dt += s"""
-\t\t\tclock-frequency = <$clockSpeed>;
-\t\t\tcurrent-speed = <$baudrate>;
-\t\t};"""
-      dt
-    }
-    def headerBareMetal(
-        name: String,
-        address: BigInt,
-        size: BigInt,
-        irqNumber: Option[Int] = null
-    ) = {
+    override def getInterrupt = Some(io.interrupt)
+    override def getError = Some(io.error)
+    override def sysconFeatures = Some(List(Feature.Uart))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
       val baseAddress = "%08x".format(address.toInt)
-      val regSize = "%04x".format(size.toInt)
-      var dt = s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}
 #define ${name.toUpperCase}_FREQ\t\t${clockSpeed}
 #define ${name.toUpperCase}_BAUD\t\t${this.p.init.baudrate}
 """
-      if (irqNumber.isDefined)
-        dt += s"""#define ${name.toUpperCase}_IRQ\t\t${irqNumber.get}\n"""
-      dt
     }
   }
 }

--- a/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.scala
+++ b/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.scala
@@ -147,6 +147,8 @@ object UartCtrl {
     val uart = master(Uart.Io(p))
     val interrupt = out(Bool)
     val pendingInterrupts = in(Bits(3 bits))
+    val error = out(Bool)
+    val pendingErrors = in(Bits(3 bits))
     val write = slave(Stream(Bits(p.dataWidthMax bits)))
     val read = master(Stream(Bits(p.dataWidthMax bits)))
     val readIsFull = in(Bool)
@@ -163,6 +165,7 @@ object UartCtrl {
     clockDivider.io.reload := io.config.clockDividerReload
 
     io.interrupt := io.pendingInterrupts.orR
+    io.error := io.pendingErrors.orR
 
     val tx = UartCtrlTx(p)
     tx.io.config <> io.frameConfig
@@ -304,6 +307,9 @@ object UartCtrl {
         errorCtrl.io.inputs(0) := ctrl.framingError
         errorCtrl.io.inputs(1) := ctrl.parityError
         errorCtrl.io.inputs(2) := ctrl.readIsFull && ctrl.read.valid
+        ctrl.pendingErrors := errorCtrl.io.pendings
+      } else {
+        ctrl.pendingErrors := 0
       }
     }
   }

--- a/hardware/scala/nafarr/peripherals/io/gpio/Gpio.scala
+++ b/hardware/scala/nafarr/peripherals/io/gpio/Gpio.scala
@@ -15,6 +15,7 @@ import spinal.lib.bus.tilelink.{
 }
 import spinal.lib.bus.wishbone._
 import spinal.lib.io.{TriStateArray, TriState}
+import nafarr.Feature
 import nafarr.peripherals.PeripheralsComponent
 
 object Gpio {
@@ -43,42 +44,12 @@ object Gpio {
 
     val mapper = GpioCtrl.Mapper(factory(io.bus), ctrl.io, p)
 
-    def deviceTreeZephyr(
-        name: String,
-        address: BigInt,
-        size: BigInt,
-        irqNumber: Option[Int] = None
-    ) = {
-      val baseAddress = "%x".format(address.toInt)
-      val regSize = "%04x".format(size.toInt)
-      var dt = s"""
-\t\t$name: $name@$baseAddress {
-\t\t\tcompatible = "aesc,gpio";
-\t\t\treg = <0x$baseAddress 0x$regSize>;"""
-      if (irqNumber.isDefined) {
-        dt += s"""
-\t\t\tinterrupt-parent = <&plic>;
-\t\t\tinterrupts = <$irqNumber 1>;"""
-      }
-      dt += s"""
-\t\t\tgpio-controller;
-\t\t\t#gpio-cells = <2>;
-\t\t\tstatus = "okay";
-\t\t};"""
-      dt
-    }
-    def headerBareMetal(
-        name: String,
-        address: BigInt,
-        size: BigInt,
-        irqNumber: Option[Int] = None
-    ) = {
+    override def getInterrupt = Some(io.interrupt)
+    override def sysconFeatures = Some(List(Feature.Gpio))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
       val baseAddress = "%08x".format(address.toInt)
-      val regSize = "%04x".format(size.toInt)
-      var dt = s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
-      if (irqNumber.isDefined)
-        dt += s"""#define ${name.toUpperCase}_IRQ\t\t${irqNumber.get}\n"""
-      dt
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
     }
   }
 }

--- a/hardware/scala/nafarr/peripherals/io/pio/Pio.scala
+++ b/hardware/scala/nafarr/peripherals/io/pio/Pio.scala
@@ -15,6 +15,8 @@ import spinal.lib.bus.tilelink.{
 }
 import spinal.lib.bus.wishbone._
 import spinal.lib.io.{TriStateArray, TriState}
+import nafarr.Feature
+import nafarr.peripherals.PeripheralsComponent
 
 object Pio {
   case class Parameter(width: Int) {
@@ -29,31 +31,28 @@ object Pio {
       parameter: PioCtrl.Parameter,
       busType: HardType[T],
       factory: T => BusSlaveFactory
-  ) extends Component {
+  ) extends PeripheralsComponent {
     val io = new Bundle {
       val bus = slave(busType())
       val pio = Io(parameter.io)
       val interrupt = out(Bool)
+      val error = out(Bool)
     }
 
     val ctrl = PioCtrl(parameter)
     ctrl.io.pio <> io.pio
     io.interrupt <> ctrl.io.interrupt
+    io.error := ctrl.io.error
 
     val mapper = PioCtrl.Mapper(factory(io.bus), ctrl.io, parameter)
 
-    def headerBareMetal(
-        name: String,
-        address: BigInt,
-        size: BigInt,
-        irqNumber: Option[Int] = None
-    ) = {
+    override def getInterrupt = Some(io.interrupt)
+    override def getError = Some(io.error)
+    override def sysconFeatures = Some(List(Feature.Pio))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
       val baseAddress = "%08x".format(address.toInt)
-      val regSize = "%04x".format(size.toInt)
-      var dt = s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
-      if (irqNumber.isDefined)
-        dt += s"""#define ${name.toUpperCase}_IRQ\t\t${irqNumber.get}\n"""
-      dt
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
     }
   }
 }

--- a/hardware/scala/nafarr/peripherals/io/pio/PioCtrl.scala
+++ b/hardware/scala/nafarr/peripherals/io/pio/PioCtrl.scala
@@ -122,6 +122,8 @@ object PioCtrl {
     val pio = Pio.Io(parameter.io)
     val interrupt = out(Bool)
     val pendingInterrupts = in(Bits(2 bits))
+    val error = out(Bool)
+    val pendingErrors = in(Bits(1 bits))
     val config = in(Config(parameter))
     val programWrite = slave(Flow(CommandContainer(parameter)))
     val writePtr = out(UInt(log2Up(parameter.memory.commandFifoDepth) bits))
@@ -145,6 +147,7 @@ object PioCtrl {
     clockDivider.io.reload := False
 
     io.interrupt := io.pendingInterrupts.orR
+    io.error := io.pendingErrors.orR
     io.loopDone := False
 
     // Program memory
@@ -464,6 +467,9 @@ object PioCtrl {
         val errorCtrl = new InterruptCtrl(1)
         errorCtrl.driveFrom(busCtrl, regs.errorPending.toInt)
         errorCtrl.io.inputs(0) := rx.readIsFull && ctrl.read.valid // read FIFO is full error
+        ctrl.pendingErrors := errorCtrl.io.pendings
+      } else {
+        ctrl.pendingErrors := 0
       }
     }
 

--- a/hardware/scala/nafarr/peripherals/io/pwm/Pwm.scala
+++ b/hardware/scala/nafarr/peripherals/io/pwm/Pwm.scala
@@ -14,6 +14,8 @@ import spinal.lib.bus.tilelink.{
   SlaveFactory => TileLinkSlaveFactory
 }
 import spinal.lib.bus.wishbone._
+import nafarr.Feature
+import nafarr.peripherals.PeripheralsComponent
 
 object Pwm {
   case class Parameter(channels: Int) {
@@ -32,29 +34,28 @@ object Pwm {
       p: PwmCtrl.Parameter,
       busType: HardType[T],
       factory: T => BusSlaveFactory
-  ) extends Component {
+  ) extends PeripheralsComponent {
     val io = new Bundle {
       val bus = slave(busType())
       val pwm = Io(p.io)
       val interrupt = out(Bool)
+      val error = out(Bool)
     }
 
     val ctrl = PwmCtrl(p)
     ctrl.io.pwm <> io.pwm
     io.interrupt := ctrl.io.interrupt
+    io.error := ctrl.io.error
 
     val mapper = PwmCtrl.Mapper(factory(io.bus), ctrl.io, p)
 
-    def headerBareMetal(
-        name: String,
-        address: BigInt,
-        size: BigInt,
-        irqNumber: Option[Int] = null
-    ) = {
+    override def getInterrupt = Some(io.interrupt)
+    override def getError = Some(io.error)
+    override def sysconFeatures = Some(List(Feature.Pwm))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
       val baseAddress = "%08x".format(address.toInt)
-      val regSize = "%04x".format(size.toInt)
-      var dt = s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
-      dt
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
     }
   }
 }

--- a/hardware/scala/nafarr/peripherals/io/pwm/PwmCtrl.scala
+++ b/hardware/scala/nafarr/peripherals/io/pwm/PwmCtrl.scala
@@ -90,6 +90,7 @@ object PwmCtrl {
     val irqPeriodComplete = InterruptConfig(p)
     val faultError = out(Bool)
     val errorPending = in(Bool)
+    val error = out(Bool)
   }
 
   case class PwmCtrl(p: Parameter) extends Component {
@@ -240,6 +241,7 @@ object PwmCtrl {
 
     val faultInPrev = RegNext(io.pwm.faultIn, False)
     io.faultError := io.pwm.faultIn && !faultInPrev
+    io.error := io.errorPending
 
     io.interrupt := io.irqPeriodComplete.pending.orR
   }

--- a/hardware/scala/nafarr/peripherals/pinmux/Pinmux.scala
+++ b/hardware/scala/nafarr/peripherals/pinmux/Pinmux.scala
@@ -17,6 +17,8 @@ import spinal.lib.bus.wishbone._
 import spinal.lib.io.{TriStateArray, TriState}
 
 import scala.collection.mutable.ArrayBuffer
+import nafarr.Feature
+import nafarr.peripherals.PeripheralsComponent
 
 object Pinmux {
   case class Parameter(width: Int) {
@@ -32,7 +34,7 @@ object Pinmux {
       mapping: ArrayBuffer[(Int, List[Int])],
       busType: HardType[T],
       factory: T => BusSlaveFactory
-  ) extends Component {
+  ) extends PeripheralsComponent {
     val io = new Bundle {
       val bus = slave(busType())
       val pins = Io(p.io)
@@ -43,16 +45,11 @@ object Pinmux {
     ctrl.io.inputs <> io.inputs
     val mapper = PinmuxCtrl.Mapper(factory(io.bus), ctrl.io, p)
 
-    def headerBareMetal(
-        name: String,
-        address: BigInt,
-        size: BigInt,
-        irqNumber: Option[Int] = null
-    ) = {
+    override def sysconFeatures = Some(List(Feature.Pinmux))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
       val baseAddress = "%08x".format(address.toInt)
-      val regSize = "%04x".format(size.toInt)
-      var dt = s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
-      dt
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
     }
   }
 }

--- a/hardware/scala/nafarr/system/clock/ClockController.scala
+++ b/hardware/scala/nafarr/system/clock/ClockController.scala
@@ -15,7 +15,8 @@ import spinal.lib.bus.tilelink.{
 }
 import spinal.lib.bus.wishbone._
 
-import nafarr.IpIdentification
+import nafarr.{Feature, IpIdentification}
+import nafarr.peripherals.PeripheralsComponent
 
 case class ClockParameter(
     name: String,
@@ -31,7 +32,7 @@ object ClockController {
       p: ClockControllerCtrl.Parameter,
       busType: HardType[T],
       factory: T => BusSlaveFactory
-  ) extends Component {
+  ) extends PeripheralsComponent {
     val io = new Bundle {
       val bus = slave(busType())
       val config = out(ClockControllerCtrl.Config(p))
@@ -45,6 +46,13 @@ object ClockController {
     busCtrl.read(B(p.domains.length, 8 bits), regs.domains)
 
     busCtrl.driveAndRead(io.config.enable, regs.enable).init(U((0 until p.domains.length) -> true))
+
+    override def sysconFeatures = Some(List(Feature.Clock))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
+      val baseAddress = "%08x".format(address.toInt)
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
+    }
   }
 }
 

--- a/hardware/scala/nafarr/system/esm/Esm.scala
+++ b/hardware/scala/nafarr/system/esm/Esm.scala
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.system.esm
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.BusSlaveFactory
+import spinal.lib.bus.amba3.apb._
+import spinal.lib.bus.tilelink.{
+  Bus => TileLinkBus,
+  BusParameter => TileLinkParameter,
+  SlaveFactory => TileLinkSlaveFactory
+}
+import spinal.lib.bus.wishbone._
+import nafarr.Feature
+import nafarr.peripherals.PeripheralsComponent
+
+object Esm {
+
+  class Core[T <: spinal.core.Data with IMasterSlave](
+      p: EsmCtrl.Parameter,
+      busType: HardType[T],
+      factory: T => BusSlaveFactory
+  ) extends PeripheralsComponent {
+    val io = new Bundle {
+      val bus = slave(busType())
+      val inputs = in(Bits(p.inputCount bits))
+      val infoInterrupt = out Bool ()
+      val warnInterrupt = out Bool ()
+      val errorSignal = out Bool ()
+    }
+    val busCtrl = factory(io.bus)
+    val ctrl = EsmCtrl(p)
+    val mapper = EsmCtrl.Mapper(busCtrl, ctrl, p)
+    ctrl.io.inputs := io.inputs
+    io.infoInterrupt := ctrl.io.infoInterrupt
+    io.warnInterrupt := ctrl.io.warnInterrupt
+    io.errorSignal := ctrl.io.errorSignal
+
+    override def sysconFeatures = Some(List(Feature.Esm))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
+      val baseAddress = "%08x".format(address.toInt)
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
+    }
+  }
+}
+
+case class Apb3Esm(
+    p: EsmCtrl.Parameter,
+    busConfig: Apb3Config = Apb3Config(12, 32)
+) extends Esm.Core[Apb3](
+      p,
+      Apb3(busConfig),
+      Apb3SlaveFactory(_)
+    )
+
+case class TileLinkEsm(
+    p: EsmCtrl.Parameter,
+    busConfig: TileLinkParameter = TileLinkParameter.simple(12, 32, 4, 1)
+) extends Esm.Core[TileLinkBus](
+      p,
+      TileLinkBus(busConfig),
+      new TileLinkSlaveFactory(_, false)
+    )
+
+case class WishboneEsm(
+    p: EsmCtrl.Parameter,
+    busConfig: WishboneConfig = WishboneConfig(12, 32)
+) extends Esm.Core[Wishbone](
+      p,
+      Wishbone(busConfig),
+      WishboneSlaveFactory(_)
+    )

--- a/hardware/scala/nafarr/system/esm/EsmCtrl.scala
+++ b/hardware/scala/nafarr/system/esm/EsmCtrl.scala
@@ -1,0 +1,328 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.system.esm
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.BusSlaveFactory
+
+import nafarr.IpIdentification
+
+object EsmCtrl {
+  def apply(p: Parameter) = new EsmCtrl(p)
+  def apply(inputCount: Int) = EsmCtrl(Parameter.default(inputCount))
+
+  case class Parameter(
+      inputCount: Int,
+      counterWidth: Int = 24,
+      locked: Boolean = true
+  ) {
+    require(inputCount >= 1 && inputCount <= 256, "ESM input count must be between 1 and 256")
+    require(counterWidth >= 1 && counterWidth <= 32, "ESM counter width must be between 1 and 32")
+    val bankCount: Int = (inputCount + 7) / 8
+  }
+  object Parameter {
+    def default(inputCount: Int) = Parameter(inputCount)
+    def small(inputCount: Int) = Parameter(inputCount, counterWidth = 16)
+    def large(inputCount: Int) = Parameter(inputCount, counterWidth = 32)
+  }
+
+  object Regs {
+    def apply(base: BigInt) = new Regs(base)
+  }
+
+  /** Register map.
+    *
+    * Global registers start at `base` (= IpIdentification header length = 8):
+    *   info          base + 0x00  — self-disclosure (read-only)
+    *   control       base + 0x04  — enable, lock, injectEnable
+    *   status        base + 0x08  — counterActive, errorSignal (read-only)
+    *   errorCounter  base + 0x0c  — grace-period reload value (locked)
+    *
+    * Per-bank registers, stride 0x10, bank N base = base + 0x20 + N * 0x10:
+    *   enable   +0x00  — combined INFO/WARN/ERROR/FATAL routing mask
+    *   pending  +0x04  — combined INFO/WARN/ERROR/FATAL pending bits (W1C)
+    *   raw      +0x08  — active inputs for this bank (read-only)
+    *   inject   +0x0c  — injected inputs for this bank
+    *
+    * Enable/pending register layout (same for both):
+    *   bits [31:24] = FATAL for inputs [7:0] of this bank
+    *   bits [23:16] = ERROR for inputs [7:0] of this bank
+    *   bits  [15:8] = WARN  for inputs [7:0] of this bank
+    *   bits   [7:0] = INFO  for inputs [7:0] of this bank
+    *
+    * The last bank may cover fewer than 8 inputs; upper bits in each level byte
+    * are unused and always read as zero.
+    *
+    * Lock scope: writes to ERROR/FATAL fields of enable (bits [31:16]) and to
+    * errorCounter and inject are ignored once the ESM is locked.
+    * INFO/WARN fields of enable (bits [15:0]) are never locked.
+    */
+  class Regs(base: BigInt) {
+    val info = base + 0x00
+    val control = base + 0x04
+    val status = base + 0x08
+    val errorCounter = base + 0x0c
+    private def bankBase(bank: Int): BigInt = base + 0x20 + bank * 0x10
+    def enable(bank: Int) = bankBase(bank) + 0x00
+    def pending(bank: Int) = bankBase(bank) + 0x04
+    def raw(bank: Int) = bankBase(bank) + 0x08
+    def inject(bank: Int) = bankBase(bank) + 0x0c
+  }
+
+  /** Error Signaling Module controller.
+    *
+    * Aggregates up to `p.inputCount` independent error inputs from other IP cores, grouped into
+    * banks of 8 inputs. Each bank has a single combined enable register and a single combined
+    * pending register that pack all four severity levels into one 32-bit word, allowing the input
+    * space to scale beyond 32 bits without changes to the register interface. Each input is
+    * synchronised through a 2-FF chain to filter glitches and prevent metastability. The ESM
+    * routes events to one of four severity levels:
+    *
+    *   INFO  — masked, latched → `infoInterrupt` (low-priority PLIC lane)
+    *   WARN  — masked, latched → `warnInterrupt` (high-priority PLIC lane)
+    *   ERROR — masked, latched → `errorSignal` after a configurable grace-period counter
+    *   FATAL — masked, latched → `errorSignal` immediately, bypassing the counter
+    *
+    * An input can be assigned to multiple levels simultaneously via independent bits in the
+    * combined enable register. Pending bits are pre-masked (only enabled inputs are latched)
+    * and cleared by writing 1 (W1C).
+    *
+    * The grace-period counter starts when any ERROR-level pending bit is set. If software clears
+    * all ERROR pending bits before the counter expires the counter resets and `errorSignal` is
+    * never asserted from that event. Setting `errorCounter = 0` makes ERROR behave like FATAL.
+    *
+    * Software error injection is controlled by `injectEnable` (control bit 2). When enabled,
+    * writes to the inject registers OR with the synchronised hardware inputs. Locking the ESM
+    * (control bit 1) atomically clears `injectEnable` and all inject bank registers, and freezes
+    * the ERROR/FATAL fields of the enable registers, `errorCounter`, and the inject registers.
+    *
+    * io.inputs          : in  — raw error inputs from other IP cores.
+    * io.injectInputs    : in  — inject register values, driven by Mapper.
+    * io.injectEnable    : in  — gates inject OR path.
+    * io.errorPendingAny : in  — OR of all ERROR pending bits (from Mapper).
+    * io.fatalPendingAny : in  — OR of all FATAL pending bits (from Mapper).
+    * io.infoPendingAny  : in  — OR of all INFO pending bits (from Mapper).
+    * io.warnPendingAny  : in  — OR of all WARN pending bits (from Mapper).
+    * io.counterPreload  : in  — grace-period counter reload value (from Mapper).
+    * io.activeInputs    : out — synchronised inputs OR inject; feeds Mapper pending registers.
+    * io.counterActive   : out — high while grace-period counter is counting.
+    * io.counterExpired  : out — latched high when counter reaches zero; cleared by Mapper.
+    * io.infoInterrupt   : out — asserted while any INFO pending bit is set.
+    * io.warnInterrupt   : out — asserted while any WARN pending bit is set.
+    * io.errorSignal     : out — asserted on FATAL event or after grace-period expiry.
+    */
+  case class EsmCtrl(p: Parameter) extends Component {
+    val io = new Bundle {
+      val inputs = in(Bits(p.inputCount bits))
+      val injectInputs = in(Bits(p.inputCount bits))
+      val injectEnable = in Bool ()
+      val errorPendingAny = in Bool ()
+      val fatalPendingAny = in Bool ()
+      val infoPendingAny = in Bool ()
+      val warnPendingAny = in Bool ()
+      val counterPreload = in(UInt(p.counterWidth bits))
+      val activeInputs = out(Bits(p.inputCount bits))
+      val counterActive = out Bool ()
+      val counterExpired = out Bool ()
+      val infoInterrupt = out Bool ()
+      val warnInterrupt = out Bool ()
+      val errorSignal = out Bool ()
+    }
+
+    // Two-FF synchroniser: filters glitches and prevents metastability.
+    val stage1 = RegNext(io.inputs, B(0, p.inputCount bits))
+    val syncInputs = RegNext(stage1, B(0, p.inputCount bits))
+
+    val injected = Bits(p.inputCount bits)
+    injected := B(0, p.inputCount bits)
+    when(io.injectEnable) {
+      injected := io.injectInputs
+    }
+    io.activeInputs := syncInputs | injected
+
+    // Grace-period counter for ERROR level.
+    val counter = Reg(UInt(p.counterWidth bits)) init (0)
+    val counterActiveReg = Reg(Bool()) init (False)
+    val counterExpiredReg = Reg(Bool()) init (False)
+
+    when(!io.errorPendingAny) {
+      counterActiveReg := False
+      counter := 0
+      counterExpiredReg := False
+    } elsewhen (!counterActiveReg && !counterExpiredReg) {
+      when(io.counterPreload === 0) {
+        counterExpiredReg := True
+      } otherwise {
+        counterActiveReg := True
+        counter := io.counterPreload
+      }
+    } elsewhen (counterActiveReg) {
+      when(counter === 0) {
+        counterActiveReg := False
+        counterExpiredReg := True
+      } otherwise {
+        counter := counter - 1
+      }
+    }
+
+    io.counterActive := counterActiveReg
+    io.counterExpired := counterExpiredReg
+    io.infoInterrupt := io.infoPendingAny
+    io.warnInterrupt := io.warnPendingAny
+    io.errorSignal := counterExpiredReg || io.fatalPendingAny
+  }
+
+  case class Mapper(
+      busCtrl: BusSlaveFactory,
+      ctrl: EsmCtrl,
+      p: Parameter
+  ) extends Area {
+    val idCtrl = IpIdentification(IpIdentification.Ids.Esm, 1, 0, 0)
+    idCtrl.driveFrom(busCtrl)
+    val regs = Regs(idCtrl.length)
+
+    // info: locked[24] | counterWidth[23:16] | bankCount[15:9] | inputCount[8:0]
+    busCtrl.read(
+      B(0, 7 bits) ## Bool(p.locked) ## B(p.counterWidth, 8 bits) ## B(p.bankCount, 7 bits) ## B(
+        p.inputCount,
+        9 bits
+      ),
+      regs.info
+    )
+
+    // Control: enable[0], lock[1], injectEnable[2]
+    val enableReg = Reg(Bool()) init (False)
+    val lockReg = if (p.locked) Reg(Bool()) init (False) else null
+    val isLocked: Bool = if (p.locked) lockReg else False
+    val injectEnableReg = Reg(Bool()) init (False)
+
+    // Per-bank inject registers (8-bit wide; one bit per bank input).
+    val injectBankRegs = Vec(Reg(Bits(8 bits)) init (0), p.bankCount)
+
+    val controlFlow = busCtrl.createAndDriveFlow(Bits(32 bits), regs.control)
+    when(controlFlow.valid) {
+      if (p.locked) {
+        when(controlFlow.payload(1)) {
+          lockReg := True
+          injectEnableReg := False
+          injectBankRegs.foreach(_ := B(0, 8 bits))
+        } otherwise {
+          when(!isLocked) {
+            enableReg := controlFlow.payload(0)
+            injectEnableReg := controlFlow.payload(2)
+          } elsewhen (controlFlow.payload(0)) {
+            enableReg := True
+          }
+        }
+      } else {
+        enableReg := controlFlow.payload(0)
+        injectEnableReg := controlFlow.payload(2)
+      }
+    }
+    val controlBits = Bits(3 bits)
+    controlBits(0) := enableReg
+    if (p.locked) {
+      controlBits(1) := lockReg
+    } else {
+      controlBits(1) := False
+    }
+    controlBits(2) := injectEnableReg
+    busCtrl.read(controlBits.resize(32), regs.control)
+
+    // Status (read-only).
+    val statusBits = Bits(2 bits)
+    statusBits(0) := ctrl.io.counterActive
+    statusBits(1) := ctrl.io.errorSignal
+    busCtrl.read(statusBits.resize(32), regs.status)
+
+    // Error counter (locked).
+    val counterReg = Reg(UInt(p.counterWidth bits)) init (~U(0, p.counterWidth bits))
+    val counterFlow = busCtrl.createAndDriveFlow(Bits(32 bits), regs.errorCounter)
+    when(counterFlow.valid && !isLocked) {
+      counterReg := counterFlow.payload(p.counterWidth - 1 downto 0).asUInt
+    }
+    busCtrl.read(counterReg.resize(32), regs.errorCounter)
+    ctrl.io.counterPreload := counterReg
+
+    // Gated inputs: active inputs qualified by master enable.
+    val gatedInputs = Bits(p.inputCount bits)
+    gatedInputs := B(0, p.inputCount bits)
+    when(enableReg) {
+      gatedInputs := ctrl.io.activeInputs
+    }
+
+    // Per-bank combined enable and pending registers (32-bit; layout per register:
+    //   [31:24] = FATAL, [23:16] = ERROR, [15:8] = WARN, [7:0] = INFO).
+    val enableBankRegs = Vec(Reg(Bits(32 bits)) init (0), p.bankCount)
+    val pendingBankRegs = Vec(Reg(Bits(32 bits)) init (0), p.bankCount)
+
+    for (bank <- 0 until p.bankCount) {
+      val esmBank = new Area {
+        val bankStart = bank * 8
+        val bankEnd = (bankStart + 7) min (p.inputCount - 1)
+        val bankWidth = bankEnd - bankStart + 1
+        val bankSlice = bankEnd downto bankStart
+
+        // Enable register.
+        // INFO/WARN (bits [15:0]): always writable.
+        // ERROR/FATAL (bits [31:16]): locked when ESM is locked.
+        val enableFlow = busCtrl.createAndDriveFlow(Bits(32 bits), regs.enable(bank))
+        when(enableFlow.valid) {
+          enableBankRegs(bank)(15 downto 0) := enableFlow.payload(15 downto 0)
+        }
+        when(enableFlow.valid && !isLocked) {
+          enableBankRegs(bank)(31 downto 16) := enableFlow.payload(31 downto 16)
+        }
+        busCtrl.read(enableBankRegs(bank), regs.enable(bank))
+
+        // Pending register (W1C).
+        val pendingFlow = busCtrl.createAndDriveFlow(Bits(32 bits), regs.pending(bank))
+        val clearMask = Bits(32 bits)
+        clearMask := B(0, 32 bits)
+        when(pendingFlow.valid) {
+          clearMask := pendingFlow.payload
+        }
+
+        val bankGated = gatedInputs(bankSlice).resize(8)
+        val infoEvents = bankGated & enableBankRegs(bank)(7 downto 0)
+        val warnEvents = bankGated & enableBankRegs(bank)(15 downto 8)
+        val errorEvents = bankGated & enableBankRegs(bank)(23 downto 16)
+        val fatalEvents = bankGated & enableBankRegs(bank)(31 downto 24)
+        val newEvents = fatalEvents ## errorEvents ## warnEvents ## infoEvents
+
+        pendingBankRegs(bank) := (pendingBankRegs(bank) | newEvents) & ~clearMask
+        busCtrl.read(pendingBankRegs(bank), regs.pending(bank))
+
+        // Raw (read-only, unaffected by master enable).
+        busCtrl.read(ctrl.io.activeInputs(bankSlice).resize(32), regs.raw(bank))
+
+        // Inject register (writable only when injectEnable && !locked).
+        val injectFlow = busCtrl.createAndDriveFlow(Bits(32 bits), regs.inject(bank))
+        when(injectFlow.valid && injectEnableReg && !isLocked) {
+          injectBankRegs(bank) := injectFlow.payload(7 downto 0)
+        }
+        busCtrl.read(injectBankRegs(bank).resize(32), regs.inject(bank))
+      }.setName(s"bank_${bank}")
+    }
+
+    // Assemble full-width inject signal from per-bank registers.
+    val injectFull = Bits(p.inputCount bits)
+    for (bank <- 0 until p.bankCount) {
+      val bankStart = bank * 8
+      val bankEnd = (bankStart + 7) min (p.inputCount - 1)
+      val bankWidth = bankEnd - bankStart + 1
+      injectFull(bankEnd downto bankStart) := injectBankRegs(bank)(bankWidth - 1 downto 0)
+    }
+    ctrl.io.injectInputs := injectFull
+    ctrl.io.injectEnable := injectEnableReg
+
+    // Pending-any signals: OR-reduce the relevant level byte across all banks.
+    ctrl.io.infoPendingAny := pendingBankRegs.map(_(7 downto 0).orR).reduce(_ || _)
+    ctrl.io.warnPendingAny := pendingBankRegs.map(_(15 downto 8).orR).reduce(_ || _)
+    ctrl.io.errorPendingAny := pendingBankRegs.map(_(23 downto 16).orR).reduce(_ || _)
+    ctrl.io.fatalPendingAny := pendingBankRegs.map(_(31 downto 24).orR).reduce(_ || _)
+  }
+}

--- a/hardware/scala/nafarr/system/mailbox/Mailbox.scala
+++ b/hardware/scala/nafarr/system/mailbox/Mailbox.scala
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.system.mailbox
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.BusSlaveFactory
+import spinal.lib.bus.amba3.apb._
+import spinal.lib.bus.tilelink.{
+  Bus => TileLinkBus,
+  BusParameter => TileLinkParameter,
+  SlaveFactory => TileLinkSlaveFactory
+}
+import spinal.lib.bus.wishbone._
+
+object Mailbox {
+
+  class Core[T <: spinal.core.Data with IMasterSlave](
+      p: MailboxCtrl.Parameter,
+      busType: HardType[T],
+      factory: T => BusSlaveFactory
+  ) extends Component {
+    val io = new Bundle {
+      val bus = slave(busType())
+      val interrupt = out(Bool())
+    }
+    val busCtrl = factory(io.bus)
+    val ctrl = MailboxCtrl(p)
+    val mapper = MailboxCtrl.Mapper(busCtrl, ctrl, p)
+    io.interrupt := ctrl.io.interrupt
+  }
+}
+
+case class Apb3Mailbox(
+    p: MailboxCtrl.Parameter,
+    busConfig: Apb3Config = Apb3Config(8, 32)
+) extends Mailbox.Core[Apb3](
+      p,
+      Apb3(busConfig),
+      Apb3SlaveFactory(_)
+    )
+
+case class TileLinkMailbox(
+    p: MailboxCtrl.Parameter,
+    busConfig: TileLinkParameter = TileLinkParameter.simple(8, 32, 4, 1)
+) extends Mailbox.Core[TileLinkBus](
+      p,
+      TileLinkBus(busConfig),
+      new TileLinkSlaveFactory(_, false)
+    )
+
+case class WishboneMailbox(
+    p: MailboxCtrl.Parameter,
+    busConfig: WishboneConfig = WishboneConfig(8, 32)
+) extends Mailbox.Core[Wishbone](
+      p,
+      Wishbone(busConfig),
+      WishboneSlaveFactory(_)
+    )

--- a/hardware/scala/nafarr/system/mailbox/MailboxCtrl.scala
+++ b/hardware/scala/nafarr/system/mailbox/MailboxCtrl.scala
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.system.mailbox
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.BusSlaveFactory
+import spinal.lib.misc.InterruptCtrl
+
+import nafarr.IpIdentification
+
+object MailboxCtrl {
+  def apply(p: Parameter = Parameter.medium()) = MailboxCtrl(p)
+
+  case class Parameter(depth: Int = 8, channelCount: Int = 2) {
+    require(depth > 0 && depth < 256, "Mailbox FIFO depth must be between 1 and 255")
+    require(channelCount >= 2, "Mailbox must have at least 2 channels")
+  }
+  object Parameter {
+    def small() = Parameter(depth = 4)
+    def medium() = Parameter(depth = 8)
+    def large() = Parameter(depth = 16)
+  }
+
+  object Regs {
+    def apply(base: BigInt) = new Regs(base)
+  }
+  class Regs(base: BigInt) {
+    val info = base + 0x00
+    val status = base + 0x04
+    private def channelBase(ch: Int) = base + 0x08 + ch * 0x14
+    def write(ch: Int) = channelBase(ch) + 0x00
+    def read(ch: Int) = channelBase(ch) + 0x04
+    def occupancy(ch: Int) = channelBase(ch) + 0x08
+    def interruptPending(ch: Int) = channelBase(ch) + 0x0c
+    def interruptMask(ch: Int) = channelBase(ch) + 0x10
+  }
+
+  /** Hardware mailbox controller.
+    *
+    * Provides `p.channelCount` symmetric FIFO channels for inter-CPU messaging.
+    * Each channel has an independent push/pop stream and occupancy counter.
+    *
+    * Convention: CPU A sends on channel 0 and receives on channel 1.
+    *             CPU B sends on channel 1 and receives on channel 0.
+    *
+    * io.push            : in  — stream of messages pushed into each channel FIFO.
+    * io.pop             : out — stream of messages popped from each channel FIFO.
+    * io.occupancy       : out — number of entries currently stored per channel.
+    * io.interrupt        : out — single interrupt, asserted when any channel has a
+    *                              masked pending source (OR of all channel IRQ bits).
+    * io.pendingInterrupts: in  — masked pending interrupt bits per channel, driven by Mapper.
+    */
+  case class MailboxCtrl(p: Parameter) extends Component {
+    val io = new Bundle {
+      val push = Vec(slave(Stream(Bits(32 bits))), p.channelCount)
+      val pop = Vec(master(Stream(Bits(32 bits))), p.channelCount)
+      val occupancy = out(Vec(UInt(log2Up(p.depth + 1) bits), p.channelCount))
+      val interrupt = out Bool()
+      val pendingInterrupts = in(Vec(Bits(2 bits), p.channelCount))
+    }
+
+    for (ch <- 0 until p.channelCount) {
+      val fifo = StreamFifo(Bits(32 bits), p.depth)
+      fifo.io.push << io.push(ch)
+      io.pop(ch) << fifo.io.pop
+      io.occupancy(ch) := fifo.io.occupancy
+    }
+
+    io.interrupt := io.pendingInterrupts.map(_.orR).reduce(_ || _)
+  }
+
+  case class Mapper(
+      busCtrl: BusSlaveFactory,
+      ctrl: MailboxCtrl,
+      p: Parameter
+  ) extends Area {
+    val idCtrl = IpIdentification(IpIdentification.Ids.Mailbox, 1, 0, 0)
+    idCtrl.driveFrom(busCtrl)
+    val regs = Regs(idCtrl.length)
+
+    busCtrl.read(B(0, 16 bits) ## B(p.depth, 8 bits) ## B(p.channelCount, 8 bits), regs.info)
+
+    val emptyBits = Bits(p.channelCount bits)
+    val fullBits = Bits(p.channelCount bits)
+
+    for (ch <- 0 until p.channelCount) {
+      new Area {
+        // Push: bus write fires data into the FIFO; silently drops if full.
+        val pushStream = busCtrl.createAndDriveFlow(Bits(32 bits), regs.write(ch)).toStream
+        ctrl.io.push(ch) << pushStream
+        pushStream.ready.allowPruning()
+
+        // Pop: bus read pops one entry; returns the payload register value.
+        // Software must check the empty flag in the status register before reading.
+        val popFire = Bool()
+        popFire := False
+        busCtrl.onRead(regs.read(ch)) { popFire := True }
+        ctrl.io.pop(ch).ready := popFire
+        busCtrl.read(ctrl.io.pop(ch).payload, regs.read(ch))
+
+        busCtrl.read(ctrl.io.occupancy(ch).resize(32), regs.occupancy(ch))
+
+        val irqCtrl = new InterruptCtrl(2)
+        irqCtrl.driveFrom(busCtrl, regs.interruptPending(ch).toInt)
+        irqCtrl.io.inputs(0) := ctrl.io.pop(ch).valid // not-empty
+        irqCtrl.io.inputs(1) := ctrl.io.push(ch).ready // not-full
+        ctrl.io.pendingInterrupts(ch) := irqCtrl.io.pendings
+
+        emptyBits(ch) := !ctrl.io.pop(ch).valid
+        fullBits(ch) := !ctrl.io.push(ch).ready
+      }
+    }
+
+    busCtrl.read(B(0, 28 bits) ## fullBits ## emptyBits, regs.status)
+  }
+}

--- a/hardware/scala/nafarr/system/mailbox/MailboxCtrl.scala
+++ b/hardware/scala/nafarr/system/mailbox/MailboxCtrl.scala
@@ -58,7 +58,7 @@ object MailboxCtrl {
       val push = Vec(slave(Stream(Bits(32 bits))), p.channelCount)
       val pop = Vec(master(Stream(Bits(32 bits))), p.channelCount)
       val occupancy = out(Vec(UInt(log2Up(p.depth + 1) bits), p.channelCount))
-      val interrupt = out Bool()
+      val interrupt = out Bool ()
       val pendingInterrupts = in(Vec(Bits(2 bits), p.channelCount))
     }
 

--- a/hardware/scala/nafarr/system/mtimer/MachineTimer.scala
+++ b/hardware/scala/nafarr/system/mtimer/MachineTimer.scala
@@ -14,13 +14,15 @@ import spinal.lib.bus.tilelink.{
   SlaveFactory => TileLinkSlaveFactory
 }
 import spinal.lib.bus.wishbone._
+import nafarr.Feature
+import nafarr.peripherals.PeripheralsComponent
 
 object MachineTimer {
   class Core[T <: spinal.core.Data with IMasterSlave](
       p: MachineTimerCtrl.Parameter,
       busType: HardType[T],
       factory: T => BusSlaveFactory
-  ) extends Component {
+  ) extends PeripheralsComponent {
     val io = new Bundle {
       val bus = slave(busType())
       val interrupt = out(Bool)
@@ -32,7 +34,10 @@ object MachineTimer {
     val mapper = MachineTimerCtrl.Mapper(factory(io.bus), ctrl.io, p)
 
     val clockSpeed = ClockDomain.current.frequency.getValue.toInt
-    def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
+    override def getInterrupt = Some(io.interrupt)
+    override def sysconFeatures = Some(List(Feature.Mtimer))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
       val baseAddress = "%08x".format(address.toInt)
       val regSize = "%04x".format(size.toInt)
       var dt = s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}

--- a/hardware/scala/nafarr/system/plic/Plic.scala
+++ b/hardware/scala/nafarr/system/plic/Plic.scala
@@ -14,6 +14,8 @@ import spinal.lib.bus.tilelink.{
   SlaveFactory => TileLinkSlaveFactory
 }
 import spinal.lib.bus.wishbone._
+import nafarr.Feature
+import nafarr.peripherals.PeripheralsComponent
 import spinal.lib.misc.plic._
 
 import scala.collection.mutable.ArrayBuffer
@@ -23,7 +25,7 @@ object Plic {
       p: PlicCtrl.Parameter,
       busType: HardType[T],
       factory: T => BusSlaveFactory
-  ) extends Component {
+  ) extends PeripheralsComponent {
     val io = new Bundle {
       val bus = slave(busType())
       val interrupt = out(Bool)
@@ -55,16 +57,11 @@ object Plic {
 
     io.interrupt := targets(0).iep
 
-    def headerBareMetal(
-        name: String,
-        address: BigInt,
-        size: BigInt,
-        irqNumber: Option[Int] = null
-    ) = {
+    override def sysconFeatures = Some(List(Feature.Plic))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
       val baseAddress = "%08x".format(address.toInt)
-      val regSize = "%04x".format(size.toInt)
-      var dt = s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
-      dt
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
     }
   }
 }

--- a/hardware/scala/nafarr/system/reset/ResetController.scala
+++ b/hardware/scala/nafarr/system/reset/ResetController.scala
@@ -15,7 +15,8 @@ import spinal.lib.bus.tilelink.{
 }
 import spinal.lib.bus.wishbone._
 
-import nafarr.IpIdentification
+import nafarr.{Feature, IpIdentification}
+import nafarr.peripherals.PeripheralsComponent
 
 case class ResetParameter(name: String, delay: Int)
 
@@ -24,7 +25,7 @@ object ResetController {
       p: ResetControllerCtrl.Parameter,
       busType: HardType[T],
       factory: T => BusSlaveFactory
-  ) extends Component {
+  ) extends PeripheralsComponent {
     val io = new Bundle {
       val bus = slave(busType())
       val config = out(ResetControllerCtrl.Config(p))
@@ -50,6 +51,13 @@ object ResetController {
 
     io.config.trigger := trigger
     io.config.acknowledge := acknowledge
+
+    override def sysconFeatures = Some(List(Feature.Reset))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
+      val baseAddress = "%08x".format(address.toInt)
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
+    }
   }
 }
 

--- a/hardware/scala/nafarr/system/semaphore/Semaphore.scala
+++ b/hardware/scala/nafarr/system/semaphore/Semaphore.scala
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.system.semaphore
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.BusSlaveFactory
+import spinal.lib.bus.amba3.apb._
+import spinal.lib.bus.tilelink.{
+  Bus => TileLinkBus,
+  BusParameter => TileLinkParameter,
+  SlaveFactory => TileLinkSlaveFactory
+}
+import spinal.lib.bus.wishbone._
+import nafarr.Feature
+import nafarr.peripherals.PeripheralsComponent
+
+/** Hardware semaphore peripheral.
+  *
+  * Provides `p.count` atomic semaphore slots accessible via a memory-mapped
+  * register interface.
+  *
+  * Register map (after the 8-byte IpIdentification header):
+  *
+  *   base+0x00  STATUS  (R)    Bitmask of taken slots; bit N = semaphore N taken.
+  *   base+0x04  SEM_0   (R/W)  Read to claim slot 0; write to release slot 0.
+  *   base+0x08  SEM_1   (R/W)  ...
+  *   ...
+  *
+  * Claim protocol (read):
+  *   Returns 0 — semaphore was free; caller now holds it.
+  *   Returns 1 — semaphore was already taken; caller must retry.
+  *   The returned value reflects the state *before* the read; the claim flag
+  *   is set on the same bus transaction so no other master can interleave.
+  *
+  * Release protocol (write):
+  *   Any write to the semaphore register unconditionally releases it.
+  */
+object Semaphore {
+
+  class Core[T <: spinal.core.Data with IMasterSlave](
+      p: SemaphoreCtrl.Parameter,
+      busType: HardType[T],
+      factory: T => BusSlaveFactory
+  ) extends PeripheralsComponent {
+    val io = new Bundle {
+      val bus = slave(busType())
+    }
+    val busCtrl = factory(io.bus)
+    val ctrl = SemaphoreCtrl(p)
+    val mapper = SemaphoreCtrl.Mapper(busCtrl, ctrl, p)
+
+    override def sysconFeatures = Some(List(Feature.Semaphore))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
+      val baseAddress = "%08x".format(address.toInt)
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
+    }
+  }
+}
+
+case class Apb3Semaphore(
+    p: SemaphoreCtrl.Parameter,
+    busConfig: Apb3Config = Apb3Config(8, 32)
+) extends Semaphore.Core[Apb3](
+      p,
+      Apb3(busConfig),
+      Apb3SlaveFactory(_)
+    )
+
+case class TileLinkSemaphore(
+    p: SemaphoreCtrl.Parameter,
+    busConfig: TileLinkParameter = TileLinkParameter.simple(8, 32, 4, 1)
+) extends Semaphore.Core[TileLinkBus](
+      p,
+      TileLinkBus(busConfig),
+      new TileLinkSlaveFactory(_, false)
+    )
+
+case class WishboneSemaphore(
+    p: SemaphoreCtrl.Parameter,
+    busConfig: WishboneConfig = WishboneConfig(8, 32)
+) extends Semaphore.Core[Wishbone](
+      p,
+      Wishbone(busConfig),
+      WishboneSlaveFactory(_)
+    )

--- a/hardware/scala/nafarr/system/semaphore/SemaphoreCtrl.scala
+++ b/hardware/scala/nafarr/system/semaphore/SemaphoreCtrl.scala
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.system.semaphore
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.BusSlaveFactory
+
+import nafarr.IpIdentification
+
+object SemaphoreCtrl {
+  def apply(p: Parameter = Parameter()) = SemaphoreCtrl(p)
+
+  case class Parameter(count: Int = 8) {
+    require(count > 0 && count <= 32, "Semaphore count must be between 1 and 32")
+  }
+  object Parameter {
+    def small() = Parameter(count = 4)
+    def medium() = Parameter(count = 8)
+    def large() = Parameter(count = 16)
+  }
+
+  object Regs {
+    def apply(base: BigInt, p: Parameter) = new Regs(base, p)
+  }
+
+  class Regs(base: BigInt, p: Parameter) {
+
+    /** Number of available semaphores */
+    val info = base + 0x00
+
+    /** Read-only bitmask of all taken slots; bit N = semaphore N taken. */
+    val status = base + 0x04
+
+    /** Per-semaphore register: read to claim, write to release. */
+    def semaphore(i: Int): BigInt = {
+      require(i >= 0 && i < p.count, s"Semaphore index $i out of range [0, ${p.count})")
+      base + 0x08 + i * 0x04
+    }
+  }
+
+  /** Hardware semaphore controller — no bus logic.
+    *
+    * Manages `p.count` semaphore slots as a registered bitmask.  Claim and
+    * release are combinatorial inputs; the state updates at every clock edge.
+    * Release takes priority over simultaneous claim on the same slot.
+    *
+    * This component can be driven by any frontend:
+    *   - SemaphoreCtrl.Mapper  — memory-mapped register access
+    *   - A custom I2C-device frontend — claim/release via I2C commands
+    *   - Direct wiring         — software-managed from an Area
+    *
+    * io.claim   : in  — bitmask of slots to claim this cycle.
+    * io.release : in  — bitmask of slots to release this cycle.
+    * io.taken   : out — registered bitmask of currently taken slots.
+    */
+  case class SemaphoreCtrl(p: Parameter) extends Component {
+    val io = new Bundle {
+      val claim = in Bits (p.count bits)
+      val release = in Bits (p.count bits)
+      val taken = out Bits (p.count bits)
+    }
+
+    val state = Reg(Bits(p.count bits)) init 0
+    // Release takes priority: a simultaneous claim+release on the same slot
+    // leaves it free.
+    state := (state | io.claim) & ~io.release
+    io.taken := state
+  }
+
+  /** Register-map frontend for SemaphoreCtrl.
+    *
+    * Wires a BusSlaveFactory to the claim/release/taken ports of a
+    * SemaphoreCtrl component.  Instantiate this inside the parent Component
+    * that owns both the bus and the ctrl subcomponent.
+    */
+  case class Mapper(
+      busCtrl: BusSlaveFactory,
+      ctrl: SemaphoreCtrl,
+      p: Parameter
+  ) extends Area {
+    val idCtrl = IpIdentification(IpIdentification.Ids.Semaphore, 1, 0, 0)
+    idCtrl.driveFrom(busCtrl)
+
+    val regs = Regs(idCtrl.length, p)
+
+    busCtrl.read(B(p.count, 8 bits), regs.info)
+
+    // Intermediate signals — default to no-op; overridden per-slot below.
+    val claimVec = Vec(Bool(), p.count)
+    val releaseVec = Vec(Bool(), p.count)
+
+    for (i <- 0 until p.count) {
+      claimVec(i) := False
+      releaseVec(i) := False
+
+      // Read returns the state BEFORE the claim (old value) because
+      // ctrl.io.taken reflects the registered state; the claim register
+      // update happens at the next clock edge.
+      busCtrl.read(ctrl.io.taken(i).asUInt.resize(32), regs.semaphore(i))
+      busCtrl.onRead(regs.semaphore(i)) { claimVec(i) := True }
+      busCtrl.onWrite(regs.semaphore(i)) { releaseVec(i) := True }
+    }
+
+    busCtrl.read(ctrl.io.taken.resize(32), regs.status)
+
+    ctrl.io.claim := claimVec.asBits
+    ctrl.io.release := releaseVec.asBits
+  }
+}

--- a/hardware/scala/nafarr/system/syscon/Syscon.scala
+++ b/hardware/scala/nafarr/system/syscon/Syscon.scala
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.system.syscon
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.BusSlaveFactory
+import spinal.lib.bus.amba3.apb._
+import spinal.lib.bus.tilelink.{
+  Bus => TileLinkBus,
+  BusParameter => TileLinkParameter,
+  SlaveFactory => TileLinkSlaveFactory
+}
+import spinal.lib.bus.wishbone._
+
+import nafarr.{IpIdentification, Vendor, Platform, PlatformClass, Product, Feature}
+import nafarr.peripherals.PeripheralsComponent
+
+object Syscon {
+
+  case class Parameter(
+      vendor: Vendor.E,
+      platform: Platform.E,
+      platformClass: PlatformClass.E,
+      product: Product.E,
+      refClockHz: Long,
+      siliconMajor: Int = 0,
+      siliconMinor: Int = 1,
+      features: List[Feature.E] = List(),
+      buildDate: Long = Parameter.buildTimestamp
+  )
+  object Parameter {
+    def buildTimestamp: Long =
+      sys.env.get("BUILD_DATE").map(_.toLong).getOrElse(System.currentTimeMillis() / 1000)
+  }
+
+  object Regs {
+    def apply(base: BigInt) = new Regs(base)
+  }
+  class Regs(base: BigInt) {
+    val identity = base + 0x00
+    val siliconMajor = base + 0x04
+    val siliconMinor = base + 0x08
+    val features = base + 0x0c
+    val refClock = base + 0x10
+    val buildDate = base + 0x14
+  }
+
+  /** All registers are read-only constants derived from compile-time Parameters.
+    * No hardware logic is required; the mapper drives the bus directly.
+    *
+    * identity register layout:
+    *   [31:24] = platformClass  (PlatformClass enum ordinal)
+    *   [23:16] = product        (Product enum ordinal)
+    *   [15:8]  = platform       (Platform enum ordinal)
+    *   [7:0]   = vendor         (Vendor enum ordinal)
+    *
+    * features register: bit N is set when Feature element with ordinal N is present
+    * in p.features. Populated automatically by the SoC builder via sysconFeatures
+    * on each IP's Core class.
+    */
+  case class Mapper(busCtrl: BusSlaveFactory, p: Parameter) extends Area {
+    val idCtrl = IpIdentification(IpIdentification.Ids.Syscon, 1, 0, 0)
+    idCtrl.driveFrom(busCtrl)
+    val regs = Regs(idCtrl.length)
+
+    // identity: [7:0]=vendor [15:8]=platform [23:16]=product [31:24]=platformClass
+    busCtrl.read(
+      B(p.platformClass, 8 bits) ## B(p.product, 8 bits) ## B(p.platform, 8 bits) ## B(
+        p.vendor,
+        8 bits
+      ),
+      regs.identity
+    )
+
+    busCtrl.read(B(p.siliconMajor, 32 bits), regs.siliconMajor)
+    busCtrl.read(B(p.siliconMinor, 32 bits), regs.siliconMinor)
+
+    // features: bit N set for each Feature element whose ordinal is N
+    var featureMask: BigInt = 0
+    p.features.foreach { f => featureMask |= BigInt(1) << f.position }
+    busCtrl.read(B(featureMask, 32 bits), regs.features)
+
+    busCtrl.read(B(p.refClockHz, 32 bits), regs.refClock)
+    busCtrl.read(B(p.buildDate, 32 bits), regs.buildDate)
+  }
+
+  class Core[T <: spinal.core.Data with IMasterSlave](
+      p: Parameter,
+      busType: HardType[T],
+      factory: T => BusSlaveFactory
+  ) extends PeripheralsComponent {
+    val io = new Bundle {
+      val bus = slave(busType())
+    }
+    val busCtrl = factory(io.bus)
+    val mapper = Mapper(busCtrl, p)
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
+      val baseAddress = "%08x".format(address.toInt)
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
+    }
+  }
+}
+
+case class Apb3Syscon(
+    p: Syscon.Parameter,
+    busConfig: Apb3Config = Apb3Config(8, 32)
+) extends Syscon.Core[Apb3](
+      p,
+      Apb3(busConfig),
+      Apb3SlaveFactory(_)
+    )
+
+case class TileLinkSyscon(
+    p: Syscon.Parameter,
+    busConfig: TileLinkParameter = TileLinkParameter.simple(8, 32, 4, 1)
+) extends Syscon.Core[TileLinkBus](
+      p,
+      TileLinkBus(busConfig),
+      new TileLinkSlaveFactory(_, false)
+    )
+
+case class WishboneSyscon(
+    p: Syscon.Parameter,
+    busConfig: WishboneConfig = WishboneConfig(8, 32)
+) extends Syscon.Core[Wishbone](
+      p,
+      Wishbone(busConfig),
+      WishboneSlaveFactory(_)
+    )

--- a/hardware/scala/nafarr/system/timer/Timer.scala
+++ b/hardware/scala/nafarr/system/timer/Timer.scala
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.system.timer
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.BusSlaveFactory
+import spinal.lib.bus.amba3.apb._
+import spinal.lib.bus.tilelink.{
+  Bus => TileLinkBus,
+  BusParameter => TileLinkParameter,
+  SlaveFactory => TileLinkSlaveFactory
+}
+import spinal.lib.bus.wishbone._
+
+object Timer {
+
+  class Core[T <: spinal.core.Data with IMasterSlave](
+      p: TimerCtrl.Parameter,
+      busType: HardType[T],
+      factory: T => BusSlaveFactory
+  ) extends Component {
+    val io = new Bundle {
+      val bus = slave(busType())
+      val interrupt = out Bool ()
+    }
+    val ctrl = TimerCtrl(p)
+    val mapper = TimerCtrl.Mapper(factory(io.bus), ctrl, p)
+    io.interrupt := mapper.interrupt
+  }
+}
+
+case class Apb3Timer(
+    p: TimerCtrl.Parameter,
+    busConfig: Apb3Config = Apb3Config(12, 32)
+) extends Timer.Core[Apb3](p, Apb3(busConfig), Apb3SlaveFactory(_))
+
+case class TileLinkTimer(
+    p: TimerCtrl.Parameter,
+    busConfig: TileLinkParameter = TileLinkParameter.simple(12, 32, 4, 1)
+) extends Timer.Core[TileLinkBus](p, TileLinkBus(busConfig), new TileLinkSlaveFactory(_, false))
+
+case class WishboneTimer(
+    p: TimerCtrl.Parameter,
+    busConfig: WishboneConfig = WishboneConfig(12, 32)
+) extends Timer.Core[Wishbone](p, Wishbone(busConfig), WishboneSlaveFactory(_))

--- a/hardware/scala/nafarr/system/timer/TimerCtrl.scala
+++ b/hardware/scala/nafarr/system/timer/TimerCtrl.scala
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.system.timer
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.BusSlaveFactory
+import spinal.lib.misc.InterruptCtrl
+
+import nafarr.IpIdentification
+
+object TimerCtrl {
+  def apply(p: Parameter) = new TimerCtrl(p)
+
+  case class Parameter(
+      count: Int = 1,
+      channelCount: Int = 1,
+      width: Int = 32,
+      prescalerWidth: Int = 16
+  ) {
+    require(count >= 1 && count <= 16, "count must be 1..16")
+    require(channelCount >= 1 && channelCount <= 8, "channelCount must be 1..8")
+    require(width >= 1 && width <= 32, "width must be 1..32")
+    require(prescalerWidth >= 0 && prescalerWidth <= 32, "prescalerWidth must be 0..32")
+    val timerStride: Int = 0x10 + channelCount * 0x04
+    val irqSources: Int = count * (1 + channelCount)
+  }
+  object Parameter {
+    def default() = Parameter()
+    def small() = Parameter(count = 1, channelCount = 1, width = 16, prescalerWidth = 8)
+    def medium() = Parameter(count = 1, channelCount = 2, width = 32, prescalerWidth = 16)
+    def large() = Parameter(count = 4, channelCount = 2, width = 32, prescalerWidth = 16)
+  }
+
+  object Regs {
+    def apply(base: BigInt, p: Parameter) = new Regs(base, p)
+  }
+  class Regs(base: BigInt, p: Parameter) {
+    val info = base + 0x00
+    val irqPending = base + 0x04
+    val irqMask = base + 0x08
+    private def timerBase(t: Int): BigInt = base + 0x0c + t * p.timerStride
+    def control(t: Int) = timerBase(t) + 0x00
+    def prescaler(t: Int) = timerBase(t) + 0x04
+    def counter(t: Int) = timerBase(t) + 0x08
+    def reload(t: Int) = timerBase(t) + 0x0c
+    def compare(t: Int, ch: Int) = timerBase(t) + 0x10 + ch * 0x04
+  }
+
+  /** Per-timer configuration driven from the Mapper into the controller. */
+  case class TimerInstanceConfig(p: Parameter) extends Bundle {
+    val enable = Bool()
+    val mode = Bits(2 bits) // 00=free-run 01=periodic 10=one-shot
+    val reloadVal = UInt(p.width bits)
+    val compareVals = Vec(UInt(p.width bits), p.channelCount)
+  }
+
+  /** Per-timer status driven from the controller back to the Mapper. */
+  case class TimerInstanceStatus(p: Parameter) extends Bundle {
+    val counter = UInt(p.width bits)
+    val overflow = Bool()
+    val compareMatch = Vec(Bool(), p.channelCount)
+    val enableClear = Bool() // one-shot done: Mapper must clear the enable bit
+  }
+
+  case class Io(p: Parameter) extends Bundle {
+    val config = in Vec (TimerInstanceConfig(p), p.count)
+    val counterLoad = in Vec (Bool(), p.count)
+    val counterIn = in Vec (UInt(p.width bits), p.count)
+    val status = out Vec (TimerInstanceStatus(p), p.count)
+    val prescaler = (p.prescalerWidth > 0) generate in(Vec(UInt(p.prescalerWidth bits), p.count))
+  }
+
+  /** Timer controller.
+    *
+    * Contains all counter and prescaler hardware. No bus logic.
+    *
+    * config       : per-timer enable, mode, reload, compare values (from Mapper registers).
+    * counterLoad  : preload strobe — loads counterIn into the counter on the next edge.
+    *               Hardware update has priority; preload only takes effect when stopped.
+    * counterIn    : preload value written by software.
+    * prescaler    : prescaler reload value (only present when prescalerWidth > 0).
+    *
+    * status.counter      : current counter value (readable by Mapper via bus).
+    * status.overflow     : pulses one cycle on counter bound (all modes).
+    * status.compareMatch : pulses one cycle when counter equals compareVals[ch].
+    * status.enableClear  : pulses one cycle on completion of a one-shot run.
+    *
+    * Modes (mode[1:0]):
+    *   00 free-run  — counts 0 to maxVal, wraps to 0.
+    *   01 periodic  — counts 0 to reloadVal, resets to 0; repeats.
+    *   10 one-shot  — counts 0 to reloadVal, resets to 0, asserts enableClear.
+    */
+  case class TimerCtrl(p: Parameter) extends Component {
+    val io = Io(p)
+
+    for (t <- 0 until p.count) {
+      new Area {
+        val cfg = io.config(t)
+        val sts = io.status(t)
+
+        // Prescaler: counts down from prescalerReg; generates tick on zero.
+        val tick = Bool()
+        if (p.prescalerWidth > 0) {
+          val prescalerCounter = Reg(UInt(p.prescalerWidth bits)) init (0)
+          tick := False
+          when(prescalerCounter === 0) {
+            tick := True
+            prescalerCounter := io.prescaler(t)
+          } otherwise {
+            prescalerCounter := prescalerCounter - 1
+          }
+        } else {
+          tick := True
+        }
+
+        // Counter register.
+        val counterReg = Reg(UInt(p.width bits)) init (0)
+        sts.counter := counterReg
+
+        // Overflow: at maxVal for free-run, at reloadVal for periodic/one-shot.
+        val maxVal = U((BigInt(1) << p.width) - 1, p.width bits)
+        val atBound = Bool()
+        when(cfg.mode === B"00") {
+          atBound := counterReg === maxVal
+        } otherwise {
+          atBound := counterReg === cfg.reloadVal
+        }
+
+        sts.overflow := cfg.enable && tick && atBound
+        sts.enableClear := cfg.enable && tick && atBound && (cfg.mode === B"10")
+
+        // Compare matches (checked against current counter value each tick).
+        for (ch <- 0 until p.channelCount) {
+          sts.compareMatch(ch) := cfg.enable && tick && (counterReg === cfg.compareVals(ch))
+        }
+
+        // Counter update. Hardware has priority; preload only takes effect when stopped.
+        when(cfg.enable && tick) {
+          when(atBound) {
+            counterReg := 0
+          } otherwise {
+            counterReg := counterReg + 1
+          }
+        } elsewhen (io.counterLoad(t)) {
+          counterReg := io.counterIn(t)
+        }
+      }.setName(s"timer_$t")
+    }
+  }
+
+  case class Mapper(
+      busCtrl: BusSlaveFactory,
+      ctrl: TimerCtrl,
+      p: Parameter
+  ) extends Area {
+    val idCtrl = IpIdentification(IpIdentification.Ids.Timer, 1, 0, 0)
+    idCtrl.driveFrom(busCtrl)
+    val regs = Regs(idCtrl.length, p)
+
+    // info: [7:0]=count [15:8]=channelCount [23:16]=width [31:24]=prescalerWidth
+    busCtrl.read(
+      B(p.prescalerWidth, 8 bits) ## B(p.width, 8 bits) ##
+        B(p.channelCount, 8 bits) ## B(p.count, 8 bits),
+      regs.info
+    )
+
+    // InterruptCtrl accumulates events; io.masks hardwired to all-ones so io.pendings
+    // returns raw (unmasked) pending on bus reads. A separate maskReg drives the
+    // interrupt output, keeping standard W1C-at-irqPending / mask-at-irqMask layout.
+    val irqCtrl = new InterruptCtrl(p.irqSources)
+    irqCtrl.io.masks := B((BigInt(1) << p.irqSources) - 1, p.irqSources bits)
+    val clearFlow = busCtrl.createAndDriveFlow(Bits(p.irqSources bits), regs.irqPending.toInt)
+    irqCtrl.io.clears := 0
+    when(clearFlow.valid) { irqCtrl.io.clears := clearFlow.payload }
+    busCtrl.read(irqCtrl.io.pendings.resized, regs.irqPending.toInt)
+    val maskReg = Reg(Bits(p.irqSources bits)) init (0)
+    busCtrl.readAndWrite(maskReg, regs.irqMask.toInt)
+    val irqEvents = Vec(Bool(), p.irqSources)
+
+    // Prescaler registers (only when prescalerWidth > 0).
+    if (p.prescalerWidth > 0) {
+      for (t <- 0 until p.count) {
+        val prescalerReg = Reg(UInt(p.prescalerWidth bits)) init (0)
+        busCtrl.readAndWrite(prescalerReg, regs.prescaler(t))
+        ctrl.io.prescaler(t) := prescalerReg
+      }
+    } else {
+      for (t <- 0 until p.count) {
+        busCtrl.read(B(0, 32 bits), regs.prescaler(t))
+      }
+    }
+
+    for (t <- 0 until p.count) {
+      new Area {
+        // Control register: hardware clears enable on one-shot completion.
+        val controlFlow = busCtrl.createAndDriveFlow(Bits(3 bits), regs.control(t))
+        val controlReg = Reg(Bits(3 bits)) init (0)
+        when(ctrl.io.status(t).enableClear) {
+          controlReg := B"000"
+        } elsewhen (controlFlow.valid) {
+          controlReg := controlFlow.payload
+        }
+        busCtrl.read(controlReg, regs.control(t))
+        ctrl.io.config(t).enable := controlReg(0)
+        ctrl.io.config(t).mode := controlReg(2 downto 1)
+
+        // Reload register.
+        val reloadReg = Reg(UInt(p.width bits)) init (0)
+        busCtrl.readAndWrite(reloadReg, regs.reload(t))
+        ctrl.io.config(t).reloadVal := reloadReg
+
+        // Compare registers.
+        for (ch <- 0 until p.channelCount) {
+          val compareReg =
+            Reg(UInt(p.width bits)) init (U((BigInt(1) << p.width) - 1, p.width bits))
+          busCtrl.readAndWrite(compareReg, regs.compare(t, ch))
+          ctrl.io.config(t).compareVals(ch) := compareReg
+        }
+
+        // Counter: bus reads live value; bus write preloads (when stopped).
+        val counterFlow = busCtrl.createAndDriveFlow(UInt(p.width bits), regs.counter(t))
+        ctrl.io.counterLoad(t) := counterFlow.valid
+        ctrl.io.counterIn(t) := counterFlow.payload
+        busCtrl.read(ctrl.io.status(t).counter, regs.counter(t))
+
+        // Interrupt sources: overflow at irqBase, compare[ch] at irqBase+1+ch.
+        val irqBase = t * (1 + p.channelCount)
+        irqEvents(irqBase) := ctrl.io.status(t).overflow
+        for (ch <- 0 until p.channelCount) {
+          irqEvents(irqBase + 1 + ch) := ctrl.io.status(t).compareMatch(ch)
+        }
+      }.setName(s"timer_$t")
+    }
+
+    irqCtrl.io.inputs := irqEvents.asBits
+    val interrupt = (irqCtrl.io.pendings & maskReg).orR
+  }
+}

--- a/hardware/scala/nafarr/system/watchdog/Watchdog.scala
+++ b/hardware/scala/nafarr/system/watchdog/Watchdog.scala
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.system.watchdog
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.BusSlaveFactory
+import spinal.lib.bus.amba3.apb._
+import spinal.lib.bus.tilelink.{
+  Bus => TileLinkBus,
+  BusParameter => TileLinkParameter,
+  SlaveFactory => TileLinkSlaveFactory
+}
+import spinal.lib.bus.wishbone._
+import nafarr.Feature
+import nafarr.peripherals.PeripheralsComponent
+
+object Watchdog {
+
+  class Core[T <: spinal.core.Data with IMasterSlave](
+      p: WatchdogCtrl.Parameter,
+      busType: HardType[T],
+      factory: T => BusSlaveFactory
+  ) extends PeripheralsComponent {
+    val io = new Bundle {
+      val bus = slave(busType())
+      val interrupt = out(Bool())
+      val error = out(Bool())
+    }
+    val busCtrl = factory(io.bus)
+    val ctrl = WatchdogCtrl(p)
+    val mapper = WatchdogCtrl.Mapper(busCtrl, ctrl, p)
+    io.interrupt := ctrl.io.interrupt
+    io.error := ctrl.io.error
+
+    override def getInterrupt = Some(io.interrupt)
+    override def getError = Some(io.error)
+    override def sysconFeatures = Some(List(Feature.Watchdog))
+
+    override def headerBareMetal(name: String, address: BigInt, size: BigInt) = {
+      val baseAddress = "%08x".format(address.toInt)
+      s"""#define ${name.toUpperCase}_BASE\t\t0x${baseAddress}\n"""
+    }
+  }
+}
+
+case class Apb3Watchdog(
+    p: WatchdogCtrl.Parameter,
+    busConfig: Apb3Config = Apb3Config(12, 32)
+) extends Watchdog.Core[Apb3](
+      p,
+      Apb3(busConfig),
+      Apb3SlaveFactory(_)
+    )
+
+case class TileLinkWatchdog(
+    p: WatchdogCtrl.Parameter,
+    busConfig: TileLinkParameter = TileLinkParameter.simple(12, 32, 4, 1)
+) extends Watchdog.Core[TileLinkBus](
+      p,
+      TileLinkBus(busConfig),
+      new TileLinkSlaveFactory(_, false)
+    )
+
+case class WishboneWatchdog(
+    p: WatchdogCtrl.Parameter,
+    busConfig: WishboneConfig = WishboneConfig(12, 32)
+) extends Watchdog.Core[Wishbone](
+      p,
+      Wishbone(busConfig),
+      WishboneSlaveFactory(_)
+    )

--- a/hardware/scala/nafarr/system/watchdog/WatchdogCtrl.scala
+++ b/hardware/scala/nafarr/system/watchdog/WatchdogCtrl.scala
@@ -1,0 +1,250 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.system.watchdog
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.misc.BusSlaveFactory
+import spinal.lib.misc.InterruptCtrl
+
+import nafarr.IpIdentification
+
+object WatchdogCtrl {
+  def apply(p: Parameter = Parameter.default()) = WatchdogCtrl(p)
+
+  case class Parameter(
+      count: Int = 1,
+      width: Int = 32,
+      prescalerWidth: Int = 16,
+      windowed: Boolean = false,
+      locked: Boolean = true
+  ) {
+    require(count >= 1 && count <= 255, "Watchdog count must be between 1 and 255")
+    require(width >= 1 && width <= 32, "Watchdog counter width must be between 1 and 32")
+    require(
+      prescalerWidth >= 1 && prescalerWidth <= 32,
+      "Prescaler width must be between 1 and 32"
+    )
+    val irqCount = if (windowed) 4 else 2
+  }
+  object Parameter {
+    def default() = Parameter()
+    def small() = Parameter(width = 16, prescalerWidth = 8)
+    def windowed() = Parameter(windowed = true)
+  }
+
+  object Regs {
+    def apply(base: BigInt) = new Regs(base)
+  }
+  class Regs(base: BigInt) {
+    val info = base + 0x00
+    private def wdtBase(wdt: Int) = base + 0x04 + wdt * 0x20
+    def control(wdt: Int) = wdtBase(wdt) + 0x00
+    def prescaler(wdt: Int) = wdtBase(wdt) + 0x04
+    def timeout(wdt: Int) = wdtBase(wdt) + 0x08
+    def windowOpen(wdt: Int) = wdtBase(wdt) + 0x0c
+    def status(wdt: Int) = wdtBase(wdt) + 0x10
+    def irqPending(wdt: Int) = wdtBase(wdt) + 0x14
+    def irqMask(wdt: Int) = wdtBase(wdt) + 0x18
+    def kick(wdt: Int) = wdtBase(wdt) + 0x1c
+  }
+
+  /** Hardware watchdog controller.
+    *
+    * Provides `p.count` independent watchdog timers. Each watchdog has a configurable
+    * prescaler and down-counter. When the counter reaches zero a timeout fires. In windowed
+    * mode a kick is only valid while the counter is at or below `windowOpen`; an early kick
+    * raises a window-violation event instead.
+    *
+    * Each watchdog has four independently maskable interrupt sources (two when not windowed):
+    *   - inputs(0): timeout → interrupt
+    *   - inputs(1): timeout → error
+    *   - inputs(2): window violation → interrupt  (windowed only)
+    *   - inputs(3): window violation → error      (windowed only)
+    *
+    * All masked pending bits across all watchdogs are OR-ed into the single `interrupt` output.
+    *
+    * io.enable          : in  — runtime enable per watchdog; rising edge reloads the counter.
+    * io.prescalerVal    : in  — divide-by-(n+1) prescaler value per watchdog.
+    * io.timeoutVal      : in  — counter reload value per watchdog.
+    * io.windowOpenVal   : in  — kick is valid when counter <= windowOpenVal (windowed mode).
+    * io.kick            : in  — pulse reloads the counter (or raises violation when windowed).
+    * io.timeoutEvent    : out — one-cycle pulse when the counter reaches zero.
+    * io.windowViolationEvent : out — one-cycle pulse on an early kick (windowed mode).
+    * io.inWindow        : out — high while counter <= windowOpenVal and watchdog is enabled.
+    * io.interrupt       : out — combined OR of all masked pending interrupt bits.
+    * io.pendingInterrupts : in — masked pending bits per watchdog, driven by Mapper.
+    */
+  case class WatchdogCtrl(p: Parameter) extends Component {
+    val io = new Bundle {
+      val enable = in(Vec(Bool(), p.count))
+      val prescalerVal = in(Vec(UInt(p.prescalerWidth bits), p.count))
+      val timeoutVal = in(Vec(UInt(p.width bits), p.count))
+      val windowOpenVal = in(Vec(UInt(p.width bits), p.count))
+      val kick = in(Vec(Bool(), p.count))
+      val timeoutEvent = out(Vec(Bool(), p.count))
+      val windowViolationEvent = out(Vec(Bool(), p.count))
+      val inWindow = out(Vec(Bool(), p.count))
+      val interrupt = out Bool ()
+      val error = out Bool ()
+      val pendingInterrupts = in(Vec(Bits(p.irqCount bits), p.count))
+    }
+
+    for (i <- 0 until p.count) {
+      val prescalerCnt = Reg(UInt(p.prescalerWidth bits)) init (0)
+      val counter = Reg(UInt(p.width bits)) init (0)
+      val enablePrev = RegNext(io.enable(i)) init (False)
+      val enableRise = io.enable(i) && !enablePrev
+      val tick = prescalerCnt === io.prescalerVal(i)
+
+      io.timeoutEvent(i) := False
+      io.windowViolationEvent(i) := False
+      if (p.windowed) {
+        io.inWindow(i) := io.enable(i) && (counter <= io.windowOpenVal(i))
+      } else {
+        io.inWindow(i) := False
+      }
+
+      when(enableRise) {
+        counter := io.timeoutVal(i)
+        prescalerCnt := 0
+      } elsewhen (io.enable(i)) {
+        when(io.kick(i)) {
+          if (p.windowed) {
+            when(counter <= io.windowOpenVal(i)) {
+              counter := io.timeoutVal(i)
+              prescalerCnt := 0
+            } otherwise {
+              io.windowViolationEvent(i) := True
+            }
+          } else {
+            counter := io.timeoutVal(i)
+            prescalerCnt := 0
+          }
+        } elsewhen (tick) {
+          prescalerCnt := 0
+          when(counter === 0) {
+            io.timeoutEvent(i) := True
+            counter := io.timeoutVal(i)
+          } otherwise {
+            counter := counter - 1
+          }
+        } otherwise {
+          prescalerCnt := prescalerCnt + 1
+        }
+      }
+    }
+
+    io.interrupt := io.pendingInterrupts
+      .map(bits => bits(0) || (if (p.windowed) bits(2) else False))
+      .reduce(_ || _)
+    io.error := io.pendingInterrupts
+      .map(bits => bits(1) || (if (p.windowed) bits(3) else False))
+      .reduce(_ || _)
+  }
+
+  case class Mapper(
+      busCtrl: BusSlaveFactory,
+      ctrl: WatchdogCtrl,
+      p: Parameter
+  ) extends Area {
+    val idCtrl = IpIdentification(IpIdentification.Ids.Watchdog, 1, 0, 0)
+    idCtrl.driveFrom(busCtrl)
+    val regs = Regs(idCtrl.length)
+
+    busCtrl.read(
+      B(0, 6 bits) ## Bool(p.locked) ## Bool(p.windowed) ##
+        B(p.prescalerWidth, 8 bits) ## B(p.width, 8 bits) ## B(p.count, 8 bits),
+      regs.info
+    )
+
+    for (wdt <- 0 until p.count) {
+      new Area {
+        val enableReg = Reg(Bool()) init (False)
+        val lockReg = if (p.locked) Reg(Bool()) init (False) else null
+        val isLocked: Bool = if (p.locked) lockReg else False
+
+        val controlFlow = busCtrl.createAndDriveFlow(Bits(32 bits), regs.control(wdt))
+        when(controlFlow.valid) {
+          if (p.locked) {
+            when(!isLocked) {
+              enableReg := controlFlow.payload(0)
+            } elsewhen (controlFlow.payload(0)) {
+              enableReg := True
+            }
+            when(controlFlow.payload(1)) {
+              lockReg := True
+            }
+          } else {
+            enableReg := controlFlow.payload(0)
+          }
+        }
+        val controlBits = Bits(2 bits)
+        controlBits(0) := enableReg
+        if (p.locked) {
+          controlBits(1) := lockReg
+        } else {
+          controlBits(1) := False
+        }
+        busCtrl.read(controlBits.resize(32), regs.control(wdt))
+
+        val prescalerReg = Reg(UInt(p.prescalerWidth bits)) init (~U(0, p.prescalerWidth bits))
+        val prescalerFlow = busCtrl.createAndDriveFlow(Bits(32 bits), regs.prescaler(wdt))
+        when(prescalerFlow.valid && !isLocked) {
+          prescalerReg := prescalerFlow.payload(p.prescalerWidth - 1 downto 0).asUInt
+        }
+        busCtrl.read(prescalerReg.resize(32), regs.prescaler(wdt))
+
+        val timeoutReg = Reg(UInt(p.width bits)) init (~U(0, p.width bits))
+        val timeoutFlow = busCtrl.createAndDriveFlow(Bits(32 bits), regs.timeout(wdt))
+        when(timeoutFlow.valid && !isLocked) {
+          timeoutReg := timeoutFlow.payload(p.width - 1 downto 0).asUInt
+        }
+        busCtrl.read(timeoutReg.resize(32), regs.timeout(wdt))
+
+        if (p.windowed) {
+          val windowOpenReg = Reg(UInt(p.width bits)) init (U(0, p.width bits))
+          val windowOpenFlow = busCtrl.createAndDriveFlow(Bits(32 bits), regs.windowOpen(wdt))
+          when(windowOpenFlow.valid && !isLocked) {
+            windowOpenReg := windowOpenFlow.payload(p.width - 1 downto 0).asUInt
+          }
+          busCtrl.read(windowOpenReg.resize(32), regs.windowOpen(wdt))
+          ctrl.io.windowOpenVal(wdt) := windowOpenReg
+        } else {
+          busCtrl.read(B(0, 32 bits), regs.windowOpen(wdt))
+          ctrl.io.windowOpenVal(wdt) := U(0, p.width bits)
+        }
+
+        ctrl.io.enable(wdt) := enableReg
+        ctrl.io.prescalerVal(wdt) := prescalerReg
+        ctrl.io.timeoutVal(wdt) := timeoutReg
+
+        val statusBits = Bits(3 bits)
+        statusBits(0) := enableReg
+        if (p.locked) {
+          statusBits(1) := lockReg
+        } else {
+          statusBits(1) := False
+        }
+        statusBits(2) := ctrl.io.inWindow(wdt)
+        busCtrl.read(statusBits.resize(32), regs.status(wdt))
+
+        val irqCtrl = new InterruptCtrl(p.irqCount)
+        irqCtrl.driveFrom(busCtrl, regs.irqPending(wdt).toInt)
+        irqCtrl.io.inputs(0) := ctrl.io.timeoutEvent(wdt)
+        irqCtrl.io.inputs(1) := ctrl.io.timeoutEvent(wdt)
+        if (p.windowed) {
+          irqCtrl.io.inputs(2) := ctrl.io.windowViolationEvent(wdt)
+          irqCtrl.io.inputs(3) := ctrl.io.windowViolationEvent(wdt)
+        }
+        ctrl.io.pendingInterrupts(wdt) := irqCtrl.io.pendings
+
+        val kickFlow = busCtrl.createAndDriveFlow(Bits(32 bits), regs.kick(wdt))
+        ctrl.io.kick(wdt) := kickFlow.valid
+        kickFlow.payload.allowPruning()
+      }
+    }
+  }
+}

--- a/software/driver/clock.c
+++ b/software/driver/clock.c
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "clock.h"
+
+void clock_init(struct clock_driver *driver, unsigned long base_address)
+{
+	driver->regs = (struct clock_regs *)base_address;
+}
+
+unsigned int clock_domain_count(struct clock_driver *driver)
+{
+	return driver->regs->domains & 0xFF;
+}
+
+unsigned int clock_enable_get(struct clock_driver *driver)
+{
+	return driver->regs->enable;
+}
+
+void clock_enable_set(struct clock_driver *driver, unsigned int mask)
+{
+	driver->regs->enable = mask;
+}

--- a/software/driver/crc32.c
+++ b/software/driver/crc32.c
@@ -6,7 +6,7 @@
 
 #include "crc32.h"
 
-int crc32_init_driver(struct crc32_driver *driver, unsigned int base_address)
+int crc32_init_driver(struct crc32_driver *driver, unsigned long base_address)
 {
 	driver->regs = (volatile struct crc32_regs *)base_address;
 

--- a/software/driver/crc32.c
+++ b/software/driver/crc32.c
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "crc32.h"
+
+int crc32_init_driver(struct crc32_driver *driver, unsigned int base_address)
+{
+	driver->regs = (volatile struct crc32_regs *)base_address;
+
+	return 1;
+}
+
+void crc32_init(struct crc32_driver *driver)
+{
+	driver->regs->control = 1;
+}
+
+void crc32_write(struct crc32_driver *driver, unsigned int word)
+{
+	driver->regs->data = word;
+}
+
+unsigned int crc32_read(struct crc32_driver *driver)
+{
+	return driver->regs->result;
+}
+
+unsigned int crc32_info(struct crc32_driver *driver)
+{
+	return driver->regs->info;
+}
+
+unsigned int crc32_get_xorout(struct crc32_driver *driver)
+{
+	return driver->regs->xor_out;
+}
+
+void crc32_set_xorout(struct crc32_driver *driver, unsigned int value)
+{
+	driver->regs->xor_out = value;
+}

--- a/software/driver/esm.c
+++ b/software/driver/esm.c
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "esm.h"
+
+int esm_init(struct esm_driver *driver, unsigned int base_address)
+{
+	driver->regs = (volatile struct esm_regs *)base_address;
+	driver->bank_count = (driver->regs->info >> 9) & 0x7Fu;
+	return 1;
+}
+
+void esm_enable(struct esm_driver *driver)
+{
+	driver->regs->control |= ESM_CTRL_ENABLE;
+}
+
+void esm_disable(struct esm_driver *driver)
+{
+	driver->regs->control &= ~ESM_CTRL_ENABLE;
+}
+
+void esm_lock(struct esm_driver *driver)
+{
+	driver->regs->control |= ESM_CTRL_LOCK;
+}
+
+void esm_configure(struct esm_driver *driver, unsigned int bank, uint32_t mask)
+{
+	driver->regs->banks[bank].enable = mask;
+}
+
+void esm_configure_counter(struct esm_driver *driver, uint32_t counter)
+{
+	driver->regs->error_counter = counter;
+}
+
+void esm_inject_enable(struct esm_driver *driver)
+{
+	driver->regs->control |= ESM_CTRL_INJECT_ENABLE;
+}
+
+void esm_inject_disable(struct esm_driver *driver)
+{
+	driver->regs->control &= ~ESM_CTRL_INJECT_ENABLE;
+}
+
+void esm_inject_set(struct esm_driver *driver, unsigned int bank, uint32_t bits)
+{
+	driver->regs->banks[bank].inject |= bits;
+}
+
+void esm_inject_clear(struct esm_driver *driver, unsigned int bank, uint32_t bits)
+{
+	driver->regs->banks[bank].inject &= ~bits;
+}
+
+uint32_t esm_status(struct esm_driver *driver)
+{
+	return driver->regs->status;
+}
+
+uint32_t esm_raw(struct esm_driver *driver, unsigned int bank)
+{
+	return driver->regs->banks[bank].raw;
+}
+
+uint32_t esm_pending(struct esm_driver *driver, unsigned int bank)
+{
+	return driver->regs->banks[bank].pending;
+}
+
+void esm_clear(struct esm_driver *driver, unsigned int bank, uint32_t mask)
+{
+	driver->regs->banks[bank].pending = mask;
+}

--- a/software/driver/esm.c
+++ b/software/driver/esm.c
@@ -6,7 +6,7 @@
 
 #include "esm.h"
 
-int esm_init(struct esm_driver *driver, unsigned int base_address)
+int esm_init(struct esm_driver *driver, unsigned long base_address)
 {
 	driver->regs = (volatile struct esm_regs *)base_address;
 	driver->bank_count = (driver->regs->info >> 9) & 0x7Fu;

--- a/software/driver/gpio.c
+++ b/software/driver/gpio.c
@@ -6,7 +6,7 @@
 
 #include "gpio.h"
 
-int gpio_init(struct gpio_driver *driver, unsigned int base_address)
+int gpio_init(struct gpio_driver *driver, unsigned long base_address)
 {
 	driver->regs = (struct gpio_regs *)base_address;
 
@@ -18,7 +18,7 @@ unsigned int gpio_value_get(struct gpio_driver *driver, unsigned int pin)
 	volatile struct gpio_bank_regs *bank = &driver->regs->banks[pin / GPIO_BANK_WIDTH];
 	unsigned int bit = pin % GPIO_BANK_WIDTH;
 
-	return (bank->data_in >> bit) & 0x1;
+	return (bank->input >> bit) & 0x1;
 }
 
 void gpio_value_set(struct gpio_driver *driver, unsigned int pin)
@@ -26,7 +26,7 @@ void gpio_value_set(struct gpio_driver *driver, unsigned int pin)
 	volatile struct gpio_bank_regs *bank = &driver->regs->banks[pin / GPIO_BANK_WIDTH];
 	unsigned int bit = pin % GPIO_BANK_WIDTH;
 
-	bank->data_out |= 1 << bit;
+	bank->output |= 1 << bit;
 }
 
 void gpio_value_clr(struct gpio_driver *driver, unsigned int pin)
@@ -34,7 +34,7 @@ void gpio_value_clr(struct gpio_driver *driver, unsigned int pin)
 	volatile struct gpio_bank_regs *bank = &driver->regs->banks[pin / GPIO_BANK_WIDTH];
 	unsigned int bit = pin % GPIO_BANK_WIDTH;
 
-	bank->data_out &= ~(1 << bit);
+	bank->output &= ~(1 << bit);
 }
 
 void gpio_dir_set(struct gpio_driver *driver, unsigned int pin)
@@ -42,7 +42,7 @@ void gpio_dir_set(struct gpio_driver *driver, unsigned int pin)
 	volatile struct gpio_bank_regs *bank = &driver->regs->banks[pin / GPIO_BANK_WIDTH];
 	unsigned int bit = pin % GPIO_BANK_WIDTH;
 
-	bank->dir_en |= 1 << bit;
+	bank->direction |= 1 << bit;
 }
 
 void gpio_dir_clr(struct gpio_driver *driver, unsigned int pin)
@@ -50,7 +50,7 @@ void gpio_dir_clr(struct gpio_driver *driver, unsigned int pin)
 	volatile struct gpio_bank_regs *bank = &driver->regs->banks[pin / GPIO_BANK_WIDTH];
 	unsigned int bit = pin % GPIO_BANK_WIDTH;
 
-	bank->dir_en &= ~(1 << bit);
+	bank->direction &= ~(1 << bit);
 }
 
 int gpio_irq_enable(struct gpio_driver *driver, unsigned int pin, int flags)
@@ -58,22 +58,14 @@ int gpio_irq_enable(struct gpio_driver *driver, unsigned int pin, int flags)
 	volatile struct gpio_bank_regs *bank = &driver->regs->banks[pin / GPIO_BANK_WIDTH];
 	unsigned int bit = pin % GPIO_BANK_WIDTH;
 
-	if (flags & GPIO_IRQ_LEVEL_HIGH) {
-		bank->irq_high_pending |= 1 << bit;
-		bank->irq_high_mask |= 1 << bit;
-	}
-	if (flags & GPIO_IRQ_LEVEL_LOW) {
-		bank->irq_low_pending |= 1 << bit;
-		bank->irq_low_mask |= 1 << bit;
-	}
-	if (flags & GPIO_IRQ_RISING_EDGE) {
-		bank->irq_rising_pending |= 1 << bit;
-		bank->irq_rising_mask |= 1 << bit;
-	}
-	if (flags & GPIO_IRQ_FALLING_EDGE) {
-		bank->irq_falling_pending |= 1 << bit;
-		bank->irq_falling_mask |= 1 << bit;
-	}
+	if (flags & GPIO_IRQ_LEVEL_HIGH)
+		bank->irq_high_enable |= 1 << bit;
+	if (flags & GPIO_IRQ_LEVEL_LOW)
+		bank->irq_low_enable |= 1 << bit;
+	if (flags & GPIO_IRQ_RISING_EDGE)
+		bank->irq_rising_enable |= 1 << bit;
+	if (flags & GPIO_IRQ_FALLING_EDGE)
+		bank->irq_falling_enable |= 1 << bit;
 
 	return 1;
 }
@@ -84,13 +76,13 @@ int gpio_irq_disable(struct gpio_driver *driver, unsigned int pin, int flags)
 	unsigned int bit = pin % GPIO_BANK_WIDTH;
 
 	if (flags & GPIO_IRQ_LEVEL_HIGH)
-		bank->irq_high_mask &= ~(1 << bit);
+		bank->irq_high_enable &= ~(1 << bit);
 	if (flags & GPIO_IRQ_LEVEL_LOW)
-		bank->irq_low_mask &= ~(1 << bit);
+		bank->irq_low_enable &= ~(1 << bit);
 	if (flags & GPIO_IRQ_RISING_EDGE)
-		bank->irq_rising_mask &= ~(1 << bit);
+		bank->irq_rising_enable &= ~(1 << bit);
 	if (flags & GPIO_IRQ_FALLING_EDGE)
-		bank->irq_falling_mask &= ~(1 << bit);
+		bank->irq_falling_enable &= ~(1 << bit);
 
 	return 1;
 }

--- a/software/driver/mailbox.c
+++ b/software/driver/mailbox.c
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "mailbox.h"
+
+int mailbox_init(struct mailbox_driver *driver, unsigned int base_address)
+{
+	driver->regs = (volatile struct mailbox_regs *)base_address;
+
+	return 1;
+}
+
+int mailbox_write(struct mailbox_driver *driver, unsigned int ch,
+		  unsigned int data)
+{
+	if (driver->regs->status & MAILBOX_STATUS_FULL(ch))
+		return 0;
+
+	driver->regs->channel[ch].write = data;
+
+	return 1;
+}
+
+int mailbox_read(struct mailbox_driver *driver, unsigned int ch,
+		 unsigned int *data)
+{
+	if (driver->regs->status & MAILBOX_STATUS_EMPTY(ch))
+		return 0;
+
+	*data = driver->regs->channel[ch].read;
+
+	return 1;
+}
+
+unsigned int mailbox_status(struct mailbox_driver *driver)
+{
+	return driver->regs->status;
+}
+
+unsigned int mailbox_occupancy(struct mailbox_driver *driver, unsigned int ch)
+{
+	return driver->regs->channel[ch].occupancy;
+}
+
+int mailbox_irq_enable(struct mailbox_driver *driver, unsigned int ch,
+		       int flags)
+{
+	driver->regs->channel[ch].irq_mask |= flags;
+
+	return 1;
+}
+
+int mailbox_irq_disable(struct mailbox_driver *driver, unsigned int ch,
+			int flags)
+{
+	driver->regs->channel[ch].irq_mask &= ~flags;
+
+	return 1;
+}
+
+int mailbox_irq_pending(struct mailbox_driver *driver, unsigned int ch,
+			int flags)
+{
+	return !!(driver->regs->channel[ch].irq_pending & flags);
+}
+
+void mailbox_irq_clear(struct mailbox_driver *driver, unsigned int ch,
+		       int flags)
+{
+	driver->regs->channel[ch].irq_pending = flags;
+}

--- a/software/driver/mailbox.c
+++ b/software/driver/mailbox.c
@@ -6,7 +6,7 @@
 
 #include "mailbox.h"
 
-int mailbox_init(struct mailbox_driver *driver, unsigned int base_address)
+int mailbox_init(struct mailbox_driver *driver, unsigned long base_address)
 {
 	driver->regs = (volatile struct mailbox_regs *)base_address;
 

--- a/software/driver/mtimer.c
+++ b/software/driver/mtimer.c
@@ -6,7 +6,7 @@
 
 #include "mtimer.h"
 
-int mtimer_init(struct mtimer_driver *driver, unsigned int base_address)
+int mtimer_init(struct mtimer_driver *driver, unsigned long base_address)
 {
 	driver->regs = (struct mtimer_regs *)base_address;
 

--- a/software/driver/pinmux.c
+++ b/software/driver/pinmux.c
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "pinmux.h"
+
+void pinmux_init(struct pinmux_driver *driver, unsigned long base_address)
+{
+	driver->regs = (struct pinmux_regs *)base_address;
+	driver->pin_count = PINMUX_PIN_COUNT(driver->regs->info);
+	driver->options_count = PINMUX_OPTIONS_COUNT(driver->regs->info);
+}
+
+unsigned int pinmux_pin_count(struct pinmux_driver *driver)
+{
+	return driver->pin_count;
+}
+
+unsigned int pinmux_options_count(struct pinmux_driver *driver)
+{
+	return driver->options_count;
+}
+
+void pinmux_set(struct pinmux_driver *driver, unsigned int pin, unsigned int option)
+{
+	if (pin >= driver->pin_count)
+		return;
+	driver->regs->option[pin] = option;
+}
+
+unsigned int pinmux_get(struct pinmux_driver *driver, unsigned int pin)
+{
+	if (pin >= driver->pin_count)
+		return 0;
+	return driver->regs->option[pin];
+}

--- a/software/driver/pio.c
+++ b/software/driver/pio.c
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: 2025 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "pio.h"
+
+void pio_init(struct pio_driver *driver, unsigned long base_address)
+{
+	driver->regs = (struct pio_regs *)base_address;
+}
+
+void pio_enable(struct pio_driver *driver)
+{
+	driver->regs->control |= PIO_CTRL_ENABLE;
+}
+
+void pio_disable(struct pio_driver *driver)
+{
+	driver->regs->control &= ~PIO_CTRL_ENABLE;
+}
+
+void pio_set_stop_at_loop(struct pio_driver *driver, int enable)
+{
+	if (enable)
+		driver->regs->control |= PIO_CTRL_STOP_AT_LOOP;
+	else
+		driver->regs->control &= ~PIO_CTRL_STOP_AT_LOOP;
+}
+
+void pio_program_reset(struct pio_driver *driver)
+{
+	driver->regs->fifo_status = 1;
+}
+
+void pio_program_write(struct pio_driver *driver, unsigned int cmd_word)
+{
+	driver->regs->read_write = cmd_word;
+}
+
+int pio_read(struct pio_driver *driver, unsigned int *result)
+{
+	unsigned int val = driver->regs->read_write;
+
+	if (!(val & PIO_READ_VALID))
+		return -1;
+
+	*result = PIO_READ_RESULT(val);
+	return 0;
+}
+
+void pio_irq_enable(struct pio_driver *driver, unsigned int mask)
+{
+	driver->regs->irq_enable |= mask;
+}
+
+void pio_irq_disable(struct pio_driver *driver, unsigned int mask)
+{
+	driver->regs->irq_enable &= ~mask;
+}
+
+unsigned int pio_irq_pending(struct pio_driver *driver)
+{
+	return driver->regs->irq_pending;
+}
+
+void pio_irq_clear(struct pio_driver *driver, unsigned int mask)
+{
+	driver->regs->irq_pending = mask;
+}

--- a/software/driver/plic.c
+++ b/software/driver/plic.c
@@ -6,7 +6,7 @@
 
 #include "plic.h"
 
-int plic_init(struct plic_driver *driver, unsigned int base_address)
+int plic_init(struct plic_driver *driver, unsigned long base_address)
 {
 	driver->gateway_priority = (unsigned int *)base_address;
 	driver->gateway_pending = (unsigned int *)base_address +

--- a/software/driver/prng.c
+++ b/software/driver/prng.c
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "prng.h"
+
+int prng_init(struct prng_driver *driver, unsigned int base_address)
+{
+	driver->regs = (volatile struct prng_regs *)base_address;
+
+	return 1;
+}
+
+void prng_enable(struct prng_driver *driver)
+{
+	driver->regs->control |= 1;
+}
+
+void prng_disable(struct prng_driver *driver)
+{
+	driver->regs->control &= ~1;
+}
+
+int prng_seed(struct prng_driver *driver, unsigned int seed)
+{
+	if (seed == 0)
+		return 0;
+
+	driver->regs->seed = seed;
+
+	return 1;
+}
+
+unsigned int prng_read(struct prng_driver *driver)
+{
+	return driver->regs->output;
+}
+
+int prng_error_pending(struct prng_driver *driver, int flags)
+{
+	return !!(driver->regs->error_pending & flags);
+}
+
+void prng_error_clear(struct prng_driver *driver, int flags)
+{
+	driver->regs->error_pending = flags;
+}
+
+void prng_error_mask(struct prng_driver *driver, int flags)
+{
+	driver->regs->error_mask |= flags;
+}
+
+void prng_error_unmask(struct prng_driver *driver, int flags)
+{
+	driver->regs->error_mask &= ~flags;
+}

--- a/software/driver/prng.c
+++ b/software/driver/prng.c
@@ -6,7 +6,7 @@
 
 #include "prng.h"
 
-int prng_init(struct prng_driver *driver, unsigned int base_address)
+int prng_init(struct prng_driver *driver, unsigned long base_address)
 {
 	driver->regs = (volatile struct prng_regs *)base_address;
 

--- a/software/driver/pwm.c
+++ b/software/driver/pwm.c
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: 2025 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "pwm.h"
+
+void pwm_init(struct pwm_driver *driver, unsigned long base_address)
+{
+	driver->regs = (struct pwm_regs *)base_address;
+	driver->channel_count = PWM_CHANNEL_COUNT(driver->regs->channel_config);
+}
+
+unsigned int pwm_channel_count(struct pwm_driver *driver)
+{
+	return driver->channel_count;
+}
+
+void pwm_channel_enable(struct pwm_driver *driver, unsigned int ch)
+{
+	pwm_channel(driver, ch)->control |= PWM_CTRL_ENABLE;
+}
+
+void pwm_channel_disable(struct pwm_driver *driver, unsigned int ch)
+{
+	pwm_channel(driver, ch)->control &= ~PWM_CTRL_ENABLE;
+}
+
+void pwm_channel_set_invert(struct pwm_driver *driver, unsigned int ch, int invert)
+{
+	if (invert)
+		pwm_channel(driver, ch)->control |= PWM_CTRL_INVERT;
+	else
+		pwm_channel(driver, ch)->control &= ~PWM_CTRL_INVERT;
+}
+
+void pwm_channel_set_mode_center(struct pwm_driver *driver, unsigned int ch, int center)
+{
+	if (center)
+		pwm_channel(driver, ch)->control |= PWM_CTRL_MODE_CENTER;
+	else
+		pwm_channel(driver, ch)->control &= ~PWM_CTRL_MODE_CENTER;
+}
+
+void pwm_channel_set_clock_div(struct pwm_driver *driver, unsigned int ch, unsigned int div)
+{
+	pwm_channel(driver, ch)->clock_div = div;
+}
+
+void pwm_channel_set_period(struct pwm_driver *driver, unsigned int ch, unsigned int period)
+{
+	pwm_channel(driver, ch)->period = period;
+}
+
+void pwm_channel_set_duty(struct pwm_driver *driver, unsigned int ch,
+	unsigned int rising, unsigned int falling)
+{
+	volatile struct pwm_channel_regs *c = pwm_channel(driver, ch);
+	c->rising_edge = rising;
+	c->falling_edge = falling;
+}
+
+void pwm_channel_set_dead_time(struct pwm_driver *driver, unsigned int ch, unsigned int dt)
+{
+	pwm_channel(driver, ch)->dead_time = dt;
+}
+
+void pwm_channel_set_phase_offset(struct pwm_driver *driver, unsigned int ch, unsigned int offset)
+{
+	pwm_channel(driver, ch)->phase_offset = offset;
+}
+
+void pwm_channel_set_shot_count(struct pwm_driver *driver, unsigned int ch, unsigned int count)
+{
+	pwm_channel(driver, ch)->shot_count = count;
+}
+
+unsigned int pwm_channel_status(struct pwm_driver *driver, unsigned int ch)
+{
+	return pwm_channel(driver, ch)->status;
+}
+
+void pwm_irq_enable(struct pwm_driver *driver, unsigned int channel_mask)
+{
+	driver->regs->irq_enable |= channel_mask;
+}
+
+void pwm_irq_disable(struct pwm_driver *driver, unsigned int channel_mask)
+{
+	driver->regs->irq_enable &= ~channel_mask;
+}
+
+unsigned int pwm_irq_pending(struct pwm_driver *driver)
+{
+	return driver->regs->irq_pending;
+}
+
+void pwm_irq_clear(struct pwm_driver *driver, unsigned int channel_mask)
+{
+	driver->regs->irq_pending = channel_mask;
+}

--- a/software/driver/reset.c
+++ b/software/driver/reset.c
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "reset.h"
+
+void reset_init(struct reset_driver *driver, unsigned long base_address)
+{
+	driver->regs = (struct reset_regs *)base_address;
+}
+
+unsigned int reset_domain_count(struct reset_driver *driver)
+{
+	return driver->regs->domains & 0xFF;
+}
+
+unsigned int reset_enable_get(struct reset_driver *driver)
+{
+	return driver->regs->enable;
+}
+
+void reset_enable_set(struct reset_driver *driver, unsigned int mask)
+{
+	driver->regs->enable = mask;
+}
+
+void reset_trigger(struct reset_driver *driver, unsigned int mask)
+{
+	driver->regs->trigger = mask;
+}
+
+void reset_acknowledge(struct reset_driver *driver)
+{
+	driver->regs->acknowledge = 1;
+}

--- a/software/driver/semaphore.c
+++ b/software/driver/semaphore.c
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "semaphore.h"
+
+int semaphore_init(struct semaphore_driver *driver, unsigned int base_address,
+		   unsigned int count)
+{
+	driver->regs = (volatile struct semaphore_regs *)base_address;
+	driver->count = count;
+
+	return 1;
+}
+
+int semaphore_claim(struct semaphore_driver *driver, unsigned int n)
+{
+	return driver->regs->semaphore[n] & 0x1;
+}
+
+void semaphore_release(struct semaphore_driver *driver, unsigned int n)
+{
+	driver->regs->semaphore[n] = 0;
+}
+
+unsigned int semaphore_status(struct semaphore_driver *driver)
+{
+	return driver->regs->status;
+}

--- a/software/driver/semaphore.c
+++ b/software/driver/semaphore.c
@@ -6,7 +6,7 @@
 
 #include "semaphore.h"
 
-int semaphore_init(struct semaphore_driver *driver, unsigned int base_address,
+int semaphore_init(struct semaphore_driver *driver, unsigned long base_address,
 		   unsigned int count)
 {
 	driver->regs = (volatile struct semaphore_regs *)base_address;

--- a/software/driver/syscon.c
+++ b/software/driver/syscon.c
@@ -6,7 +6,7 @@
 
 #include "syscon.h"
 
-void syscon_init(struct syscon_driver *driver, unsigned int base_address)
+void syscon_init(struct syscon_driver *driver, unsigned long base_address)
 {
 	driver->regs = (volatile struct syscon_regs *)base_address;
 }

--- a/software/driver/syscon.c
+++ b/software/driver/syscon.c
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "syscon.h"
+
+void syscon_init(struct syscon_driver *driver, unsigned int base_address)
+{
+	driver->regs = (volatile struct syscon_regs *)base_address;
+}
+
+unsigned int syscon_vendor(struct syscon_driver *driver)
+{
+	return SYSCON_VENDOR(driver->regs->identity);
+}
+
+unsigned int syscon_platform(struct syscon_driver *driver)
+{
+	return SYSCON_PLATFORM(driver->regs->identity);
+}
+
+unsigned int syscon_platform_class(struct syscon_driver *driver)
+{
+	return SYSCON_PLATFORM_CLASS(driver->regs->identity);
+}
+
+unsigned int syscon_product(struct syscon_driver *driver)
+{
+	return SYSCON_PRODUCT(driver->regs->identity);
+}
+
+unsigned int syscon_silicon_major(struct syscon_driver *driver)
+{
+	return driver->regs->silicon_major;
+}
+
+unsigned int syscon_silicon_minor(struct syscon_driver *driver)
+{
+	return driver->regs->silicon_minor;
+}
+
+unsigned int syscon_features(struct syscon_driver *driver)
+{
+	return driver->regs->features;
+}
+
+unsigned int syscon_ref_clock(struct syscon_driver *driver)
+{
+	return driver->regs->ref_clock;
+}
+
+unsigned int syscon_build_date(struct syscon_driver *driver)
+{
+	return driver->regs->build_date;
+}
+
+int syscon_has_feature(struct syscon_driver *driver, unsigned int feature_bit)
+{
+	return (driver->regs->features & feature_bit) != 0;
+}

--- a/software/driver/timer.c
+++ b/software/driver/timer.c
@@ -14,7 +14,7 @@ static volatile unsigned int *timer_base(struct timer_driver *driver, unsigned i
 					 t * driver->stride);
 }
 
-void timer_init(struct timer_driver *driver, unsigned int base_address)
+void timer_init(struct timer_driver *driver, unsigned long base_address)
 {
 	unsigned int info;
 

--- a/software/driver/timer.c
+++ b/software/driver/timer.c
@@ -1,0 +1,82 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "timer.h"
+
+/* Per-timer registers start at regs base + 0x14, stride bytes apart.
+ * Returns a pointer to word 0 (control) of timer t. */
+static volatile unsigned int *timer_base(struct timer_driver *driver, unsigned int t)
+{
+	return (volatile unsigned int *)((unsigned char *)driver->regs + 0x14 +
+					 t * driver->stride);
+}
+
+void timer_init(struct timer_driver *driver, unsigned int base_address)
+{
+	unsigned int info;
+
+	driver->regs = (volatile struct timer_regs *)base_address;
+	info = driver->regs->info;
+	driver->count         = TIMER_INFO_COUNT(info);
+	driver->channel_count = TIMER_INFO_CHANNEL_COUNT(info);
+	driver->stride        = 0x10 + driver->channel_count * 4;
+}
+
+void timer_set_control(struct timer_driver *driver, unsigned int t, unsigned int ctrl)
+{
+	timer_base(driver, t)[0] = ctrl;
+}
+
+unsigned int timer_get_control(struct timer_driver *driver, unsigned int t)
+{
+	return timer_base(driver, t)[0];
+}
+
+void timer_set_prescaler(struct timer_driver *driver, unsigned int t, unsigned int val)
+{
+	timer_base(driver, t)[1] = val;
+}
+
+void timer_set_reload(struct timer_driver *driver, unsigned int t, unsigned int val)
+{
+	timer_base(driver, t)[3] = val;
+}
+
+unsigned int timer_get_counter(struct timer_driver *driver, unsigned int t)
+{
+	return timer_base(driver, t)[2];
+}
+
+void timer_set_counter(struct timer_driver *driver, unsigned int t, unsigned int val)
+{
+	timer_base(driver, t)[2] = val;
+}
+
+void timer_set_compare(struct timer_driver *driver, unsigned int t, unsigned int ch,
+		       unsigned int val)
+{
+	timer_base(driver, t)[4 + ch] = val;
+}
+
+unsigned int timer_irq_pending(struct timer_driver *driver)
+{
+	return driver->regs->irq_pending;
+}
+
+void timer_irq_clear(struct timer_driver *driver, unsigned int mask)
+{
+	driver->regs->irq_pending = mask;
+}
+
+void timer_irq_enable(struct timer_driver *driver, unsigned int mask)
+{
+	driver->regs->irq_mask |= mask;
+}
+
+void timer_irq_disable(struct timer_driver *driver, unsigned int mask)
+{
+	driver->regs->irq_mask &= ~mask;
+}

--- a/software/driver/uart.c
+++ b/software/driver/uart.c
@@ -6,10 +6,7 @@
 
 #include "uart.h"
 
-#define DEV_UART_IRQ_TX_EN		(1 << 0)
-#define DEV_UART_IRQ_RX_EN		(1 << 1)
-
-int uart_init(struct uart_driver *driver, unsigned int base_address,
+int uart_init(struct uart_driver *driver, unsigned long base_address,
 		unsigned int frequency)
 {
 	driver->regs = (struct uart_regs *)base_address;
@@ -33,14 +30,15 @@ void uart_putc(struct uart_driver *driver, unsigned char c)
 {
 	volatile struct uart_regs *uart = driver->regs;
 
-	while ((uart->status & 0x00FF0000) == 0);
+	/* wait for TX FIFO vacancy ([23:16] nonzero) */
+	while ((uart->fifo_status & 0x00FF0000) == 0);
 	uart->read_write = c;
 }
 
 int uart_getc(struct uart_driver *driver, unsigned char *c)
 {
 	volatile struct uart_regs *uart = driver->regs;
-	int val;
+	unsigned int val;
 
 	val = uart->read_write;
 	if (val & 0x10000) {
@@ -55,8 +53,7 @@ int uart_irq_rx_enable(struct uart_driver *driver)
 {
 	volatile struct uart_regs *uart = driver->regs;
 
-	uart->ip |= DEV_UART_IRQ_RX_EN;
-	uart->ie |= DEV_UART_IRQ_RX_EN;
+	uart->irq_enable |= UART_IRQ_RX;
 
 	return 1;
 }
@@ -65,7 +62,7 @@ int uart_irq_rx_disable(struct uart_driver *driver)
 {
 	volatile struct uart_regs *uart = driver->regs;
 
-	uart->ie &= ~DEV_UART_IRQ_RX_EN;
+	uart->irq_enable &= ~UART_IRQ_RX;
 
 	return 1;
 }
@@ -74,5 +71,5 @@ int uart_irq_rx_ready(struct uart_driver *driver)
 {
 	volatile struct uart_regs *uart = driver->regs;
 
-	return !!(uart->ip & DEV_UART_IRQ_RX_EN);
+	return !!(uart->irq_pending & UART_IRQ_RX);
 }

--- a/software/driver/watchdog.c
+++ b/software/driver/watchdog.c
@@ -6,7 +6,7 @@
 
 #include "watchdog.h"
 
-int watchdog_init(struct watchdog_driver *driver, unsigned int base_address)
+int watchdog_init(struct watchdog_driver *driver, unsigned long base_address)
 {
 	driver->regs = (volatile struct watchdog_regs *)base_address;
 

--- a/software/driver/watchdog.c
+++ b/software/driver/watchdog.c
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "watchdog.h"
+
+int watchdog_init(struct watchdog_driver *driver, unsigned int base_address)
+{
+	driver->regs = (volatile struct watchdog_regs *)base_address;
+
+	return 1;
+}
+
+void watchdog_configure(struct watchdog_driver *driver, unsigned int wdt,
+			uint32_t prescaler, uint32_t timeout)
+{
+	driver->regs->wdt[wdt].prescaler = prescaler;
+	driver->regs->wdt[wdt].timeout = timeout;
+}
+
+void watchdog_configure_window(struct watchdog_driver *driver, unsigned int wdt,
+			       uint32_t window_open)
+{
+	driver->regs->wdt[wdt].window_open = window_open;
+}
+
+void watchdog_enable(struct watchdog_driver *driver, unsigned int wdt)
+{
+	driver->regs->wdt[wdt].control |= WATCHDOG_CTRL_ENABLE;
+}
+
+void watchdog_disable(struct watchdog_driver *driver, unsigned int wdt)
+{
+	driver->regs->wdt[wdt].control &= ~WATCHDOG_CTRL_ENABLE;
+}
+
+void watchdog_lock(struct watchdog_driver *driver, unsigned int wdt)
+{
+	driver->regs->wdt[wdt].control |= WATCHDOG_CTRL_LOCK;
+}
+
+void watchdog_kick(struct watchdog_driver *driver, unsigned int wdt)
+{
+	driver->regs->wdt[wdt].kick = 1;
+}
+
+uint32_t watchdog_status(struct watchdog_driver *driver, unsigned int wdt)
+{
+	return driver->regs->wdt[wdt].status;
+}
+
+void watchdog_irq_enable(struct watchdog_driver *driver, unsigned int wdt,
+			 uint32_t flags)
+{
+	driver->regs->wdt[wdt].irq_mask |= flags;
+}
+
+void watchdog_irq_disable(struct watchdog_driver *driver, unsigned int wdt,
+			  uint32_t flags)
+{
+	driver->regs->wdt[wdt].irq_mask &= ~flags;
+}
+
+int watchdog_irq_pending(struct watchdog_driver *driver, unsigned int wdt,
+			 uint32_t flags)
+{
+	return !!(driver->regs->wdt[wdt].irq_pending & flags);
+}
+
+void watchdog_irq_clear(struct watchdog_driver *driver, unsigned int wdt,
+			uint32_t flags)
+{
+	driver->regs->wdt[wdt].irq_pending = flags;
+}

--- a/software/include/clock.h
+++ b/software/include/clock.h
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ELEMENTS_CLOCK_H
+#define ELEMENTS_CLOCK_H
+
+struct clock_regs {
+	unsigned int ip_header;   /* 0x000 — IP identification header */
+	unsigned int ip_version;  /* 0x004 — IP identification version */
+	unsigned int domains;     /* 0x008 — number of clock domains (read-only) */
+	unsigned int enable;      /* 0x00C — enabled domain bitmask (1=enabled) */
+};
+
+struct clock_driver {
+	volatile struct clock_regs *regs;
+};
+
+void clock_init(struct clock_driver *driver, unsigned long base_address);
+
+unsigned int clock_domain_count(struct clock_driver *driver);
+unsigned int clock_enable_get(struct clock_driver *driver);
+void clock_enable_set(struct clock_driver *driver, unsigned int mask);
+
+#endif

--- a/software/include/crc32.h
+++ b/software/include/crc32.h
@@ -27,7 +27,7 @@ struct crc32_driver {
 	volatile struct crc32_regs *regs;
 };
 
-int crc32_init_driver(struct crc32_driver *driver, unsigned int base_address);
+int crc32_init_driver(struct crc32_driver *driver, unsigned long base_address);
 
 /**
  * Reset the CRC state to the polynomial init value.

--- a/software/include/crc32.h
+++ b/software/include/crc32.h
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ELEMENTS_CRC32_H
+#define ELEMENTS_CRC32_H
+
+/* info register bit masks */
+#define CRC32_INFO_POLY_ORDER_MASK    (0xFF)
+#define CRC32_INFO_INPUT_REFLECT      (1 << 8)
+#define CRC32_INFO_OUTPUT_REFLECT     (1 << 9)
+#define CRC32_INFO_XOROUT_PRESENT     (1 << 10)
+
+struct crc32_regs {
+	unsigned int ip_header;   /* 0x000 */
+	unsigned int ip_version;  /* 0x004 */
+	unsigned int info;        /* 0x008 - self-disclosure (read-only) */
+	unsigned int control;     /* 0x00C - write any to init/reset CRC state */
+	unsigned int data;        /* 0x010 - write-only, fold one 32-bit word */
+	unsigned int result;      /* 0x014 - read-only, crc32_state XOR xor_out */
+	unsigned int xor_out;     /* 0x018 - R/W, optional (reads 0 if absent) */
+};
+
+struct crc32_driver {
+	volatile struct crc32_regs *regs;
+};
+
+int crc32_init_driver(struct crc32_driver *driver, unsigned int base_address);
+
+/**
+ * Reset the CRC state to the polynomial init value.
+ */
+void crc32_init(struct crc32_driver *driver);
+
+/**
+ * Fold one 32-bit word into the CRC state.
+ */
+void crc32_write(struct crc32_driver *driver, unsigned int word);
+
+/**
+ * Read the current CRC result (crc32_state XOR xor_out).
+ */
+unsigned int crc32_read(struct crc32_driver *driver);
+
+/**
+ * Read the info register to determine the compiled configuration.
+ */
+unsigned int crc32_info(struct crc32_driver *driver);
+
+/**
+ * Read the xorOut register. Returns 0 when not present.
+ */
+unsigned int crc32_get_xorout(struct crc32_driver *driver);
+
+/**
+ * Write the xorOut register. No-op when not present in hardware.
+ */
+void crc32_set_xorout(struct crc32_driver *driver, unsigned int value);
+
+#endif

--- a/software/include/esm.h
+++ b/software/include/esm.h
@@ -1,0 +1,155 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ELEMENTS_ESM_H
+#define ELEMENTS_ESM_H
+
+#include <stdint.h>
+
+/* control register bits */
+#define ESM_CTRL_ENABLE        (1u << 0)
+#define ESM_CTRL_LOCK          (1u << 1)
+#define ESM_CTRL_INJECT_ENABLE (1u << 2)
+
+/* status register bits */
+#define ESM_STATUS_COUNTER_ACTIVE (1u << 0)
+#define ESM_STATUS_ERROR_SIGNAL   (1u << 1)
+
+/*
+ * Enable/pending register layout (one register covers all four levels for 8 inputs).
+ *
+ * Each 32-bit register is divided into four byte lanes, one per severity level:
+ *   bits [31:24] = FATAL  for inputs [7:0] of the bank
+ *   bits [23:16] = ERROR  for inputs [7:0] of the bank
+ *   bits  [15:8] = WARN   for inputs [7:0] of the bank
+ *   bits   [7:0] = INFO   for inputs [7:0] of the bank
+ *
+ * Macros to build a mask for the enable/pending registers:
+ *   ESM_LEVEL_INFO/WARN/ERROR/FATAL(input_mask) — place input_mask in the right byte lane.
+ *
+ * Example: route inputs 0 and 1 to WARN and inputs 2 and 3 to FATAL:
+ *   esm_configure(driver, bank, ESM_LEVEL_WARN(0x3) | ESM_LEVEL_FATAL(0xc));
+ */
+#define ESM_LEVEL_INFO(mask)  (((mask) & 0xFFu))
+#define ESM_LEVEL_WARN(mask)  (((mask) & 0xFFu) << 8)
+#define ESM_LEVEL_ERROR(mask) (((mask) & 0xFFu) << 16)
+#define ESM_LEVEL_FATAL(mask) (((mask) & 0xFFu) << 24)
+
+/* Extract per-level pending bits from a pending register value. */
+#define ESM_PENDING_INFO(reg)  ((reg) & 0xFFu)
+#define ESM_PENDING_WARN(reg)  (((reg) >> 8) & 0xFFu)
+#define ESM_PENDING_ERROR(reg) (((reg) >> 16) & 0xFFu)
+#define ESM_PENDING_FATAL(reg) (((reg) >> 24) & 0xFFu)
+
+/*
+ * Per-bank register block (stride 0x10).
+ *
+ * Each bank covers 8 inputs. For inputCount <= 8: only banks[0] is used.
+ * The last bank may cover fewer than 8 inputs; upper bits are reserved/zero.
+ *
+ * Severity levels and their outputs:
+ *   INFO  -> infoInterrupt  (low-priority PLIC lane)
+ *   WARN  -> warnInterrupt  (high-priority PLIC lane)
+ *   ERROR -> errorSignal    (after grace-period counter)
+ *   FATAL -> errorSignal    (immediately, bypasses counter)
+ *
+ * Pending bits are write-1-to-clear (W1C). An input can be routed to
+ * multiple levels simultaneously via the combined enable register.
+ *
+ * Lock scope: ERROR/FATAL fields of enable (bits [31:16]) and inject are
+ * frozen once the ESM is locked. INFO/WARN fields (bits [15:0]) are never locked.
+ */
+struct esm_bank {
+	uint32_t enable;  /* +0x00 [31:24]=FATAL,[23:16]=ERROR,[15:8]=WARN,[7:0]=INFO */
+	uint32_t pending; /* +0x04 same layout, W1C */
+	uint32_t raw;     /* +0x08 active inputs for this bank (read-only) */
+	uint32_t inject;  /* +0x0C bits [7:0]: injected inputs; writable only when injectEnable && !locked */
+};
+
+/*
+ * ESM register map.
+ *
+ * info register fields (read-only):
+ *   bits  [8:0] = inputCount
+ *   bits [15:9] = bankCount
+ *   bits [23:16] = counterWidth
+ *   bit  [24]   = locked
+ *
+ * The grace-period counter starts when any ERROR pending bit is set. If all
+ * ERROR pending bits are cleared before it expires no errorSignal is raised.
+ * Setting errorCounter = 0 makes ERROR behave like FATAL (immediate).
+ *
+ * Locking (ESM_CTRL_LOCK) atomically clears injectEnable, zeroes all inject
+ * bank registers, and freezes ERROR/FATAL enables, errorCounter, and inject.
+ */
+struct esm_regs {
+	uint32_t ip_header;    /* 0x000 */
+	uint32_t ip_version;   /* 0x004 */
+	uint32_t info;         /* 0x008 - inputCount[8:0] | bankCount[15:9] | counterWidth[23:16] | locked[24] */
+	uint32_t control;      /* 0x00C */
+	uint32_t status;       /* 0x010 */
+	uint32_t error_counter;/* 0x014 - grace-period reload value; locked */
+	uint32_t _pad[2];      /* 0x018-0x01F */
+	struct esm_bank banks[32]; /* 0x020, stride 0x10; only banks[0..bankCount-1] are valid */
+};
+
+struct esm_driver {
+	volatile struct esm_regs *regs;
+	uint32_t bank_count;
+};
+
+int esm_init(struct esm_driver *driver, unsigned int base_address);
+
+/* Master enable / disable. Disable is ignored when locked. */
+void esm_enable(struct esm_driver *driver);
+void esm_disable(struct esm_driver *driver);
+
+/**
+ * Lock the ESM. Atomically clears injectEnable, zeroes inject registers, and
+ * freezes ERROR/FATAL enables, errorCounter, and inject registers.
+ */
+void esm_lock(struct esm_driver *driver);
+
+/**
+ * Write the combined enable register for a bank.
+ * Build the mask with ESM_LEVEL_INFO/WARN/ERROR/FATAL(input_mask).
+ * ERROR/FATAL fields (bits [31:16]) are ignored once locked.
+ */
+void esm_configure(struct esm_driver *driver, unsigned int bank, uint32_t mask);
+
+/**
+ * Configure the grace-period counter for ERROR level.
+ * errorSignal asserts after (counter + 1) cycles if any ERROR pending bit
+ * remains set. Set to 0 for immediate assertion (same behaviour as FATAL).
+ * Write ignored when locked.
+ */
+void esm_configure_counter(struct esm_driver *driver, uint32_t counter);
+
+/* Software error injection. */
+void esm_inject_enable(struct esm_driver *driver);
+void esm_inject_disable(struct esm_driver *driver);
+void esm_inject_set(struct esm_driver *driver, unsigned int bank, uint32_t bits);
+void esm_inject_clear(struct esm_driver *driver, unsigned int bank, uint32_t bits);
+
+/* Read current status register. */
+uint32_t esm_status(struct esm_driver *driver);
+
+/* Read raw (synchronised) input state including active inject, for a bank. */
+uint32_t esm_raw(struct esm_driver *driver, unsigned int bank);
+
+/**
+ * Read the pending register for a bank.
+ * Use ESM_PENDING_INFO/WARN/ERROR/FATAL(value) to extract per-level bits.
+ */
+uint32_t esm_pending(struct esm_driver *driver, unsigned int bank);
+
+/**
+ * Clear pending bits for a bank (W1C).
+ * Build the mask with ESM_LEVEL_INFO/WARN/ERROR/FATAL(input_mask).
+ */
+void esm_clear(struct esm_driver *driver, unsigned int bank, uint32_t mask);
+
+#endif

--- a/software/include/esm.h
+++ b/software/include/esm.h
@@ -101,7 +101,7 @@ struct esm_driver {
 	uint32_t bank_count;
 };
 
-int esm_init(struct esm_driver *driver, unsigned int base_address);
+int esm_init(struct esm_driver *driver, unsigned long base_address);
 
 /* Master enable / disable. Disable is ignored when locked. */
 void esm_enable(struct esm_driver *driver);

--- a/software/include/gpio.h
+++ b/software/include/gpio.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ELEMNETS_GPIO
-#define ELEMNETS_GPIO
+#ifndef ELEMENTS_GPIO_H
+#define ELEMENTS_GPIO_H
 
 #ifndef GPIO_BANK_WIDTH
 #define GPIO_BANK_WIDTH 32
@@ -16,23 +16,23 @@
 #endif
 
 struct gpio_bank_regs {
-	int data_in;
-	int data_out;
-	int dir_en;
-	int irq_high_pending;
-	int irq_high_mask;
-	int irq_low_pending;
-	int irq_low_mask;
-	int irq_rising_pending;
-	int irq_rising_mask;
-	int irq_falling_pending;
-	int irq_falling_mask;
+	unsigned int input;
+	unsigned int output;
+	unsigned int direction;
+	unsigned int irq_high_pending;
+	unsigned int irq_high_enable;
+	unsigned int irq_low_pending;
+	unsigned int irq_low_enable;
+	unsigned int irq_rising_pending;
+	unsigned int irq_rising_enable;
+	unsigned int irq_falling_pending;
+	unsigned int irq_falling_enable;
 };
 
 struct gpio_regs {
-	int ip_api;
-	int ip_version;
-	int ip_info;
+	unsigned int ip_header;
+	unsigned int ip_version;
+	unsigned int ip_info;
 	struct gpio_bank_regs banks[GPIO_MAX_BANKS];
 };
 
@@ -45,7 +45,7 @@ struct gpio_driver {
 #define GPIO_IRQ_RISING_EDGE		(1 << 2)
 #define GPIO_IRQ_FALLING_EDGE		(1 << 3)
 
-int gpio_init(struct gpio_driver *driver, unsigned int base_address);
+int gpio_init(struct gpio_driver *driver, unsigned long base_address);
 unsigned int gpio_value_get(struct gpio_driver *driver, unsigned int pin);
 void gpio_value_set(struct gpio_driver *driver, unsigned int pin);
 void gpio_value_clr(struct gpio_driver *driver, unsigned int pin);

--- a/software/include/mailbox.h
+++ b/software/include/mailbox.h
@@ -45,7 +45,7 @@ struct mailbox_driver {
 	volatile struct mailbox_regs *regs;
 };
 
-int          mailbox_init(struct mailbox_driver *driver, unsigned int base_address);
+int          mailbox_init(struct mailbox_driver *driver, unsigned long base_address);
 
 /**
  * Push a 32-bit message to channel @ch.

--- a/software/include/mailbox.h
+++ b/software/include/mailbox.h
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ELEMENTS_MAILBOX_H
+#define ELEMENTS_MAILBOX_H
+
+#include <stdint.h>
+
+#ifndef MAILBOX_CHANNEL_COUNT
+#define MAILBOX_CHANNEL_COUNT 2
+#endif
+
+/*
+ * Status register bit helpers. The hardware packs empty flags in the low
+ * MAILBOX_CHANNEL_COUNT bits and full flags in the next MAILBOX_CHANNEL_COUNT
+ * bits, so the full base shifts by the channel count.
+ */
+#define MAILBOX_STATUS_EMPTY(ch)  (1u << (ch))
+#define MAILBOX_STATUS_FULL(ch)   (1u << (MAILBOX_CHANNEL_COUNT + (ch)))
+
+/* Per-channel interrupt source bits (irq_pending / irq_mask registers). */
+#define MAILBOX_IRQ_NOT_EMPTY  (1u << 0)
+#define MAILBOX_IRQ_NOT_FULL   (1u << 1)
+
+struct mailbox_channel_regs {
+	uint32_t write;        /* 0x00 - push data (write-only) */
+	uint32_t read;         /* 0x04 - pop data (read-only)   */
+	uint32_t occupancy;    /* 0x08 */
+	uint32_t irq_pending;  /* 0x0C - write 1 to clear */
+	uint32_t irq_mask;     /* 0x10 - 1 = enable source */
+};
+
+struct mailbox_regs {
+	uint32_t ip_header;                                      /* 0x000 */
+	uint32_t ip_version;                                     /* 0x004 */
+	uint32_t info;                                           /* 0x008 */
+	uint32_t status;                                         /* 0x00C */
+	struct mailbox_channel_regs channel[MAILBOX_CHANNEL_COUNT]; /* 0x010 */
+};
+
+struct mailbox_driver {
+	volatile struct mailbox_regs *regs;
+};
+
+int          mailbox_init(struct mailbox_driver *driver, unsigned int base_address);
+
+/**
+ * Push a 32-bit message to channel @ch.
+ * Returns 1 on success, 0 if the FIFO is full.
+ */
+int          mailbox_write(struct mailbox_driver *driver, unsigned int ch,
+			   unsigned int data);
+
+/**
+ * Pop a 32-bit message from channel @ch and store it in @data.
+ * Returns 1 if a message was available, 0 if the FIFO was empty.
+ */
+int          mailbox_read(struct mailbox_driver *driver, unsigned int ch,
+			  unsigned int *data);
+
+unsigned int mailbox_status(struct mailbox_driver *driver);
+unsigned int mailbox_occupancy(struct mailbox_driver *driver, unsigned int ch);
+
+/**
+ * Interrupt control. The hardware ORs all masked pending bits across every
+ * channel into a single interrupt output line. In the ISR, call
+ * mailbox_irq_pending() for each channel to find the source, then
+ * mailbox_irq_clear() to acknowledge it.
+ *
+ * @flags: bitmask of MAILBOX_IRQ_NOT_EMPTY / MAILBOX_IRQ_NOT_FULL
+ */
+int          mailbox_irq_enable(struct mailbox_driver *driver, unsigned int ch,
+				int flags);
+int          mailbox_irq_disable(struct mailbox_driver *driver, unsigned int ch,
+				 int flags);
+int          mailbox_irq_pending(struct mailbox_driver *driver, unsigned int ch,
+				 int flags);
+void         mailbox_irq_clear(struct mailbox_driver *driver, unsigned int ch,
+			       int flags);
+
+#endif

--- a/software/include/mtimer.h
+++ b/software/include/mtimer.h
@@ -20,7 +20,7 @@ struct mtimer_driver {
 	volatile struct mtimer_regs *regs;
 };
 
-int mtimer_init(struct mtimer_driver *driver, unsigned int base_address);
+int mtimer_init(struct mtimer_driver *driver, unsigned long base_address);
 unsigned int mtimer_sleep32(struct mtimer_driver *driver, unsigned int cycles);
 
 #endif

--- a/software/include/pinmux.h
+++ b/software/include/pinmux.h
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ELEMENTS_PINMUX_H
+#define ELEMENTS_PINMUX_H
+
+/*
+ * Register layout:
+ *   0x000  ip_header   — IP identification header
+ *   0x004  ip_version  — IP identification version
+ *   0x008  info        — [7:0]=pin_count, [15:8]=options_count
+ *   0x00C  (reserved)
+ *   0x010 + pin*4      — option register for pin N (selects function index)
+ */
+
+struct pinmux_regs {
+	unsigned int ip_header;   /* 0x000 */
+	unsigned int ip_version;  /* 0x004 */
+	unsigned int info;        /* 0x008 */
+	unsigned int _reserved;   /* 0x00C */
+	unsigned int option[];    /* 0x010 + pin*4 — flexible array, index by pin */
+};
+
+/* info register fields */
+#define PINMUX_PIN_COUNT(reg)     ((reg) & 0xFF)
+#define PINMUX_OPTIONS_COUNT(reg) (((reg) >> 8) & 0xFF)
+
+struct pinmux_driver {
+	volatile struct pinmux_regs *regs;
+	unsigned int pin_count;
+	unsigned int options_count;
+};
+
+void pinmux_init(struct pinmux_driver *driver, unsigned long base_address);
+
+unsigned int pinmux_pin_count(struct pinmux_driver *driver);
+unsigned int pinmux_options_count(struct pinmux_driver *driver);
+void pinmux_set(struct pinmux_driver *driver, unsigned int pin, unsigned int option);
+unsigned int pinmux_get(struct pinmux_driver *driver, unsigned int pin);
+
+#endif

--- a/software/include/pio.h
+++ b/software/include/pio.h
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: 2025 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ELEMENTS_PIO_H
+#define ELEMENTS_PIO_H
+
+/*
+ * Register layout (all offsets from base):
+ *   0x000  ip_header        — IP identification header
+ *   0x004  ip_version       — IP identification version
+ *   0x008  data_width       — [7:0]=pin_count, [15:8]=data_width, [23:16]=clk_div_width, [31:24]=read_buf_depth
+ *   0x00C  fifo_depth       — [7:0]=cmd_fifo_depth, [15:8]=read_fifo_depth
+ *   0x010  permissions      — [0]=bus_can_write_clock_div
+ *   0x014  control          — [0]=enable, [1]=stop_at_loop
+ *   0x018  read_write       — write: program command word; read: [15:0]=result, [16]=valid
+ *   0x01C  fifo_status      — read: [7:0]=exec_ptr, [15:8]=write_ptr, [31:24]=rx_occupancy
+ *                             write: any value resets program write pointer
+ *   0x020  clock_div        — clock divider value
+ *   0x024  read_delay       — read delay in clock ticks
+ *   0x028  error_pending    — [0]=read FIFO overflow (W1C)
+ *   0x02C  error_enable     — error enable mask
+ *   0x030  irq_pending      — [0]=rx data ready, [1]=loop done (W1C)
+ *   0x034  irq_enable       — interrupt enable mask
+ */
+
+struct pio_regs {
+	unsigned int ip_header;     /* 0x000 */
+	unsigned int ip_version;    /* 0x004 */
+	unsigned int data_width;    /* 0x008 */
+	unsigned int fifo_depth;    /* 0x00C */
+	unsigned int permissions;   /* 0x010 */
+	unsigned int control;       /* 0x014 */
+	unsigned int read_write;    /* 0x018 */
+	unsigned int fifo_status;   /* 0x01C */
+	unsigned int clock_div;     /* 0x020 */
+	unsigned int read_delay;    /* 0x024 */
+	unsigned int error_pending; /* 0x028 */
+	unsigned int error_enable;  /* 0x02C */
+	unsigned int irq_pending;   /* 0x030 */
+	unsigned int irq_enable;    /* 0x034 */
+};
+
+/* data_width register fields */
+#define PIO_PIN_COUNT(reg)       ((reg) & 0xFF)
+#define PIO_DATA_WIDTH(reg)      (((reg) >> 8) & 0xFF)
+#define PIO_CLK_DIV_WIDTH(reg)   (((reg) >> 16) & 0xFF)
+#define PIO_READ_BUF_DEPTH(reg)  (((reg) >> 24) & 0xFF)
+
+/* fifo_depth register fields */
+#define PIO_CMD_FIFO_DEPTH(reg)  ((reg) & 0xFF)
+#define PIO_READ_FIFO_DEPTH(reg) (((reg) >> 8) & 0xFF)
+
+/* control register bits */
+#define PIO_CTRL_ENABLE          (1U << 0)
+#define PIO_CTRL_STOP_AT_LOOP    (1U << 1)
+
+/* fifo_status register fields */
+#define PIO_EXEC_PTR(reg)        ((reg) & 0xFF)
+#define PIO_WRITE_PTR(reg)       (((reg) >> 8) & 0xFF)
+#define PIO_RX_OCCUPANCY(reg)    (((reg) >> 24) & 0xFF)
+
+/* read_write read fields */
+#define PIO_READ_VALID           (1U << 16)
+#define PIO_READ_RESULT(reg)     ((reg) & 0x1)
+
+/* error_pending / error_enable bits */
+#define PIO_ERROR_RX_OVERFLOW    (1U << 0)
+
+/* irq_pending / irq_enable bits */
+#define PIO_IRQ_RX_READY         (1U << 0)
+#define PIO_IRQ_LOOP_DONE        (1U << 1)
+
+/* Command types */
+#define PIO_CMD_HIGH             0x0
+#define PIO_CMD_HIGH_SET         0x1
+#define PIO_CMD_LOW              0x2
+#define PIO_CMD_LOW_SET          0x3
+#define PIO_CMD_FLOAT            0x4
+#define PIO_CMD_FLOAT_SET        0x5
+#define PIO_CMD_TOGGLE           0x6
+#define PIO_CMD_TOGGLE_SET       0x7
+#define PIO_CMD_WAIT             0x8
+#define PIO_CMD_WAIT_FOR_HIGH    0x9
+#define PIO_CMD_WAIT_FOR_LOW     0xA
+#define PIO_CMD_READ             0xB
+#define PIO_CMD_LOOP             0xC
+
+/* Build a 32-bit command word: [3:0]=cmd, [7:4]=pin, [31:8]=data */
+#define PIO_MAKE_CMD(cmd, pin, data) \
+	(((unsigned int)(data) << 8) | (((unsigned int)(pin) & 0xF) << 4) | ((unsigned int)(cmd) & 0xF))
+
+struct pio_driver {
+	volatile struct pio_regs *regs;
+};
+
+void pio_init(struct pio_driver *driver, unsigned long base_address);
+
+void pio_enable(struct pio_driver *driver);
+void pio_disable(struct pio_driver *driver);
+void pio_set_stop_at_loop(struct pio_driver *driver, int enable);
+
+void pio_program_reset(struct pio_driver *driver);
+void pio_program_write(struct pio_driver *driver, unsigned int cmd_word);
+
+int pio_read(struct pio_driver *driver, unsigned int *result);
+
+void pio_irq_enable(struct pio_driver *driver, unsigned int mask);
+void pio_irq_disable(struct pio_driver *driver, unsigned int mask);
+unsigned int pio_irq_pending(struct pio_driver *driver);
+void pio_irq_clear(struct pio_driver *driver, unsigned int mask);
+
+#endif

--- a/software/include/plic.h
+++ b/software/include/plic.h
@@ -15,7 +15,7 @@ struct plic_driver {
 };
 
 
-int plic_init(struct plic_driver *driver, unsigned int base_address);
+int plic_init(struct plic_driver *driver, unsigned long base_address);
 int plic_irq_enable(struct plic_driver *driver, unsigned int number);
 int plic_irq_disable(struct plic_driver *driver, unsigned int number);
 int plic_irq_claim(struct plic_driver *driver, unsigned int number);

--- a/software/include/prng.h
+++ b/software/include/prng.h
@@ -23,7 +23,7 @@ struct prng_driver {
 	volatile struct prng_regs *regs;
 };
 
-int prng_init(struct prng_driver *driver, unsigned int base_address);
+int prng_init(struct prng_driver *driver, unsigned long base_address);
 
 void prng_enable(struct prng_driver *driver);
 void prng_disable(struct prng_driver *driver);

--- a/software/include/prng.h
+++ b/software/include/prng.h
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ELEMENTS_PRNG_H
+#define ELEMENTS_PRNG_H
+
+#define PRNG_ERROR_ZERO_SEED  (1 << 0)
+
+struct prng_regs {
+	unsigned int ip_header;      /* 0x000 */
+	unsigned int ip_version;     /* 0x004 */
+	unsigned int control;        /* 0x008 - bit 0 = enable */
+	unsigned int error_pending;  /* 0x00C - bit 0 = zero seed (W1C) */
+	unsigned int error_mask;     /* 0x010 - bit 0 = enable zero-seed error output */
+	unsigned int seed;           /* 0x014 - write-only, non-zero */
+	unsigned int output;         /* 0x018 - read-only */
+};
+
+struct prng_driver {
+	volatile struct prng_regs *regs;
+};
+
+int prng_init(struct prng_driver *driver, unsigned int base_address);
+
+void prng_enable(struct prng_driver *driver);
+void prng_disable(struct prng_driver *driver);
+
+/**
+ * Reseed the PRNG. Returns 1 on success, 0 if seed is zero (invalid).
+ */
+int prng_seed(struct prng_driver *driver, unsigned int seed);
+
+unsigned int prng_read(struct prng_driver *driver);
+
+int prng_error_pending(struct prng_driver *driver, int flags);
+void prng_error_clear(struct prng_driver *driver, int flags);
+void prng_error_mask(struct prng_driver *driver, int flags);
+void prng_error_unmask(struct prng_driver *driver, int flags);
+
+#endif

--- a/software/include/pwm.h
+++ b/software/include/pwm.h
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: 2025 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ELEMENTS_PWM_H
+#define ELEMENTS_PWM_H
+
+/*
+ * Register layout (all offsets from base):
+ *   0x000  ip_header        — IP identification header
+ *   0x004  ip_version       — IP identification version
+ *   0x008  channel_config   — [7:0]=channels, [15:8]=clk_div_width, [23:16]=pulse_width, [31:24]=period_width
+ *   0x00C  timing_config    — [7:0]=dead_time_width, [15:8]=shot_count_width
+ *   0x010  permissions      — [0]=bus_can_write_clock_div
+ *   0x014  irq_pending      — per-channel period-complete pending (W1C), bit N = channel N
+ *   0x018  irq_enable       — per-channel period-complete enable mask
+ *   0x01C  error_pending    — [0]=faultIn, [1+N]=channel N config error (W1C)
+ *   0x020  error_enable     — error enable mask
+ *
+ * Per-channel registers (stride 0x24 per channel, starting at 0x024):
+ *   ch_base = 0x024 + ch * 0x024
+ *   ch_base + 0x00  control      — [0]=enable, [1]=invert, [2]=mode (0=edge, 1=center)
+ *   ch_base + 0x04  clock_div    — clock divider value
+ *   ch_base + 0x08  period       — period in ticks
+ *   ch_base + 0x0C  rising_edge  — rising edge tick offset
+ *   ch_base + 0x10  falling_edge — falling edge tick offset
+ *   ch_base + 0x14  dead_time    — dead-time in ticks
+ *   ch_base + 0x18  phase_offset — phase offset in ticks (applied on enable)
+ *   ch_base + 0x1C  shot_count   — 0=continuous, N=run N periods then stop
+ *   ch_base + 0x20  status       — [0]=config_error (falling>period), [1]=shot_done (read-only)
+ */
+
+/* channel_config register fields */
+#define PWM_CHANNEL_COUNT(reg)    ((reg) & 0xFF)
+#define PWM_CLK_DIV_WIDTH(reg)    (((reg) >> 8) & 0xFF)
+#define PWM_PULSE_WIDTH(reg)      (((reg) >> 16) & 0xFF)
+#define PWM_PERIOD_WIDTH(reg)     (((reg) >> 24) & 0xFF)
+
+/* timing_config register fields */
+#define PWM_DEAD_TIME_WIDTH(reg)  ((reg) & 0xFF)
+#define PWM_SHOT_COUNT_WIDTH(reg) (((reg) >> 8) & 0xFF)
+
+/* control register bits */
+#define PWM_CTRL_ENABLE           (1U << 0)
+#define PWM_CTRL_INVERT           (1U << 1)
+#define PWM_CTRL_MODE_CENTER      (1U << 2)
+
+/* status register bits */
+#define PWM_STATUS_CONFIG_ERROR   (1U << 0)
+#define PWM_STATUS_SHOT_DONE      (1U << 1)
+
+/* error_pending / error_enable bits */
+#define PWM_ERROR_FAULT_IN        (1U << 0)
+/* bit (1 + ch) = channel ch config error */
+
+#define PWM_CH_STRIDE             0x24U
+#define PWM_CH_BASE(ch)           (0x24U + (ch) * PWM_CH_STRIDE)
+
+struct pwm_regs {
+	unsigned int ip_header;      /* 0x000 */
+	unsigned int ip_version;     /* 0x004 */
+	unsigned int channel_config; /* 0x008 */
+	unsigned int timing_config;  /* 0x00C */
+	unsigned int permissions;    /* 0x010 */
+	unsigned int irq_pending;    /* 0x014 */
+	unsigned int irq_enable;     /* 0x018 */
+	unsigned int error_pending;  /* 0x01C */
+	unsigned int error_enable;   /* 0x020 */
+};
+
+struct pwm_channel_regs {
+	unsigned int control;        /* +0x00 */
+	unsigned int clock_div;      /* +0x04 */
+	unsigned int period;         /* +0x08 */
+	unsigned int rising_edge;    /* +0x0C */
+	unsigned int falling_edge;   /* +0x10 */
+	unsigned int dead_time;      /* +0x14 */
+	unsigned int phase_offset;   /* +0x18 */
+	unsigned int shot_count;     /* +0x1C */
+	unsigned int status;         /* +0x20 */
+};
+
+struct pwm_driver {
+	volatile struct pwm_regs *regs;
+	unsigned int channel_count;
+};
+
+void pwm_init(struct pwm_driver *driver, unsigned long base_address);
+
+static inline volatile struct pwm_channel_regs *
+pwm_channel(struct pwm_driver *driver, unsigned int ch)
+{
+	return (volatile struct pwm_channel_regs *)
+		((unsigned char *)driver->regs + PWM_CH_BASE(ch));
+}
+
+unsigned int pwm_channel_count(struct pwm_driver *driver);
+
+void pwm_channel_enable(struct pwm_driver *driver, unsigned int ch);
+void pwm_channel_disable(struct pwm_driver *driver, unsigned int ch);
+void pwm_channel_set_invert(struct pwm_driver *driver, unsigned int ch, int invert);
+void pwm_channel_set_mode_center(struct pwm_driver *driver, unsigned int ch, int center);
+
+void pwm_channel_set_clock_div(struct pwm_driver *driver, unsigned int ch, unsigned int div);
+void pwm_channel_set_period(struct pwm_driver *driver, unsigned int ch, unsigned int period);
+void pwm_channel_set_duty(struct pwm_driver *driver, unsigned int ch,
+	unsigned int rising, unsigned int falling);
+void pwm_channel_set_dead_time(struct pwm_driver *driver, unsigned int ch, unsigned int dt);
+void pwm_channel_set_phase_offset(struct pwm_driver *driver, unsigned int ch, unsigned int offset);
+void pwm_channel_set_shot_count(struct pwm_driver *driver, unsigned int ch, unsigned int count);
+
+unsigned int pwm_channel_status(struct pwm_driver *driver, unsigned int ch);
+
+void pwm_irq_enable(struct pwm_driver *driver, unsigned int channel_mask);
+void pwm_irq_disable(struct pwm_driver *driver, unsigned int channel_mask);
+unsigned int pwm_irq_pending(struct pwm_driver *driver);
+void pwm_irq_clear(struct pwm_driver *driver, unsigned int channel_mask);
+
+#endif

--- a/software/include/reset.h
+++ b/software/include/reset.h
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ELEMENTS_RESET_H
+#define ELEMENTS_RESET_H
+
+struct reset_regs {
+	unsigned int ip_header;    /* 0x000 — IP identification header */
+	unsigned int ip_version;   /* 0x004 — IP identification version */
+	unsigned int domains;      /* 0x008 — number of reset domains (read-only) */
+	unsigned int enable;       /* 0x00C — enabled domain bitmask (1=enabled) */
+	unsigned int trigger;      /* 0x010 — trigger bitmask; write 1 to assert reset */
+	unsigned int acknowledge;  /* 0x014 — write any value to deassert pending resets */
+};
+
+struct reset_driver {
+	volatile struct reset_regs *regs;
+};
+
+void reset_init(struct reset_driver *driver, unsigned long base_address);
+
+unsigned int reset_domain_count(struct reset_driver *driver);
+unsigned int reset_enable_get(struct reset_driver *driver);
+void reset_enable_set(struct reset_driver *driver, unsigned int mask);
+void reset_trigger(struct reset_driver *driver, unsigned int mask);
+void reset_acknowledge(struct reset_driver *driver);
+
+#endif

--- a/software/include/semaphore.h
+++ b/software/include/semaphore.h
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ELEMENTS_SEMAPHORE_H
+#define ELEMENTS_SEMAPHORE_H
+
+#ifndef SEMAPHORE_MAX_COUNT
+#define SEMAPHORE_MAX_COUNT 32
+#endif
+
+struct semaphore_regs {
+	unsigned int ip_header;          /* 0x000 */
+	unsigned int ip_version;         /* 0x004 */
+	unsigned int info;               /* 0x008 — number of slots (read-only) */
+	unsigned int status;             /* 0x00C — taken bitmask (read-only) */
+	unsigned int semaphore[SEMAPHORE_MAX_COUNT]; /* 0x010 .. */
+};
+
+struct semaphore_driver {
+	volatile struct semaphore_regs *regs;
+	unsigned int count;
+};
+
+int semaphore_init(struct semaphore_driver *driver, unsigned int base_address,
+		   unsigned int count);
+
+/**
+ * Attempt to claim semaphore slot @n.
+ *
+ * Returns 0 if the slot was free and is now held by the caller.
+ * Returns 1 if the slot was already taken; the caller must retry.
+ */
+int semaphore_claim(struct semaphore_driver *driver, unsigned int n);
+
+/**
+ * Release semaphore slot @n.
+ */
+void semaphore_release(struct semaphore_driver *driver, unsigned int n);
+
+/**
+ * Return the raw taken bitmask (bit N set means slot N is held).
+ */
+unsigned int semaphore_status(struct semaphore_driver *driver);
+
+#endif

--- a/software/include/semaphore.h
+++ b/software/include/semaphore.h
@@ -24,7 +24,7 @@ struct semaphore_driver {
 	unsigned int count;
 };
 
-int semaphore_init(struct semaphore_driver *driver, unsigned int base_address,
+int semaphore_init(struct semaphore_driver *driver, unsigned long base_address,
 		   unsigned int count);
 
 /**

--- a/software/include/syscon.h
+++ b/software/include/syscon.h
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ELEMENTS_SYSCON_H
+#define ELEMENTS_SYSCON_H
+
+struct syscon_regs {
+	unsigned int ip_header;      /* 0x000 — IP identification header */
+	unsigned int ip_version;     /* 0x004 — IP identification version */
+	unsigned int identity;       /* 0x008 — vendor/platform/product/class */
+	unsigned int silicon_major;  /* 0x00C — silicon major revision */
+	unsigned int silicon_minor;  /* 0x010 — silicon minor revision */
+	unsigned int features;       /* 0x014 — feature flag bitmask */
+	unsigned int ref_clock;      /* 0x018 — reference oscillator (Hz) */
+	unsigned int build_date;     /* 0x01C — build UNIX timestamp (s) */
+};
+
+/* identity register fields */
+#define SYSCON_VENDOR(reg)         ((reg) & 0xFF)
+#define SYSCON_PLATFORM(reg)       (((reg) >> 8) & 0xFF)
+#define SYSCON_PRODUCT(reg)        (((reg) >> 16) & 0xFF)
+#define SYSCON_PLATFORM_CLASS(reg) (((reg) >> 24) & 0xFF)
+
+/* vendor ordinals */
+#define SYSCON_VENDOR_AESC_SILICON 0
+
+/* platform ordinals */
+#define SYSCON_PLATFORM_HYDROGEN   0
+#define SYSCON_PLATFORM_CARBON     1
+#define SYSCON_PLATFORM_NITROGEN   2
+#define SYSCON_PLATFORM_OXYGEN     3
+#define SYSCON_PLATFORM_PHOSPHORUS 4
+#define SYSCON_PLATFORM_SULFUR     5
+
+/* platform class ordinals */
+#define SYSCON_CLASS_NONMETAL      0  /* MCU: M-mode only, no MMU */
+#define SYSCON_CLASS_ALKALI        1  /* MPU: MMU, OS-capable */
+
+/* product ordinals */
+#define SYSCON_PRODUCT_ELEMRV      0
+
+/* feature flag bits in the features register */
+#define SYSCON_FEATURE_I2C         (1U << 0)
+#define SYSCON_FEATURE_SPI         (1U << 1)
+#define SYSCON_FEATURE_UART        (1U << 2)
+#define SYSCON_FEATURE_GPIO        (1U << 3)
+#define SYSCON_FEATURE_PIO         (1U << 4)
+#define SYSCON_FEATURE_PWM         (1U << 5)
+#define SYSCON_FEATURE_PINMUX      (1U << 6)
+#define SYSCON_FEATURE_CLOCK       (1U << 7)
+#define SYSCON_FEATURE_ESM         (1U << 8)
+#define SYSCON_FEATURE_MAILBOX     (1U << 9)
+#define SYSCON_FEATURE_MTIMER      (1U << 10)
+#define SYSCON_FEATURE_PLIC        (1U << 11)
+#define SYSCON_FEATURE_RESET       (1U << 12)
+#define SYSCON_FEATURE_SEMAPHORE   (1U << 13)
+#define SYSCON_FEATURE_WATCHDOG    (1U << 14)
+#define SYSCON_FEATURE_AES         (1U << 15)
+#define SYSCON_FEATURE_CRC         (1U << 16)
+#define SYSCON_FEATURE_PRNG        (1U << 17)
+#define SYSCON_FEATURE_HYPERBUS    (1U << 18)
+#define SYSCON_FEATURE_OCRAM       (1U << 19)
+#define SYSCON_FEATURE_SPI_FLASH   (1U << 20)
+
+struct syscon_driver {
+	volatile struct syscon_regs *regs;
+};
+
+void syscon_init(struct syscon_driver *driver, unsigned int base_address);
+
+unsigned int syscon_vendor(struct syscon_driver *driver);
+unsigned int syscon_platform(struct syscon_driver *driver);
+unsigned int syscon_platform_class(struct syscon_driver *driver);
+unsigned int syscon_product(struct syscon_driver *driver);
+unsigned int syscon_silicon_major(struct syscon_driver *driver);
+unsigned int syscon_silicon_minor(struct syscon_driver *driver);
+unsigned int syscon_features(struct syscon_driver *driver);
+unsigned int syscon_ref_clock(struct syscon_driver *driver);
+unsigned int syscon_build_date(struct syscon_driver *driver);
+
+int syscon_has_feature(struct syscon_driver *driver, unsigned int feature_bit);
+
+#endif

--- a/software/include/syscon.h
+++ b/software/include/syscon.h
@@ -69,7 +69,7 @@ struct syscon_driver {
 	volatile struct syscon_regs *regs;
 };
 
-void syscon_init(struct syscon_driver *driver, unsigned int base_address);
+void syscon_init(struct syscon_driver *driver, unsigned long base_address);
 
 unsigned int syscon_vendor(struct syscon_driver *driver);
 unsigned int syscon_platform(struct syscon_driver *driver);

--- a/software/include/timer.h
+++ b/software/include/timer.h
@@ -42,7 +42,7 @@ struct timer_driver {
  * Initialise the driver. Reads count and channel_count from the info register.
  * base_address: MMIO base of the timer IP.
  */
-void timer_init(struct timer_driver *driver, unsigned int base_address);
+void timer_init(struct timer_driver *driver, unsigned long base_address);
 
 /* Per-timer register access */
 void         timer_set_control(struct timer_driver *driver, unsigned int t, unsigned int ctrl);

--- a/software/include/timer.h
+++ b/software/include/timer.h
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ELEMENTS_TIMER_H
+#define ELEMENTS_TIMER_H
+
+struct timer_regs {
+	unsigned int ip_header;   /* 0x000 */
+	unsigned int ip_version;  /* 0x004 */
+	unsigned int info;        /* 0x008 */
+	unsigned int irq_pending; /* 0x00C — W1C */
+	unsigned int irq_mask;    /* 0x010 */
+};
+
+/* info register fields */
+#define TIMER_INFO_COUNT(r)          ((r) & 0xFF)
+#define TIMER_INFO_CHANNEL_COUNT(r)  (((r) >> 8) & 0xFF)
+#define TIMER_INFO_WIDTH(r)          (((r) >> 16) & 0xFF)
+#define TIMER_INFO_PRESCALER_WIDTH(r)(((r) >> 24) & 0xFF)
+
+/* control register fields */
+#define TIMER_CTRL_ENABLE            (1U << 0)
+#define TIMER_CTRL_MODE_FREE_RUN     (0U << 1)
+#define TIMER_CTRL_MODE_PERIODIC     (1U << 1)
+#define TIMER_CTRL_MODE_ONE_SHOT     (2U << 1)
+
+/* interrupt bit for timer t with channel_count channels per timer */
+#define TIMER_IRQ_OVERFLOW(t, cc)    (1U << ((t) * (1 + (cc))))
+#define TIMER_IRQ_COMPARE(t, cc, ch) (1U << ((t) * (1 + (cc)) + 1 + (ch)))
+
+struct timer_driver {
+	volatile struct timer_regs *regs;
+	unsigned int count;
+	unsigned int channel_count;
+	unsigned int stride; /* 0x10 + channel_count * 4 */
+};
+
+/*
+ * Initialise the driver. Reads count and channel_count from the info register.
+ * base_address: MMIO base of the timer IP.
+ */
+void timer_init(struct timer_driver *driver, unsigned int base_address);
+
+/* Per-timer register access */
+void         timer_set_control(struct timer_driver *driver, unsigned int t, unsigned int ctrl);
+unsigned int timer_get_control(struct timer_driver *driver, unsigned int t);
+void         timer_set_prescaler(struct timer_driver *driver, unsigned int t, unsigned int val);
+void         timer_set_reload(struct timer_driver *driver, unsigned int t, unsigned int val);
+unsigned int timer_get_counter(struct timer_driver *driver, unsigned int t);
+void         timer_set_counter(struct timer_driver *driver, unsigned int t, unsigned int val);
+void         timer_set_compare(struct timer_driver *driver, unsigned int t, unsigned int ch,
+                               unsigned int val);
+
+/* Interrupt helpers */
+unsigned int timer_irq_pending(struct timer_driver *driver);
+void         timer_irq_clear(struct timer_driver *driver, unsigned int mask);
+void         timer_irq_enable(struct timer_driver *driver, unsigned int mask);
+void         timer_irq_disable(struct timer_driver *driver, unsigned int mask);
+
+#endif

--- a/software/include/uart.h
+++ b/software/include/uart.h
@@ -4,23 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ELEMNETS_UART
-#define ELEMNETS_UART
+#ifndef ELEMENTS_UART_H
+#define ELEMENTS_UART_H
 
 struct uart_regs {
-	unsigned int ip_api;
-	unsigned int ip_version;
-	unsigned int ip_widths;
-	unsigned int ip_sampling_sizes;
-	unsigned int ip_fifo_depths;
-	unsigned int ip_permission;
-	unsigned int read_write;
-	unsigned int status;
-	unsigned int clock_div;
-	unsigned int frame_cfg;
-	unsigned int irq_transmit_trigger;
-	unsigned int ip;
-	unsigned int ie;
+	unsigned int ip_header;          /* 0x000 — IP identification header */
+	unsigned int ip_version;         /* 0x004 — IP identification version */
+	unsigned int data_width;         /* 0x008 — clock divider width and data width range */
+	unsigned int sampling_size;      /* 0x00C — pre/post/majority sampling sizes */
+	unsigned int fifo_depth;         /* 0x010 — TX/RX FIFO depths */
+	unsigned int permissions;        /* 0x014 — bus write permission flags */
+	unsigned int read_write;         /* 0x018 — TX write / RX read (bit 16 = RX valid) */
+	unsigned int fifo_status;        /* 0x01C — [23:16]=TX vacancy, [31:24]=RX occupancy */
+	unsigned int clock_div;          /* 0x020 — clock divider value */
+	unsigned int frame_cfg;          /* 0x024 — [7:0]=data length, [15:8]=parity, [23:16]=stop */
+	unsigned int transmit_trigger;   /* 0x028 — TX FIFO occupancy threshold for TX IRQ */
+	unsigned int irq_pending;        /* 0x02C — IRQ pending (W1C): [0]=TX, [1]=RX, [2]=TX idle */
+	unsigned int irq_enable;         /* 0x030 — IRQ enable mask */
+	unsigned int error_pending;      /* 0x034 — error pending (W1C): [0]=framing, [1]=parity, [2]=overflow */
+	unsigned int error_enable;       /* 0x038 — error enable mask */
 };
 
 struct uart_driver {
@@ -29,7 +31,17 @@ struct uart_driver {
 
 #define UART_CALC_FREQUENCY(freq, baud, bits) (freq / baud / bits)
 
-int uart_init(struct uart_driver *driver, unsigned int base_address,
+/* IRQ pending/enable bits */
+#define UART_IRQ_TX		(1U << 0)
+#define UART_IRQ_RX		(1U << 1)
+#define UART_IRQ_TX_IDLE	(1U << 2)
+
+/* error pending/enable bits */
+#define UART_ERROR_FRAMING	(1U << 0)
+#define UART_ERROR_PARITY	(1U << 1)
+#define UART_ERROR_OVERFLOW	(1U << 2)
+
+int uart_init(struct uart_driver *driver, unsigned long base_address,
 	unsigned int frequency);
 void uart_puts(struct uart_driver *driver, unsigned char *str);
 void uart_putc(struct uart_driver *driver, unsigned char c);

--- a/software/include/watchdog.h
+++ b/software/include/watchdog.h
@@ -57,7 +57,7 @@ struct watchdog_driver {
 	volatile struct watchdog_regs *regs;
 };
 
-int watchdog_init(struct watchdog_driver *driver, unsigned int base_address);
+int watchdog_init(struct watchdog_driver *driver, unsigned long base_address);
 
 /**
  * Configure prescaler and timeout for watchdog @wdt.

--- a/software/include/watchdog.h
+++ b/software/include/watchdog.h
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ELEMENTS_WATCHDOG_H
+#define ELEMENTS_WATCHDOG_H
+
+#include <stdint.h>
+
+#ifndef WATCHDOG_COUNT
+#define WATCHDOG_COUNT 1
+#endif
+
+/* control register bits */
+#define WATCHDOG_CTRL_ENABLE  (1u << 0)
+#define WATCHDOG_CTRL_LOCK    (1u << 1)
+
+/* status register bits */
+#define WATCHDOG_STATUS_ENABLED   (1u << 0)
+#define WATCHDOG_STATUS_LOCKED    (1u << 1)
+#define WATCHDOG_STATUS_IN_WINDOW (1u << 2)
+
+/*
+ * Interrupt source bits (irq_pending / irq_mask).
+ * Bits 2 and 3 are only present when the IP is compiled with windowed = true.
+ *
+ * A single hardware interrupt line is asserted when any enabled source fires.
+ * In the ISR, read irq_pending per watchdog to identify the source and write
+ * 1 to the corresponding bit to clear it.
+ */
+#define WATCHDOG_IRQ_TIMEOUT_IRQ     (1u << 0)
+#define WATCHDOG_IRQ_TIMEOUT_ERR     (1u << 1)
+#define WATCHDOG_IRQ_VIOLATION_IRQ   (1u << 2)
+#define WATCHDOG_IRQ_VIOLATION_ERR   (1u << 3)
+
+struct watchdog_wdt_regs {
+	uint32_t control;     /* +0x00 - enable[0], lock[1]         */
+	uint32_t prescaler;   /* +0x04 - tick = f_clk / (val + 1)   */
+	uint32_t timeout;     /* +0x08 - fires after (val + 1) ticks */
+	uint32_t window_open; /* +0x0C - kick valid when cnt <= val  */
+	uint32_t status;      /* +0x10 - read-only                   */
+	uint32_t irq_pending; /* +0x14 - write 1 to clear            */
+	uint32_t irq_mask;    /* +0x18 - 1 = enable source           */
+	uint32_t kick;        /* +0x1C - write any value to kick      */
+};
+
+struct watchdog_regs {
+	uint32_t ip_header;                            /* 0x000 */
+	uint32_t ip_version;                           /* 0x004 */
+	uint32_t info;                                 /* 0x008 */
+	struct watchdog_wdt_regs wdt[WATCHDOG_COUNT];  /* 0x00C */
+};
+
+struct watchdog_driver {
+	volatile struct watchdog_regs *regs;
+};
+
+int watchdog_init(struct watchdog_driver *driver, unsigned int base_address);
+
+/**
+ * Configure prescaler and timeout for watchdog @wdt.
+ * Must be called before enabling or locking.
+ *
+ * @prescaler: divide-by value; tick rate = f_clk / (prescaler + 1)
+ * @timeout:   counter reload value; fires after (timeout + 1) ticks
+ */
+void watchdog_configure(struct watchdog_driver *driver, unsigned int wdt,
+			uint32_t prescaler, uint32_t timeout);
+
+/**
+ * Set the window-open threshold for watchdog @wdt (windowed mode only).
+ * A kick is valid when the counter is at or below @window_open.
+ */
+void watchdog_configure_window(struct watchdog_driver *driver, unsigned int wdt,
+			       uint32_t window_open);
+
+/**
+ * Enable watchdog @wdt. The counter loads with the configured timeout value.
+ */
+void watchdog_enable(struct watchdog_driver *driver, unsigned int wdt);
+
+/**
+ * Disable watchdog @wdt. Has no effect when the lock bit is set.
+ */
+void watchdog_disable(struct watchdog_driver *driver, unsigned int wdt);
+
+/**
+ * Lock watchdog @wdt. Once locked, disable and configuration writes are
+ * ignored until the next hardware reset.
+ */
+void watchdog_lock(struct watchdog_driver *driver, unsigned int wdt);
+
+/**
+ * Kick watchdog @wdt to prevent a timeout.
+ * In windowed mode, kicking outside the window raises a window violation.
+ */
+void watchdog_kick(struct watchdog_driver *driver, unsigned int wdt);
+
+uint32_t watchdog_status(struct watchdog_driver *driver, unsigned int wdt);
+
+/**
+ * Interrupt control.
+ * @flags: bitmask of WATCHDOG_IRQ_* values
+ */
+void     watchdog_irq_enable(struct watchdog_driver *driver, unsigned int wdt,
+			     uint32_t flags);
+void     watchdog_irq_disable(struct watchdog_driver *driver, unsigned int wdt,
+			      uint32_t flags);
+int      watchdog_irq_pending(struct watchdog_driver *driver, unsigned int wdt,
+			      uint32_t flags);
+void     watchdog_irq_clear(struct watchdog_driver *driver, unsigned int wdt,
+			    uint32_t flags);
+
+#endif

--- a/test/scala/nafarr/crypto/crc/Crc32Test.scala
+++ b/test/scala/nafarr/crypto/crc/Crc32Test.scala
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.crypto.crc
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import spinal.sim._
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib._
+import spinal.lib.bus.amba3.apb.{Apb3, Apb3Config}
+import spinal.lib.bus.amba3.apb.sim.Apb3Driver
+
+import nafarr.CheckTester._
+import nafarr.IpIdentification
+import nafarr.IpIdentificationTest
+import nafarr.SimTest
+
+class Crc32Test extends AnyFunSuite {
+
+  def init(dut: Apb3Crc32): (Apb3Driver, Crc32Ctrl.Regs) = {
+    val driver = Apb3Driver(dut.io.bus, dut.clockDomain)
+    val regs = Crc32Ctrl.Regs(0x8)
+    dut.clockDomain.forkStimulus(10)
+    return (driver, regs)
+  }
+
+  test("Apb3Parameter") {
+    generationShouldPass(Apb3Crc32(Crc32Ctrl.Parameter.default()))
+    generationShouldPass(Apb3Crc32(Crc32Ctrl.Parameter.withXorOut()))
+  }
+
+  test("TileLinkParameter") {
+    generationShouldPass(TileLinkCrc32(Crc32Ctrl.Parameter.default()))
+    generationShouldPass(TileLinkCrc32(Crc32Ctrl.Parameter.withXorOut()))
+  }
+
+  test("WishboneParameter") {
+    generationShouldPass(WishboneCrc32(Crc32Ctrl.Parameter.default()))
+    generationShouldPass(WishboneCrc32(Crc32Ctrl.Parameter.withXorOut()))
+  }
+
+  test("basic") {
+    val compiled = SimConfig.withWave.compile {
+      val dut = Apb3Crc32(Crc32Ctrl.Parameter.default())
+      dut
+    }
+
+    compiled.doSim("registerMap") { dut =>
+      val (driver, regs) = init(dut)
+
+      /* Check IP identification */
+      IpIdentificationTest.V0.checkApi(driver, IpIdentification.Ids.Crc32)
+      IpIdentificationTest.V0.checkVersion(driver, 1, 0, 0)
+
+      /* Info register: CRC32 Standard, no xorOut
+       *   bits[7:0]  = 32 (polynomial order)
+       *   bit 8      = 1  (inputReflect)
+       *   bit 9      = 1  (outputReflect)
+       *   bit 10     = 0  (xorOut absent)
+       *   => 0x320
+       */
+      SimTest.readField(driver, regs.info, 7, 0, 32,  "Polynomial order")
+      SimTest.readField(driver, regs.info, 8, 8, 1,  "Input reflect disabled")
+      SimTest.readField(driver, regs.info, 9, 9, 1,  "Output reflect disabled")
+      SimTest.readField(driver, regs.info, 10, 10, 0,  "XOR out enabled")
+    }
+
+    compiled.doSim("initLoadsInitValue") { dut =>
+      val (driver, regs) = init(dut)
+      dut.clockDomain.waitSampling(2)
+
+      /* Trigger INIT — write any value to control */
+      driver.write(regs.control, 1)
+      dut.clockDomain.waitSampling(2)
+
+      /* CRC32 Standard initValue = 0xFFFFFFFF; xorOut disabled
+       * => result reads back raw crc_state = 0xFFFFFFFF           */
+      val result = driver.read(regs.result)
+      assert(result == 0xFFFFFFFFL, f"xorOut register mismatch: 0x${result}%08x")
+    }
+  }
+
+  test("basicWithXorOut") {
+    val compiled = SimConfig.withWave.compile {
+      val dut = Apb3Crc32(Crc32Ctrl.Parameter.withXorOut())
+      dut
+    }
+
+    compiled.doSim("registerMap") { dut =>
+      val (driver, regs) = init(dut)
+
+      /* Check IP identification */
+      IpIdentificationTest.V0.checkApi(driver, IpIdentification.Ids.Crc32)
+      IpIdentificationTest.V0.checkVersion(driver, 1, 0, 0)
+
+      /* Info register: CRC32 Standard, no xorOut
+       *   bits[7:0]  = 32 (polynomial order)
+       *   bit 8      = 1  (inputReflect)
+       *   bit 9      = 1  (outputReflect)
+       *   bit 10     = 1  (xorOut enabled)
+       *   => 0x320
+       */
+      SimTest.readField(driver, regs.info, 7, 0, 32,  "Polynomial order")
+      SimTest.readField(driver, regs.info, 8, 8, 1,  "Input reflect disabled")
+      SimTest.readField(driver, regs.info, 9, 9, 1,  "Output reflect disabled")
+      SimTest.readField(driver, regs.info, 10, 10, 1,  "XOR out disabled")
+    }
+
+    compiled.doSim("initWithXorOut") { dut =>
+      val (driver, regs) = init(dut)
+      dut.clockDomain.waitSampling(2)
+
+      /* Trigger INIT */
+      driver.write(regs.control, 1)
+      dut.clockDomain.waitSampling(2)
+
+      /* xorOut register defaults to CRC32.Standard.finalXor = 0xFFFFFFFF
+       * crc_state after init = 0xFFFFFFFF; result = state ^ xorOut = 0x00000000 */
+      val result = driver.read(regs.result)
+      assert(result == 0x0L, f"result after init with xorOut mismatch: 0x${result}%08x")
+
+      /* xorOut register should read back 0xFFFFFFFF */
+      val result2 = driver.read(regs.xorOut)
+      assert(result2 == 0xFFFFFFFFL, f"xorOut register mismatch: 0x${result2}%08x")
+    }
+  }
+}

--- a/test/scala/nafarr/crypto/prng/PrngTest.scala
+++ b/test/scala/nafarr/crypto/prng/PrngTest.scala
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.crypto.prng
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import spinal.sim._
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib._
+import spinal.lib.bus.amba3.apb.{Apb3, Apb3Config}
+import spinal.lib.bus.amba3.apb.sim.Apb3Driver
+
+import nafarr.CheckTester._
+import nafarr.IpIdentification
+import nafarr.IpIdentificationTest
+import nafarr.SimTest
+
+class PrngTest extends AnyFunSuite {
+
+  def init(dut: Apb3Prng): (Apb3Driver, PrngCtrl.Regs) = {
+    val driver = Apb3Driver(dut.io.bus, dut.clockDomain)
+    val regs = PrngCtrl.Regs(0x8)
+    dut.clockDomain.forkStimulus(10)
+    return (driver, regs)
+  }
+
+
+  test("Apb3Parameter") {
+    generationShouldPass(Apb3Prng(PrngCtrl.Parameter.default()))
+  }
+
+  test("TileLinkParameter") {
+    generationShouldPass(TileLinkPrng(PrngCtrl.Parameter.default()))
+  }
+
+  test("WishboneParameter") {
+    generationShouldPass(WishbonePrng(PrngCtrl.Parameter.default()))
+  }
+
+  test("basic") {
+    val compiled = SimConfig.withWave.compile {
+      val dut = Apb3Prng(PrngCtrl.Parameter())
+      dut
+    }
+
+    compiled.doSim("registerMap") { dut =>
+      val (driver, regs) = init(dut)
+
+      /* Check IP identification */
+      IpIdentificationTest.V0.checkApi(driver, IpIdentification.Ids.Prng)
+      IpIdentificationTest.V0.checkVersion(driver, 1, 0, 0)
+    }
+
+    compiled.doSim("Output advances each cycle when enabled") { dut =>
+      val (driver, regs) = init(dut)
+      dut.clockDomain.waitSampling(4)
+
+      val v0 = driver.read(regs.output)
+      dut.clockDomain.waitSampling(1)
+      val v1 = driver.read(regs.output)
+      dut.clockDomain.waitSampling(1)
+      val v2 = driver.read(regs.output)
+
+      assert(v0 != v1, "PRNG output should change each cycle")
+      assert(v1 != v2, "PRNG output should change each cycle")
+      assert(v0 != v2, "PRNG output should not repeat after two cycles")
+    }
+
+    compiled.doSim("Output frozen when disabled") { dut =>
+      val (driver, regs) = init(dut)
+      dut.clockDomain.waitSampling(4)
+
+      driver.write(regs.control, 0)
+      dut.clockDomain.waitSampling(2)
+
+      val v0 = driver.read(regs.output)
+      dut.clockDomain.waitSampling(4)
+      val v1 = driver.read(regs.output)
+
+      assert(v0 == v1, "PRNG output should be frozen when disabled")
+    }
+
+    compiled.doSim("Reseed changes output sequence") { dut =>
+      val (driver, regs) = init(dut)
+      dut.clockDomain.waitSampling(4)
+
+      driver.write(regs.control, 0)
+      dut.clockDomain.waitSampling(2)
+
+      driver.write(regs.seed, 0xdeadbeefL)
+      dut.clockDomain.waitSampling(2)
+      assert(driver.read(regs.output) == 0xdeadbeefL, "Output should reflect new seed")
+
+      driver.write(regs.seed, 0x12345678L)
+      dut.clockDomain.waitSampling(2)
+      assert(driver.read(regs.output) == 0x12345678L, "Output should reflect second seed")
+    }
+
+    compiled.doSim("Zero seed write sets error pending, state unchanged") { dut =>
+      val (driver, regs) = init(dut)
+      dut.clockDomain.waitSampling(4)
+
+      // Disable and set a known seed so output is predictable
+      driver.write(regs.control, 0)
+      dut.clockDomain.waitSampling(1)
+      driver.write(regs.seed, 0xabcd1234L)
+      dut.clockDomain.waitSampling(2)
+      val beforeZeroWrite = driver.read(regs.output)
+
+      // Enable the error source in the mask
+      driver.write(regs.errorMask, 1)
+      dut.clockDomain.waitSampling(1)
+
+      assert(driver.read(regs.errorPending) == 0, "Error pending should be clear initially")
+
+      // Attempt zero seed
+      driver.write(regs.seed, 0)
+      dut.clockDomain.waitSampling(2)
+
+      assert((driver.read(regs.errorPending) & 0x1) == 1, "Error pending should be set after zero seed write")
+      assert(driver.read(regs.output) == beforeZeroWrite, "PRNG state should be unchanged")
+      assert(dut.io.error.toBoolean, "Error output should be asserted")
+
+      // Clear by writing 1 to pending bit
+      driver.write(regs.errorPending, 1)
+      dut.clockDomain.waitSampling(1)
+      assert(driver.read(regs.errorPending) == 0, "Error pending should clear after write")
+      assert(!dut.io.error.toBoolean, "Error output should deassert after clear")
+    }
+  }
+
+}

--- a/test/scala/nafarr/system/esm/EsmTest.scala
+++ b/test/scala/nafarr/system/esm/EsmTest.scala
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.system.esm
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import spinal.sim._
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib._
+import spinal.lib.bus.amba3.apb.{Apb3, Apb3Config}
+import spinal.lib.bus.amba3.apb.sim.Apb3Driver
+
+import nafarr.CheckTester._
+import nafarr.IpIdentification
+import nafarr.IpIdentificationTest
+import nafarr.SimTest
+
+class EsmTest extends AnyFunSuite {
+  test("Apb3Parameter") {
+    generationShouldPass(Apb3Esm(EsmCtrl.Parameter.default(1)))
+    generationShouldPass(Apb3Esm(EsmCtrl.Parameter.small(1)))
+    generationShouldPass(Apb3Esm(EsmCtrl.Parameter.large(1)))
+    generationShouldPass(Apb3Esm(EsmCtrl.Parameter(inputCount = 256)))
+    generationShouldPass(Apb3Esm(EsmCtrl.Parameter(inputCount = 1, counterWidth = 1)))
+    generationShouldPass(Apb3Esm(EsmCtrl.Parameter(inputCount = 1, counterWidth = 32)))
+    generationShouldPass(Apb3Esm(EsmCtrl.Parameter(inputCount = 1, locked = false)))
+    generationShouldFail(Apb3Esm(EsmCtrl.Parameter(inputCount = 0)))
+    generationShouldFail(Apb3Esm(EsmCtrl.Parameter(inputCount = 257)))
+    generationShouldFail(Apb3Esm(EsmCtrl.Parameter(inputCount = 1, counterWidth = 0)))
+    generationShouldFail(Apb3Esm(EsmCtrl.Parameter(inputCount = 1, counterWidth = 33)))
+  }
+
+  test("TileLinkParameter") {
+    generationShouldPass(TileLinkEsm(EsmCtrl.Parameter.default(1)))
+    generationShouldPass(TileLinkEsm(EsmCtrl.Parameter.small(1)))
+    generationShouldFail(TileLinkEsm(EsmCtrl.Parameter(inputCount = 0)))
+    generationShouldFail(TileLinkEsm(EsmCtrl.Parameter(inputCount = 1, counterWidth = 0)))
+  }
+
+  test("WishboneParameter") {
+    generationShouldPass(WishboneEsm(EsmCtrl.Parameter.default(1)))
+    generationShouldPass(WishboneEsm(EsmCtrl.Parameter.small(1)))
+    generationShouldFail(WishboneEsm(EsmCtrl.Parameter(inputCount = 0)))
+    generationShouldFail(WishboneEsm(EsmCtrl.Parameter(inputCount = 1, counterWidth = 0)))
+  }
+
+  // 4 inputs = 1 bank (bankCount=1). locked=false keeps tests simple.
+  def simParam = EsmCtrl.Parameter(inputCount = 4, counterWidth = 4, locked = false)
+
+  def init(dut: Apb3Esm): (Apb3Driver, EsmCtrl.Regs) = {
+    val driver = Apb3Driver(dut.io.bus, dut.clockDomain)
+    val regs = EsmCtrl.Regs(dut.mapper.idCtrl.length)
+    dut.clockDomain.forkStimulus(10)
+    dut.io.inputs #= 0
+    (driver, regs)
+  }
+
+  test("IpIdentification") {
+    SimConfig.withWave.compile(Apb3Esm(EsmCtrl.Parameter.default(1)))
+      .doSim("IpIdentification") { dut =>
+        val (driver, _) = init(dut)
+        IpIdentificationTest.V0.checkApi(driver, IpIdentification.Ids.Esm)
+        IpIdentificationTest.V0.checkVersion(driver, 1, 0, 0)
+      }
+  }
+
+  test("Info register") {
+    val p = EsmCtrl.Parameter(inputCount = 8, counterWidth = 10, locked = true)
+    SimConfig.withWave.compile(Apb3Esm(p))
+      .doSim("InfoRegister") { dut =>
+        val (driver, regs) = init(dut)
+        SimTest.readField(driver, regs.info, 8, 0, 8, "InputCount")
+        SimTest.readField(driver, regs.info, 15, 9, 1, "BankCount")
+        SimTest.readField(driver, regs.info, 23, 16, 10, "CounterWidth")
+        SimTest.readField(driver, regs.info, 24, 24, 1, "Locked")
+      }
+  }
+
+  test("INFO level - pending and interrupt") {
+    SimConfig.withWave.compile(Apb3Esm(simParam))
+      .doSim("INFO_pending") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        driver.write(regs.control, 0x1)
+        driver.write(regs.enable(0), 0x01)        // input 0 → INFO (bit 0)
+
+        dut.io.inputs #= 1
+        dut.clockDomain.waitSampling(4)
+
+        SimTest.readField(driver, regs.pending(0), 0, 0, 1, "INFO pending after input")
+        assert(dut.io.infoInterrupt.toBoolean, "infoInterrupt asserted")
+
+        dut.io.inputs #= 0
+        dut.clockDomain.waitSampling(4)
+
+        SimTest.readField(driver, regs.pending(0), 0, 0, 1, "INFO pending after input")
+        assert(dut.io.infoInterrupt.toBoolean, "infoInterrupt asserted")
+
+        driver.write(regs.pending(0), 0x01)       // W1C INFO bit 0
+        dut.clockDomain.waitSampling(2)
+
+        SimTest.readField(driver, regs.pending(0), 0, 0, 0, "INFO pending cleared")
+      }
+  }
+
+  test("WARN level - pending and interrupt") {
+    SimConfig.withWave.compile(Apb3Esm(simParam))
+      .doSim("WARN_pending") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        driver.write(regs.control, 0x1)
+        driver.write(regs.enable(0), 0x0200)      // input 1 → WARN (bit 9)
+
+        dut.io.inputs #= 2
+        dut.clockDomain.waitSampling(4)
+
+        SimTest.readField(driver, regs.pending(0), 9, 9, 1, "WARN pending after input")
+        assert(dut.io.warnInterrupt.toBoolean, "warnInterrupt asserted")
+
+        dut.io.inputs #= 0
+        dut.clockDomain.waitSampling(4)
+
+        SimTest.readField(driver, regs.pending(0), 9, 9, 1, "WARN pending after input")
+        assert(dut.io.warnInterrupt.toBoolean, "warnInterrupt asserted")
+
+        driver.write(regs.pending(0), 0x200)      // W1C WARN bit 9
+        dut.clockDomain.waitSampling(2)
+        SimTest.readField(driver, regs.pending(0), 9, 9, 0, "WARN pending cleared")
+      }
+  }
+
+  test("FATAL level - errorSignal immediate") {
+    SimConfig.withWave.compile(Apb3Esm(simParam))
+      .doSim("FATAL_immediate") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        driver.write(regs.control, 0x1)
+        driver.write(regs.enable(0), 0x01000000)  // input 0 → FATAL (bit 24)
+
+        dut.io.inputs #= 1
+        dut.clockDomain.waitSampling(4)
+
+        SimTest.readField(driver, regs.pending(0), 24, 24, 1, "FATAL pending after input")
+        assert(dut.io.errorSignal.toBoolean, "errorSignal asserted immediately on FATAL")
+        SimTest.readField(driver, regs.status, 1, 1, 1, "errorSignal visible in status")
+      }
+  }
+
+  test("ERROR level - errorSignal after counter") {
+    SimConfig.withWave.compile(Apb3Esm(simParam))
+      .doSim("ERROR_counter") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        // counter=3: expires after 4 ticks
+        driver.write(regs.errorCounter, 3)
+        driver.write(regs.enable(0), 0x00010000)  // input 0 → ERROR (bit 16)
+        driver.write(regs.control, 0x1)
+
+        dut.io.inputs #= 1
+        dut.clockDomain.waitSampling(4)
+
+        SimTest.readField(driver, regs.status, 0, 0, 1, "Counter active after error input")
+        assert(!dut.io.errorSignal.toBoolean, "errorSignal not yet asserted")
+
+        dut.clockDomain.waitSampling(10)
+
+        assert(dut.io.errorSignal.toBoolean, "errorSignal asserted after counter expiry")
+        SimTest.readField(driver, regs.status, 1, 1, 1, "errorSignal in status")
+      }
+  }
+
+  test("ERROR level - clear before counter expires prevents errorSignal") {
+    SimConfig.withWave.compile(Apb3Esm(simParam))
+      .doSim("ERROR_early_clear") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        driver.write(regs.errorCounter, 15)
+        driver.write(regs.enable(0), 0x00010000)  // input 0 → ERROR
+        driver.write(regs.control, 0x1)
+
+        dut.io.inputs #= 1
+        dut.clockDomain.waitSampling(4)
+        SimTest.readField(driver, regs.status, 0, 0, 1, "Counter active")
+
+        dut.io.inputs #= 0
+        driver.write(regs.pending(0), 0x00010000) // W1C ERROR bit 16
+        dut.clockDomain.waitSampling(4)
+
+        SimTest.readField(driver, regs.status, 0, 0, 0, "Counter reset after clear")
+        assert(!dut.io.errorSignal.toBoolean, "No errorSignal after early clear")
+      }
+  }
+
+  test("Multi-level routing - same input feeds INFO and WARN") {
+    SimConfig.withWave.compile(Apb3Esm(simParam))
+      .doSim("multi_level") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        driver.write(regs.control, 0x1)
+        driver.write(regs.enable(0), 0x0101)      // input 0 → INFO (bit 0) and WARN (bit 8)
+
+        dut.io.inputs #= 1
+        dut.clockDomain.waitSampling(4)
+
+        SimTest.readField(driver, regs.pending(0), 0, 0, 1, "INFO pending")
+        SimTest.readField(driver, regs.pending(0), 8, 8, 1, "WARN pending from same input")
+        assert(dut.io.infoInterrupt.toBoolean, "infoInterrupt")
+        assert(dut.io.warnInterrupt.toBoolean, "warnInterrupt")
+      }
+  }
+
+  test("Inject - event without hardware input") {
+    SimConfig.withWave.compile(Apb3Esm(simParam))
+      .doSim("inject") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        driver.write(regs.control, 0x5)           // enable + injectEnable
+        driver.write(regs.enable(0), 0x02)        // input 1 → INFO (bit 1)
+        driver.write(regs.inject(0), 0x02)        // inject input 1; no hardware input
+        dut.clockDomain.waitSampling(4)
+
+        SimTest.readField(driver, regs.pending(0), 1, 1, 1, "INFO pending from inject")
+        assert(dut.io.infoInterrupt.toBoolean, "infoInterrupt via inject")
+
+        driver.write(regs.control, 0x1)           // disable inject
+        dut.clockDomain.waitSampling(2)
+        SimTest.readField(driver, regs.pending(0), 1, 1, 1, "INFO pending latched after inject disable")
+      }
+  }
+
+  test("Lock - freezes ERROR/FATAL enable and clears injectEnable") {
+    val lockParam = EsmCtrl.Parameter(inputCount = 4, counterWidth = 4)
+    SimConfig.withWave.compile(Apb3Esm(lockParam))
+      .doSim("lock") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        driver.write(regs.enable(0), 0x000f0000)  // inputs 0-3 → ERROR (bits [19:16])
+        driver.write(regs.control, 0x5)           // enable + injectEnable
+        dut.clockDomain.waitSampling(1)
+        SimTest.readField(driver, regs.control, 2, 2, 1, "injectEnable set before lock")
+
+        driver.write(regs.control, 0x3)           // enable + lock
+        dut.clockDomain.waitSampling(1)
+
+        SimTest.readField(driver, regs.control, 1, 1, 1, "lock bit set")
+        SimTest.readField(driver, regs.control, 2, 2, 0, "injectEnable cleared by lock")
+
+        driver.write(regs.enable(0), 0x0)         // attempt to clear all — ERROR/FATAL must be ignored
+        dut.clockDomain.waitSampling(1)
+        SimTest.readField(driver, regs.enable(0), 19, 16, 0xf, "errorEnable unchanged after lock")
+      }
+  }
+
+  test("Master enable gates pending capture") {
+    SimConfig.withWave.compile(Apb3Esm(simParam))
+      .doSim("master_enable") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        driver.write(regs.enable(0), 0x01)        // input 0 → INFO
+        dut.io.inputs #= 1
+        dut.clockDomain.waitSampling(4)
+
+        SimTest.readField(driver, regs.pending(0), 0, 0, 0, "No INFO pending when ESM disabled")
+
+        driver.write(regs.control, 0x1)
+        dut.clockDomain.waitSampling(4)
+        SimTest.readField(driver, regs.pending(0), 0, 0, 1, "INFO pending after ESM enabled")
+      }
+  }
+}

--- a/test/scala/nafarr/system/mailbox/MailboxTest.scala
+++ b/test/scala/nafarr/system/mailbox/MailboxTest.scala
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.system.mailbox
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import spinal.sim._
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib._
+import spinal.lib.bus.amba3.apb.{Apb3, Apb3Config}
+import spinal.lib.bus.amba3.apb.sim.Apb3Driver
+
+import nafarr.CheckTester._
+import nafarr.IpIdentification
+import nafarr.IpIdentificationTest
+import nafarr.SimTest
+
+class MailboxTest extends AnyFunSuite {
+  test("Apb3Parameter") {
+    generationShouldPass(Apb3Mailbox(MailboxCtrl.Parameter.small()))
+    generationShouldPass(Apb3Mailbox(MailboxCtrl.Parameter.medium()))
+    generationShouldPass(Apb3Mailbox(MailboxCtrl.Parameter.large()))
+    generationShouldPass(Apb3Mailbox(MailboxCtrl.Parameter()))
+    generationShouldPass(Apb3Mailbox(MailboxCtrl.Parameter(1)))
+    generationShouldPass(Apb3Mailbox(MailboxCtrl.Parameter(1, 2)))
+    generationShouldPass(Apb3Mailbox(MailboxCtrl.Parameter(255)))
+    generationShouldFail(Apb3Mailbox(MailboxCtrl.Parameter(0)))
+    generationShouldFail(Apb3Mailbox(MailboxCtrl.Parameter(256)))
+    generationShouldFail(Apb3Mailbox(MailboxCtrl.Parameter(1, 1)))
+  }
+
+  test("TileLinkParameter") {
+    generationShouldPass(TileLinkMailbox(MailboxCtrl.Parameter.small()))
+    generationShouldPass(TileLinkMailbox(MailboxCtrl.Parameter.medium()))
+    generationShouldPass(TileLinkMailbox(MailboxCtrl.Parameter.large()))
+    generationShouldPass(TileLinkMailbox(MailboxCtrl.Parameter()))
+    generationShouldPass(TileLinkMailbox(MailboxCtrl.Parameter(1)))
+    generationShouldPass(TileLinkMailbox(MailboxCtrl.Parameter(1, 2)))
+    generationShouldPass(TileLinkMailbox(MailboxCtrl.Parameter(255)))
+    generationShouldFail(TileLinkMailbox(MailboxCtrl.Parameter(0)))
+    generationShouldFail(TileLinkMailbox(MailboxCtrl.Parameter(256)))
+    generationShouldFail(TileLinkMailbox(MailboxCtrl.Parameter(1, 1)))
+  }
+
+  test("WishboneParameter") {
+    generationShouldPass(WishboneMailbox(MailboxCtrl.Parameter.small()))
+    generationShouldPass(WishboneMailbox(MailboxCtrl.Parameter.medium()))
+    generationShouldPass(WishboneMailbox(MailboxCtrl.Parameter.large()))
+    generationShouldPass(WishboneMailbox(MailboxCtrl.Parameter()))
+    generationShouldPass(WishboneMailbox(MailboxCtrl.Parameter(1)))
+    generationShouldPass(WishboneMailbox(MailboxCtrl.Parameter(1, 2)))
+    generationShouldPass(WishboneMailbox(MailboxCtrl.Parameter(255)))
+    generationShouldFail(WishboneMailbox(MailboxCtrl.Parameter(0)))
+    generationShouldFail(WishboneMailbox(MailboxCtrl.Parameter(256)))
+    generationShouldFail(WishboneMailbox(MailboxCtrl.Parameter(1, 1)))
+  }
+
+  def init(dut: Apb3Mailbox): (Apb3Driver, MailboxCtrl.Regs) = {
+    val driver = Apb3Driver(dut.io.bus, dut.clockDomain)
+    val regs = MailboxCtrl.Regs(dut.mapper.idCtrl.length)
+    dut.clockDomain.forkStimulus(10)
+    (driver, regs)
+  }
+
+  test("IpIdentification") {
+    SimConfig.withWave.compile(Apb3Mailbox(MailboxCtrl.Parameter.medium())).doSim { dut =>
+      val (driver, _) = init(dut)
+      IpIdentificationTest.V0.checkApi(driver, IpIdentification.Ids.Mailbox)
+      IpIdentificationTest.V0.checkVersion(driver, 1, 0, 0)
+    }
+  }
+
+  test("Info register") {
+    SimConfig.withWave.compile(Apb3Mailbox(MailboxCtrl.Parameter.medium())).doSim { dut =>
+      val (driver, regs) = init(dut)
+      SimTest.readField(driver, regs.info, 15, 8, 8, "Mailbox depth")
+      SimTest.readField(driver, regs.info, 7, 0, 2, "Channel count")
+    }
+  }
+
+  test("Status - initially empty") {
+    SimConfig.withWave.compile(Apb3Mailbox(MailboxCtrl.Parameter.medium())).doSim { dut =>
+      val (driver, regs) = init(dut)
+      dut.clockDomain.waitSampling(2)
+      SimTest.readField(driver, regs.status, 1, 0, 0x3, "Both channels empty")
+      SimTest.readField(driver, regs.status, 3, 2, 0x0, "Neither channel full")
+    }
+  }
+
+  test("Channel 0 - push and pop") {
+    SimConfig.withWave.compile(Apb3Mailbox(MailboxCtrl.Parameter.medium())).doSim { dut =>
+      val (driver, regs) = init(dut)
+      dut.clockDomain.waitSampling(2)
+
+      driver.write(regs.write(0), 0xdeadbeefL)
+      dut.clockDomain.waitSampling(2)
+
+      SimTest.readField(driver, regs.status, 0, 0, 0, "Channel 0 not empty after push")
+      SimTest.readField(driver, regs.occupancy(0), 31, 0, 1, "Channel 0 occupancy is 1")
+      SimTest.read(driver, regs.read(0), 0xdeadbeefL, "Channel 0 pop value")
+      dut.clockDomain.waitSampling(2)
+
+      SimTest.readField(driver, regs.status, 0, 0, 1, "Channel 0 empty after pop")
+    }
+  }
+
+  test("Channel 1 - push and pop") {
+    SimConfig.withWave.compile(Apb3Mailbox(MailboxCtrl.Parameter.medium())).doSim { dut =>
+      val (driver, regs) = init(dut)
+      dut.clockDomain.waitSampling(2)
+
+      driver.write(regs.write(1), 0xcafebabeL)
+      dut.clockDomain.waitSampling(2)
+
+      SimTest.readField(driver, regs.status, 1, 1, 0, "Channel 1 not empty after push")
+      SimTest.read(driver, regs.read(1), 0xcafebabeL, "Channel 1 pop value")
+    }
+  }
+
+  test("Channel 0 - fill to full") {
+    SimConfig.withWave.compile(Apb3Mailbox(MailboxCtrl.Parameter.small())).doSim { dut =>
+      val (driver, regs) = init(dut)
+      dut.clockDomain.waitSampling(2)
+
+      for (i <- 0 until dut.p.depth) {
+        driver.write(regs.write(0), i)
+        dut.clockDomain.waitSampling(1)
+      }
+      dut.clockDomain.waitSampling(2)
+
+      SimTest.readField(driver, regs.status, 2, 2, 1, "Channel 0 full")
+
+      for (i <- 0 until dut.p.depth) {
+        SimTest.read(driver, regs.read(0), i, s"Channel 0 drain value $i")
+        dut.clockDomain.waitSampling(1)
+      }
+    }
+  }
+
+  test("Interrupt - not-empty fires after push") {
+    SimConfig.withWave.compile(Apb3Mailbox(MailboxCtrl.Parameter.medium())).doSim { dut =>
+      val (driver, regs) = init(dut)
+      dut.clockDomain.waitSampling(2)
+
+      driver.write(regs.interruptMask(0), 0x1)
+      dut.clockDomain.waitSampling(1)
+
+      SimTest.readField(driver, regs.interruptPending(0), 0, 0, 0, "No pending interrupts initially")
+
+      driver.write(regs.write(0), 0x1234)
+      dut.clockDomain.waitSampling(2)
+
+      SimTest.readField(driver, regs.interruptPending(0), 0, 0, 1, "Not-empty IRQ pending after push")
+
+      driver.write(regs.interruptPending(0), 0x1)
+      dut.clockDomain.waitSampling(1)
+    }
+  }
+}

--- a/test/scala/nafarr/system/semaphore/SemaphoreTest.scala
+++ b/test/scala/nafarr/system/semaphore/SemaphoreTest.scala
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.system.semaphore
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import spinal.sim._
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib.bus.amba3.apb.sim.Apb3Driver
+
+import nafarr.CheckTester._
+import nafarr.IpIdentification
+import nafarr.IpIdentificationTest
+import nafarr.SimTest
+
+class SemaphoreTest extends AnyFunSuite {
+  test("Apb3SemaphoreParameters") {
+    generationShouldPass(Apb3Semaphore(SemaphoreCtrl.Parameter()))
+    generationShouldPass(Apb3Semaphore(SemaphoreCtrl.Parameter.small()))
+    generationShouldPass(Apb3Semaphore(SemaphoreCtrl.Parameter.medium()))
+    generationShouldPass(Apb3Semaphore(SemaphoreCtrl.Parameter.large()))
+    generationShouldPass(Apb3Semaphore(SemaphoreCtrl.Parameter(1)))
+    generationShouldPass(Apb3Semaphore(SemaphoreCtrl.Parameter(31)))
+
+    generationShouldFail(Apb3Semaphore(SemaphoreCtrl.Parameter(0)))
+    generationShouldFail(Apb3Semaphore(SemaphoreCtrl.Parameter(33)))
+  }
+
+  test("TileLinkSemaphoreParameters") {
+    generationShouldPass(TileLinkSemaphore(SemaphoreCtrl.Parameter()))
+    generationShouldPass(TileLinkSemaphore(SemaphoreCtrl.Parameter.small()))
+    generationShouldPass(TileLinkSemaphore(SemaphoreCtrl.Parameter.medium()))
+    generationShouldPass(TileLinkSemaphore(SemaphoreCtrl.Parameter.large()))
+    generationShouldPass(TileLinkSemaphore(SemaphoreCtrl.Parameter(1)))
+    generationShouldPass(TileLinkSemaphore(SemaphoreCtrl.Parameter(31)))
+
+    generationShouldFail(TileLinkSemaphore(SemaphoreCtrl.Parameter(0)))
+    generationShouldFail(TileLinkSemaphore(SemaphoreCtrl.Parameter(33)))
+  }
+
+  test("WishboneSemaphoreParameters") {
+    generationShouldPass(WishboneSemaphore(SemaphoreCtrl.Parameter()))
+    generationShouldPass(WishboneSemaphore(SemaphoreCtrl.Parameter.small()))
+    generationShouldPass(WishboneSemaphore(SemaphoreCtrl.Parameter.medium()))
+    generationShouldPass(WishboneSemaphore(SemaphoreCtrl.Parameter.large()))
+    generationShouldPass(WishboneSemaphore(SemaphoreCtrl.Parameter(1)))
+    generationShouldPass(WishboneSemaphore(SemaphoreCtrl.Parameter(31)))
+
+    generationShouldFail(WishboneSemaphore(SemaphoreCtrl.Parameter(0)))
+    generationShouldFail(WishboneSemaphore(SemaphoreCtrl.Parameter(33)))
+  }
+
+
+  def init(dut: Apb3Semaphore): (Apb3Driver, SemaphoreCtrl.Regs) = {
+    dut.clockDomain.forkStimulus(10)
+    fork {
+      dut.clockDomain.fallingEdge()
+      sleep(10)
+      while (true) {
+        dut.clockDomain.clockToggle()
+        sleep(5)
+      }
+    }
+
+    val apb = new Apb3Driver(dut.io.bus, dut.clockDomain)
+    val regs = SemaphoreCtrl.Regs(dut.mapper.idCtrl.length, dut.p)
+
+    /* Wait for reset and check initialized state */
+    dut.clockDomain.waitSampling(2)
+    dut.clockDomain.waitFallingEdge()
+
+    return (apb, regs)
+  }
+
+  test("basic") {
+    val compiled = SimConfig.withWave.compile {
+      val dut = Apb3Semaphore(SemaphoreCtrl.Parameter())
+      dut
+    }
+
+    compiled.doSim("registerMap") { dut =>
+      val (apb, regs) = init(dut)
+
+      /* Check IP identification */
+      IpIdentificationTest.V0.checkApi(apb, IpIdentification.Ids.Semaphore)
+      IpIdentificationTest.V0.checkVersion(apb, 1, 0, 0)
+
+      /* Read bank and pin count */
+      SimTest.readField(apb, regs.info, 7, 0, 8,  "Semaphore count")
+    }
+
+    compiled.doSim("testIO") { dut =>
+      val (apb, regs) = init(dut)
+
+      for (i <- 0 until dut.p.count) {
+        SimTest.read(apb, regs.semaphore(i), 0, s"Semaphore $i already taken")
+        SimTest.read(apb, regs.status, (1 << (i + 1)) - 1, "Wrong number of taken semaphores")
+      }
+      for (i <- 0 until dut.p.count) {
+        SimTest.read(apb, regs.semaphore(i), 1, s"Semaphore $i not taken")
+      }
+      for (i <- 0 until dut.p.count) {
+        apb.write(regs.semaphore(i), 0)
+        SimTest.read(apb, regs.status, (1 << dut.p.count) - (1 << (i + 1)), "Wrong number of taken semaphores")
+      }
+    }
+
+  }
+}

--- a/test/scala/nafarr/system/syscon/SysconTest.scala
+++ b/test/scala/nafarr/system/syscon/SysconTest.scala
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.system.syscon
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import spinal.sim._
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib._
+import spinal.lib.bus.amba3.apb.{Apb3, Apb3Config}
+import spinal.lib.bus.amba3.apb.sim.Apb3Driver
+
+import nafarr.CheckTester._
+import nafarr.IpIdentification
+import nafarr.IpIdentificationTest
+import nafarr.SimTest
+import nafarr.{Vendor, Platform, PlatformClass, Product, Feature}
+
+class SysconTest extends AnyFunSuite {
+
+  def baseParam = Syscon.Parameter(
+    vendor       = Vendor.AescSilicon,
+    platform     = Platform.Hydrogen,
+    platformClass = PlatformClass.NonMetal,
+    product      = Product.ElemRV,
+    refClockHz   = 24000000L
+  )
+
+  test("Apb3Parameter") {
+    generationShouldPass(Apb3Syscon(baseParam))
+    generationShouldPass(Apb3Syscon(baseParam.copy(platform = Platform.Carbon)))
+    generationShouldPass(Apb3Syscon(baseParam.copy(platform = Platform.Sulfur)))
+    generationShouldPass(Apb3Syscon(baseParam.copy(siliconMajor = 3, siliconMinor = 7)))
+    generationShouldPass(Apb3Syscon(baseParam.copy(features = List(Feature.Uart, Feature.Gpio))))
+    generationShouldPass(Apb3Syscon(baseParam.copy(refClockHz = 48000000L)))
+  }
+
+  test("TileLinkParameter") {
+    generationShouldPass(TileLinkSyscon(baseParam))
+    generationShouldPass(TileLinkSyscon(baseParam.copy(platform = Platform.Nitrogen)))
+  }
+
+  test("WishboneParameter") {
+    generationShouldPass(WishboneSyscon(baseParam))
+    generationShouldPass(WishboneSyscon(baseParam.copy(platform = Platform.Oxygen)))
+  }
+
+  def init(dut: Apb3Syscon): (Apb3Driver, Syscon.Regs) = {
+    val driver = Apb3Driver(dut.io.bus, dut.clockDomain)
+    val regs = Syscon.Regs(dut.mapper.idCtrl.length)
+    dut.clockDomain.forkStimulus(10)
+    (driver, regs)
+  }
+
+  test("IpIdentification") {
+    SimConfig.withWave.compile(Apb3Syscon(baseParam))
+      .doSim("IpIdentification") { dut =>
+        val (driver, _) = init(dut)
+        IpIdentificationTest.V0.checkApi(driver, IpIdentification.Ids.Syscon)
+        IpIdentificationTest.V0.checkVersion(driver, 1, 0, 0)
+      }
+  }
+
+  test("Identity register") {
+    val p = baseParam.copy(
+      vendor = Vendor.AescSilicon,  // ordinal 0
+      platform = Platform.Carbon,  // ordinal 1
+      platformClass = PlatformClass.NonMetal,  // ordinal 0
+      product = Product.ElemRV  // ordinal 0
+    )
+    SimConfig.withWave.compile(Apb3Syscon(p))
+      .doSim("IdentityRegister") { dut =>
+        val (driver, regs) = init(dut)
+        SimTest.readField(driver, regs.identity,  7,  0, 0, "vendor=AescSilicon")
+        SimTest.readField(driver, regs.identity, 15,  8, 1, "platform=Carbon")
+        SimTest.readField(driver, regs.identity, 23, 16, 0, "product=ElemRV")
+        SimTest.readField(driver, regs.identity, 31, 24, 0, "platformClass=NonMetal")
+      }
+  }
+
+  test("Silicon revision registers") {
+    val p = baseParam.copy(siliconMajor = 2, siliconMinor = 5)
+    SimConfig.withWave.compile(Apb3Syscon(p))
+      .doSim("SiliconRevision") { dut =>
+        val (driver, regs) = init(dut)
+        SimTest.read(driver, regs.siliconMajor, 2, "siliconMajor=2")
+        SimTest.read(driver, regs.siliconMinor, 5, "siliconMinor=5")
+      }
+  }
+
+  test("Features register") {
+    // Uart=ordinal 2, Gpio=ordinal 3, Watchdog=ordinal 14
+    val p = baseParam.copy(features = List(Feature.Uart, Feature.Gpio, Feature.Watchdog))
+    val expectedMask = (1 << Feature.Uart.position) |
+                       (1 << Feature.Gpio.position) |
+                       (1 << Feature.Watchdog.position)
+    SimConfig.withWave.compile(Apb3Syscon(p))
+      .doSim("FeaturesRegister") { dut =>
+        val (driver, regs) = init(dut)
+        SimTest.read(driver, regs.features, expectedMask, "features bitmask")
+      }
+  }
+
+  test("Features register - empty") {
+    SimConfig.withWave.compile(Apb3Syscon(baseParam))
+      .doSim("FeaturesEmpty") { dut =>
+        val (driver, regs) = init(dut)
+        SimTest.read(driver, regs.features, 0, "no features")
+      }
+  }
+
+  test("RefClock register") {
+    val p = baseParam.copy(refClockHz = 48000000L)
+    SimConfig.withWave.compile(Apb3Syscon(p))
+      .doSim("RefClockRegister") { dut =>
+        val (driver, regs) = init(dut)
+        SimTest.read(driver, regs.refClock, 48000000L, "refClockHz=48MHz")
+      }
+  }
+
+  test("BuildDate register") {
+    val ts = 1748000000L
+    val p = baseParam.copy(buildDate = ts)
+    SimConfig.withWave.compile(Apb3Syscon(p))
+      .doSim("BuildDateRegister") { dut =>
+        val (driver, regs) = init(dut)
+        SimTest.read(driver, regs.buildDate, ts, "buildDate timestamp")
+      }
+  }
+
+  test("All platforms generate") {
+    generationShouldPass(Apb3Syscon(baseParam.copy(platform = Platform.Hydrogen)))
+    generationShouldPass(Apb3Syscon(baseParam.copy(platform = Platform.Carbon)))
+    generationShouldPass(Apb3Syscon(baseParam.copy(platform = Platform.Nitrogen)))
+    generationShouldPass(Apb3Syscon(baseParam.copy(platform = Platform.Oxygen)))
+    generationShouldPass(Apb3Syscon(baseParam.copy(platform = Platform.Phosphorus)))
+    generationShouldPass(Apb3Syscon(baseParam.copy(platform = Platform.Sulfur)))
+  }
+
+  test("PlatformClass Alkali generates") {
+    generationShouldPass(Apb3Syscon(baseParam.copy(platformClass = PlatformClass.Alkali)))
+  }
+}

--- a/test/scala/nafarr/system/timer/TimerTest.scala
+++ b/test/scala/nafarr/system/timer/TimerTest.scala
@@ -1,0 +1,279 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.system.timer
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import spinal.sim._
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib._
+import spinal.lib.bus.amba3.apb.{Apb3, Apb3Config}
+import spinal.lib.bus.amba3.apb.sim.Apb3Driver
+
+import nafarr.CheckTester._
+import nafarr.IpIdentification
+import nafarr.IpIdentificationTest
+import nafarr.SimTest
+
+class TimerTest extends AnyFunSuite {
+
+  test("Apb3Parameter") {
+    generationShouldPass(Apb3Timer(TimerCtrl.Parameter.small()))
+    generationShouldPass(Apb3Timer(TimerCtrl.Parameter.medium()))
+    generationShouldPass(Apb3Timer(TimerCtrl.Parameter.large()))
+    generationShouldPass(Apb3Timer(TimerCtrl.Parameter.default()))
+    generationShouldPass(Apb3Timer(TimerCtrl.Parameter(count = 4, channelCount = 2)))
+    generationShouldPass(Apb3Timer(TimerCtrl.Parameter(count = 1, channelCount = 8)))
+    generationShouldPass(Apb3Timer(TimerCtrl.Parameter(count = 16, channelCount = 1)))
+    generationShouldPass(Apb3Timer(TimerCtrl.Parameter(width = 8)))
+    generationShouldPass(Apb3Timer(TimerCtrl.Parameter(width = 16)))
+    generationShouldPass(Apb3Timer(TimerCtrl.Parameter(prescalerWidth = 0)))
+    generationShouldPass(Apb3Timer(TimerCtrl.Parameter(prescalerWidth = 32)))
+    generationShouldFail(Apb3Timer(TimerCtrl.Parameter(count = 0)))
+    generationShouldFail(Apb3Timer(TimerCtrl.Parameter(count = 17)))
+    generationShouldFail(Apb3Timer(TimerCtrl.Parameter(channelCount = 0)))
+    generationShouldFail(Apb3Timer(TimerCtrl.Parameter(channelCount = 9)))
+    generationShouldFail(Apb3Timer(TimerCtrl.Parameter(width = 0)))
+    generationShouldFail(Apb3Timer(TimerCtrl.Parameter(width = 33)))
+  }
+
+  test("TileLinkParameter") {
+    generationShouldPass(TileLinkTimer(TimerCtrl.Parameter.default()))
+    generationShouldPass(TileLinkTimer(TimerCtrl.Parameter(count = 2, channelCount = 2)))
+  }
+
+  test("WishboneParameter") {
+    generationShouldPass(WishboneTimer(TimerCtrl.Parameter.default()))
+    generationShouldPass(WishboneTimer(TimerCtrl.Parameter(count = 2, channelCount = 2)))
+  }
+
+  // 1 timer, 2 compare channels, 8-bit counter, 4-bit prescaler
+  def simParam = TimerCtrl.Parameter(count = 1, channelCount = 2, width = 8, prescalerWidth = 4)
+
+  def init(dut: Apb3Timer): (Apb3Driver, TimerCtrl.Regs) = {
+    val driver = Apb3Driver(dut.io.bus, dut.clockDomain)
+    val regs   = TimerCtrl.Regs(dut.mapper.idCtrl.length, simParam)
+    dut.clockDomain.forkStimulus(10)
+    (driver, regs)
+  }
+
+  test("IpIdentification") {
+    SimConfig.withWave.compile(Apb3Timer(simParam))
+      .doSim("IpIdentification") { dut =>
+        val (driver, _) = init(dut)
+        IpIdentificationTest.V0.checkApi(driver, IpIdentification.Ids.Timer)
+        IpIdentificationTest.V0.checkVersion(driver, 1, 0, 0)
+      }
+  }
+
+  test("Info register") {
+    SimConfig.withWave.compile(Apb3Timer(simParam))
+      .doSim("InfoRegister") { dut =>
+        val (driver, regs) = init(dut)
+        SimTest.readField(driver, regs.info,  7,  0, 1, "count=1")
+        SimTest.readField(driver, regs.info, 15,  8, 2, "channelCount=2")
+        SimTest.readField(driver, regs.info, 23, 16, 8, "width=8")
+        SimTest.readField(driver, regs.info, 31, 24, 4, "prescalerWidth=4")
+      }
+  }
+
+  test("Free-run: counter increments") {
+    SimConfig.withWave.compile(Apb3Timer(simParam))
+      .doSim("FreeRun") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        driver.write(regs.prescaler(0), 0)     // tick every cycle
+        driver.write(regs.control(0), 0x1)     // enable=1, mode=00 (free-run)
+        dut.clockDomain.waitSampling(6)
+
+        val cnt = driver.read(regs.counter(0))
+        assert(cnt > 0, s"counter should have incremented, got $cnt")
+        assert(cnt <= 10, s"counter ran too far, got $cnt")
+      }
+  }
+
+  test("Free-run: counter preload") {
+    SimConfig.withWave.compile(Apb3Timer(simParam))
+      .doSim("FreeRunPreload") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        driver.write(regs.counter(0), 0xE0)    // preload near overflow (width=8, max=0xFF)
+        driver.write(regs.prescaler(0), 0)
+        driver.write(regs.control(0), 0x1)     // free-run
+        dut.clockDomain.waitSampling(4)
+
+        val cnt = driver.read(regs.counter(0))
+        // After 0xE0 + ~4 ticks it should have wrapped (0xFF → 0) and continued
+        assert(cnt < 0xE0, s"counter should have wrapped, got 0x${f"$cnt%02x"}")
+      }
+  }
+
+  test("Periodic: overflow pending fires and counter reloads") {
+    SimConfig.withWave.compile(Apb3Timer(simParam))
+      .doSim("Periodic") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        driver.write(regs.prescaler(0), 0)     // tick every cycle
+        driver.write(regs.reload(0), 3)        // period = 4 ticks (0→1→2→3→overflow→0)
+        driver.write(regs.control(0), 0x3)     // enable=1, mode=01 (periodic)
+        dut.clockDomain.waitSampling(10)
+
+        SimTest.readField(driver, regs.irqPending, 0, 0, 1, "timer0 overflow pending")
+        val cnt = driver.read(regs.counter(0))
+        assert(cnt < 4, s"counter should have wrapped back, got $cnt")
+      }
+  }
+
+  test("One-shot: overflow pending fires and enable clears") {
+    SimConfig.withWave.compile(Apb3Timer(simParam))
+      .doSim("OneShot") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        driver.write(regs.prescaler(0), 0)
+        driver.write(regs.reload(0), 3)
+        driver.write(regs.control(0), 0x5)     // enable=1, mode=10 (one-shot)
+        dut.clockDomain.waitSampling(10)
+
+        SimTest.readField(driver, regs.irqPending, 0, 0, 1, "timer0 overflow pending")
+        SimTest.readField(driver, regs.control(0), 0, 0, 0, "enable cleared after one-shot")
+      }
+  }
+
+  test("One-shot: counter stops after completion") {
+    SimConfig.withWave.compile(Apb3Timer(simParam))
+      .doSim("OneShotStop") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        driver.write(regs.prescaler(0), 0)
+        driver.write(regs.reload(0), 2)
+        driver.write(regs.control(0), 0x5)     // one-shot
+        dut.clockDomain.waitSampling(10)
+
+        val cnt1 = driver.read(regs.counter(0))
+        dut.clockDomain.waitSampling(6)
+        val cnt2 = driver.read(regs.counter(0))
+        assert(cnt1 == cnt2, s"counter should not advance after one-shot: $cnt1 vs $cnt2")
+      }
+  }
+
+  test("Compare match: pending fires on match") {
+    SimConfig.withWave.compile(Apb3Timer(simParam))
+      .doSim("CompareMatch") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        driver.write(regs.compare(0, 0), 3)    // compare0 fires at counter=3
+        driver.write(regs.reload(0), 7)
+        driver.write(regs.prescaler(0), 0)
+        driver.write(regs.control(0), 0x3)     // periodic
+        dut.clockDomain.waitSampling(10)
+
+        SimTest.readField(driver, regs.irqPending, 1, 1, 1, "timer0 compare0 pending")
+      }
+  }
+
+  test("Compare match channel 1") {
+    SimConfig.withWave.compile(Apb3Timer(simParam))
+      .doSim("CompareMatchCh1") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        driver.write(regs.compare(0, 1), 2)    // compare1 fires at counter=2
+        driver.write(regs.reload(0), 7)
+        driver.write(regs.prescaler(0), 0)
+        driver.write(regs.control(0), 0x3)
+        dut.clockDomain.waitSampling(10)
+
+        SimTest.readField(driver, regs.irqPending, 2, 2, 1, "timer0 compare1 pending")
+      }
+  }
+
+  test("Prescaler: controls tick rate") {
+    SimConfig.withWave.compile(Apb3Timer(simParam))
+      .doSim("Prescaler") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        // prescaler=7 → tick every 8 cycles; after 24 cycles expect ~3 ticks
+        driver.write(regs.prescaler(0), 7)
+        driver.write(regs.control(0), 0x1)     // free-run
+        dut.clockDomain.waitSampling(30)
+
+        val cnt = driver.read(regs.counter(0))
+        assert(cnt >= 1 && cnt <= 5, s"prescaled counter out of range, got $cnt")
+      }
+  }
+
+  test("Interrupt output: fires when mask enabled") {
+    SimConfig.withWave.compile(Apb3Timer(simParam))
+      .doSim("InterruptOutput") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        val irqMask = regs.irqPending + 4
+        driver.write(irqMask, 0x1)             // enable bit 0 = timer0 overflow
+        driver.write(regs.prescaler(0), 0)
+        driver.write(regs.reload(0), 3)
+        driver.write(regs.control(0), 0x3)     // periodic
+        dut.clockDomain.waitSampling(10)
+
+        assert(dut.io.interrupt.toBoolean, "interrupt should be high after overflow")
+      }
+  }
+
+  test("Interrupt output: masked source does not fire") {
+    SimConfig.withWave.compile(Apb3Timer(simParam))
+      .doSim("InterruptMasked") { dut =>
+        val (driver, regs) = init(dut)
+        dut.clockDomain.waitSampling(2)
+
+        // mask = 0x2 (compare0 only), overflow bit 0 not enabled
+        val irqMask = regs.irqPending + 4
+        driver.write(irqMask, 0x2)
+        driver.write(regs.prescaler(0), 0)
+        driver.write(regs.reload(0), 3)
+        driver.write(regs.control(0), 0x3)     // overflow will fire, but is not masked-in
+        dut.clockDomain.waitSampling(10)
+
+        SimTest.readField(driver, regs.irqPending, 0, 0, 1, "overflow pending (raw)")
+        assert(!dut.io.interrupt.toBoolean, "interrupt should be low — overflow not in mask")
+      }
+  }
+
+  test("Multi-timer: independent operation") {
+    val p = TimerCtrl.Parameter(count = 2, channelCount = 1, width = 8, prescalerWidth = 4)
+    SimConfig.withWave.compile(Apb3Timer(p))
+      .doSim("MultiTimer") { dut =>
+        val driver = Apb3Driver(dut.io.bus, dut.clockDomain)
+        val regs   = TimerCtrl.Regs(dut.mapper.idCtrl.length, p)
+        dut.clockDomain.forkStimulus(10)
+        dut.clockDomain.waitSampling(2)
+
+        // timer0: periodic, reload=3
+        driver.write(regs.prescaler(0), 0)
+        driver.write(regs.reload(0), 3)
+        driver.write(regs.control(0), 0x3)
+
+        // timer1: one-shot, reload=5
+        driver.write(regs.prescaler(1), 0)
+        driver.write(regs.reload(1), 5)
+        driver.write(regs.control(1), 0x5)
+
+        dut.clockDomain.waitSampling(12)
+
+        // irq source 0 = timer0 overflow, irq source 1 = timer0 compare0
+        // irq source 2 = timer1 overflow, irq source 3 = timer1 compare0
+        SimTest.readField(driver, regs.irqPending, 0, 0, 1, "timer0 overflow pending")
+        SimTest.readField(driver, regs.irqPending, 2, 2, 1, "timer1 overflow pending")
+        SimTest.readField(driver, regs.control(1), 0, 0, 0, "timer1 enable cleared after one-shot")
+      }
+  }
+}

--- a/test/scala/nafarr/system/timer/TimerTest.scala
+++ b/test/scala/nafarr/system/timer/TimerTest.scala
@@ -105,7 +105,7 @@ class TimerTest extends AnyFunSuite {
         driver.write(regs.counter(0), 0xE0)    // preload near overflow (width=8, max=0xFF)
         driver.write(regs.prescaler(0), 0)
         driver.write(regs.control(0), 0x1)     // free-run
-        dut.clockDomain.waitSampling(4)
+        dut.clockDomain.waitSampling(40)       // need >32 ticks to wrap from 0xE0 past 0xFF
 
         val cnt = driver.read(regs.counter(0))
         // After 0xE0 + ~4 ticks it should have wrapped (0xFF → 0) and continued

--- a/test/scala/nafarr/system/watchdog/WatchdogTest.scala
+++ b/test/scala/nafarr/system/watchdog/WatchdogTest.scala
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package nafarr.system.watchdog
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import spinal.sim._
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib._
+import spinal.lib.bus.amba3.apb.{Apb3, Apb3Config}
+import spinal.lib.bus.amba3.apb.sim.Apb3Driver
+
+import nafarr.CheckTester._
+import nafarr.IpIdentification
+import nafarr.IpIdentificationTest
+import nafarr.SimTest
+
+class WatchdogTest extends AnyFunSuite {
+  test("Apb3Parameter") {
+    generationShouldPass(Apb3Watchdog(WatchdogCtrl.Parameter.default()))
+    generationShouldPass(Apb3Watchdog(WatchdogCtrl.Parameter.small()))
+    generationShouldPass(Apb3Watchdog(WatchdogCtrl.Parameter.windowed()))
+    generationShouldPass(Apb3Watchdog(WatchdogCtrl.Parameter(count = 4)))
+    generationShouldPass(Apb3Watchdog(WatchdogCtrl.Parameter(width = 1)))
+    generationShouldPass(Apb3Watchdog(WatchdogCtrl.Parameter(width = 32)))
+    generationShouldPass(Apb3Watchdog(WatchdogCtrl.Parameter(prescalerWidth = 1)))
+    generationShouldPass(Apb3Watchdog(WatchdogCtrl.Parameter(prescalerWidth = 32)))
+    generationShouldPass(Apb3Watchdog(WatchdogCtrl.Parameter(locked = false)))
+    generationShouldFail(Apb3Watchdog(WatchdogCtrl.Parameter(count = 0)))
+    generationShouldFail(Apb3Watchdog(WatchdogCtrl.Parameter(width = 0)))
+    generationShouldFail(Apb3Watchdog(WatchdogCtrl.Parameter(width = 33)))
+    generationShouldFail(Apb3Watchdog(WatchdogCtrl.Parameter(prescalerWidth = 0)))
+    generationShouldFail(Apb3Watchdog(WatchdogCtrl.Parameter(prescalerWidth = 33)))
+  }
+
+  test("TileLinkParameter") {
+    generationShouldPass(TileLinkWatchdog(WatchdogCtrl.Parameter.default()))
+    generationShouldPass(TileLinkWatchdog(WatchdogCtrl.Parameter.small()))
+    generationShouldPass(TileLinkWatchdog(WatchdogCtrl.Parameter.windowed()))
+    generationShouldFail(TileLinkWatchdog(WatchdogCtrl.Parameter(count = 0)))
+    generationShouldFail(TileLinkWatchdog(WatchdogCtrl.Parameter(width = 33)))
+    generationShouldFail(TileLinkWatchdog(WatchdogCtrl.Parameter(prescalerWidth = 0)))
+  }
+
+  test("WishboneParameter") {
+    generationShouldPass(WishboneWatchdog(WatchdogCtrl.Parameter.default()))
+    generationShouldPass(WishboneWatchdog(WatchdogCtrl.Parameter.small()))
+    generationShouldPass(WishboneWatchdog(WatchdogCtrl.Parameter.windowed()))
+    generationShouldFail(WishboneWatchdog(WatchdogCtrl.Parameter(count = 0)))
+    generationShouldFail(WishboneWatchdog(WatchdogCtrl.Parameter(width = 33)))
+    generationShouldFail(WishboneWatchdog(WatchdogCtrl.Parameter(prescalerWidth = 0)))
+  }
+
+  // Small counter widths to keep simulation fast.
+  def simParam = WatchdogCtrl.Parameter(width = 4, prescalerWidth = 4, locked = false)
+  def windowedParam = WatchdogCtrl.Parameter(width = 4, prescalerWidth = 4, windowed = true, locked = false)
+
+  def init(dut: Apb3Watchdog): (Apb3Driver, WatchdogCtrl.Regs) = {
+    val driver = Apb3Driver(dut.io.bus, dut.clockDomain)
+    val regs = WatchdogCtrl.Regs(dut.mapper.idCtrl.length)
+    dut.clockDomain.forkStimulus(10)
+    (driver, regs)
+  }
+
+  test("IpIdentification") {
+    SimConfig.withWave.compile(Apb3Watchdog(WatchdogCtrl.Parameter.default())).doSim { dut =>
+      val (driver, _) = init(dut)
+      IpIdentificationTest.V0.checkApi(driver, IpIdentification.Ids.Watchdog)
+      IpIdentificationTest.V0.checkVersion(driver, 1, 0, 0)
+    }
+  }
+
+  test("Info register") {
+    val p = WatchdogCtrl.Parameter(count = 2, width = 8, prescalerWidth = 10, windowed = true, locked = true)
+    SimConfig.withWave.compile(Apb3Watchdog(p)).doSim { dut =>
+      val (driver, regs) = init(dut)
+      SimTest.readField(driver, regs.info, 7, 0, 2, "Count")
+      SimTest.readField(driver, regs.info, 15, 8, 8, "Width")
+      SimTest.readField(driver, regs.info, 23, 16, 10, "PrescalerWidth")
+      SimTest.readField(driver, regs.info, 24, 24, 1, "Windowed")
+      SimTest.readField(driver, regs.info, 25, 25, 1, "Locked")
+    }
+  }
+
+  test("Timeout fires interrupt") {
+    SimConfig.withWave.compile(Apb3Watchdog(simParam)).doSim { dut =>
+      val (driver, regs) = init(dut)
+      dut.clockDomain.waitSampling(2)
+
+      // prescalerVal=1 → tick every 2 cycles; timeoutVal=3 → fires after 4 ticks (8 cycles)
+      driver.write(regs.prescaler(0), 1)
+      driver.write(regs.timeout(0), 3)
+      driver.write(regs.irqMask(0), 0x1)
+      driver.write(regs.control(0), 0x1)
+      dut.clockDomain.waitSampling(20)
+
+      SimTest.readField(driver, regs.irqPending(0), 0, 0, 1, "Timeout IRQ pending after expiry")
+      assert(dut.io.interrupt.toBoolean, "Combined interrupt asserted")
+    }
+  }
+
+  test("Kick prevents timeout") {
+    SimConfig.withWave.compile(Apb3Watchdog(simParam)).doSim { dut =>
+      val (driver, regs) = init(dut)
+      dut.clockDomain.waitSampling(2)
+
+      // timeout = 7 → 8 ticks at prescalerVal=1 → 16 cycles
+      driver.write(regs.prescaler(0), 1)
+      driver.write(regs.timeout(0), 7)
+      driver.write(regs.irqMask(0), 0x1)
+      driver.write(regs.control(0), 0x1)
+
+      for (_ <- 0 until 5) {
+        dut.clockDomain.waitSampling(10)
+        driver.write(regs.kick(0), 1)
+      }
+
+      SimTest.readField(driver, regs.irqPending(0), 0, 0, 0, "No timeout after repeated kicks")
+    }
+  }
+
+  test("Lock prevents config change") {
+    SimConfig.withWave.compile(Apb3Watchdog(WatchdogCtrl.Parameter(width = 4, prescalerWidth = 4))).doSim { dut =>
+      val (driver, regs) = init(dut)
+      dut.clockDomain.waitSampling(2)
+
+      driver.write(regs.timeout(0), 0xa)
+      driver.write(regs.control(0), 0x3) // enable + lock
+      dut.clockDomain.waitSampling(1)
+
+      driver.write(regs.timeout(0), 0x5) // attempt change — must be ignored
+      dut.clockDomain.waitSampling(1)
+
+      SimTest.readField(driver, regs.timeout(0), 3, 0, 0xa, "Timeout unchanged after lock")
+      SimTest.readField(driver, regs.status(0), 1, 1, 1, "Lock bit visible in status")
+    }
+  }
+
+  test("Lock prevents disable") {
+    SimConfig.withWave.compile(Apb3Watchdog(WatchdogCtrl.Parameter(width = 4, prescalerWidth = 4))).doSim { dut =>
+      val (driver, regs) = init(dut)
+      dut.clockDomain.waitSampling(2)
+
+      driver.write(regs.control(0), 0x3) // enable + lock
+      dut.clockDomain.waitSampling(1)
+
+      driver.write(regs.control(0), 0x0) // attempt disable — must be ignored
+      dut.clockDomain.waitSampling(1)
+
+      SimTest.readField(driver, regs.status(0), 0, 0, 1, "Watchdog still enabled after lock")
+    }
+  }
+
+  test("Windowed - valid kick resets counter") {
+    SimConfig.withWave.compile(Apb3Watchdog(windowedParam)).doSim { dut =>
+      val (driver, regs) = init(dut)
+      dut.clockDomain.waitSampling(2)
+
+      // timeout=7, windowOpen=2: window opens when counter<=2, i.e. after 5 ticks (10 cycles)
+      driver.write(regs.prescaler(0), 1)
+      driver.write(regs.timeout(0), 7)
+      driver.write(regs.windowOpen(0), 2)
+      driver.write(regs.irqMask(0), 0x5) // timeout-irq and violation-irq
+      driver.write(regs.control(0), 0x1)
+
+      dut.clockDomain.waitSampling(12) // counter should be 1 (in window)
+
+      SimTest.readField(driver, regs.status(0), 2, 2, 1, "inWindow asserted")
+      driver.write(regs.kick(0), 1)
+      dut.clockDomain.waitSampling(2)
+
+      SimTest.readField(driver, regs.irqPending(0), 2, 2, 0, "No violation after valid kick")
+    }
+  }
+
+  test("Windowed - early kick raises violation") {
+    SimConfig.withWave.compile(Apb3Watchdog(windowedParam)).doSim { dut =>
+      val (driver, regs) = init(dut)
+      dut.clockDomain.waitSampling(2)
+
+      driver.write(regs.prescaler(0), 1)
+      driver.write(regs.timeout(0), 7)
+      driver.write(regs.windowOpen(0), 1)
+      driver.write(regs.irqMask(0), 0x4) // violation-irq
+      driver.write(regs.control(0), 0x1)
+
+      dut.clockDomain.waitSampling(4) // counter ~5 or 6, outside window
+
+      driver.write(regs.kick(0), 1) // early kick — violation
+      dut.clockDomain.waitSampling(2)
+
+      SimTest.readField(driver, regs.irqPending(0), 2, 2, 1, "Violation IRQ pending after early kick")
+      assert(dut.io.interrupt.toBoolean, "Combined interrupt asserted on violation")
+    }
+  }
+}

--- a/test/software/Makefile
+++ b/test/software/Makefile
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2026 aesc silicon
+#
+# SPDX-License-Identifier: Apache-2.0
+
+DRIVERS  := clock crc32 esm gpio mailbox mtimer pinmux pio plic prng pwm reset semaphore syscon timer uart watchdog
+CC       := gcc
+CFLAGS   := -Wall -Werror -I../../software/include
+SRCDIR   := ../../software/driver
+TESTDIR  := testcases
+BUILDDIR := build
+
+TESTS    := $(addprefix $(BUILDDIR)/test_, $(DRIVERS))
+
+.PHONY: all run clean
+
+all: $(TESTS)
+
+$(BUILDDIR):
+	mkdir -p $(BUILDDIR)
+
+define DRIVER_RULE
+$(BUILDDIR)/test_$(1): $(TESTDIR)/test_$(1).c $(BUILDDIR)/$(1).o | $(BUILDDIR)
+	$(CC) $(CFLAGS) $$^ -o $$@
+
+$(BUILDDIR)/$(1).o: $(SRCDIR)/$(1).c | $(BUILDDIR)
+	$(CC) $(CFLAGS) -c $$< -o $$@
+endef
+
+$(foreach d,$(DRIVERS),$(eval $(call DRIVER_RULE,$(d))))
+
+run: all
+	@failed=0; \
+	for t in $(TESTS); do \
+		printf "%-50s " "$$t"; \
+		if ./$$t; then echo "PASS"; else echo "FAIL"; failed=$$((failed + 1)); fi; \
+	done; \
+	[ $$failed -eq 0 ]
+
+clean:
+	rm -rf $(BUILDDIR)

--- a/test/software/testcases/test_clock.c
+++ b/test/software/testcases/test_clock.c
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "clock.h"
+
+int main(void)
+{
+	struct clock_driver driver;
+	static volatile struct clock_regs fake_regs;
+
+	clock_init(&driver, 0xf0000000);
+	driver.regs = &fake_regs;
+
+	clock_domain_count(&driver);
+	clock_enable_get(&driver);
+	clock_enable_set(&driver, 0x3);
+
+	return 0;
+}

--- a/test/software/testcases/test_crc32.c
+++ b/test/software/testcases/test_crc32.c
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "crc32.h"
+
+int main(void)
+{
+	struct crc32_driver driver;
+	static volatile struct crc32_regs fake_regs;
+
+	crc32_init_driver(&driver, 0xf0000000);
+	driver.regs = &fake_regs;
+
+	crc32_init(&driver);
+	crc32_write(&driver, 0x12345678);
+	crc32_read(&driver);
+	crc32_info(&driver);
+	crc32_get_xorout(&driver);
+	crc32_set_xorout(&driver, 0xffffffff);
+
+	return 0;
+}

--- a/test/software/testcases/test_esm.c
+++ b/test/software/testcases/test_esm.c
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "esm.h"
+
+int main(void)
+{
+	struct esm_driver driver;
+	static volatile struct esm_regs fake_regs;
+
+	/* esm_init reads info to derive bank_count; pass fake address directly */
+	esm_init(&driver, (unsigned long)&fake_regs);
+	/* bank_count == 0 from zeroed info; override to exercise bank API */
+	driver.bank_count = 1;
+
+	esm_enable(&driver);
+	esm_configure(&driver, 0, ESM_LEVEL_INFO(0x3) | ESM_LEVEL_WARN(0x3));
+	esm_configure_counter(&driver, 100);
+	esm_inject_enable(&driver);
+	esm_inject_set(&driver, 0, 0x1);
+	esm_raw(&driver, 0);
+	esm_pending(&driver, 0);
+	esm_clear(&driver, 0, ESM_LEVEL_INFO(0x3));
+	esm_inject_clear(&driver, 0, 0x1);
+	esm_inject_disable(&driver);
+	esm_status(&driver);
+	esm_disable(&driver);
+	esm_lock(&driver);
+
+	return 0;
+}

--- a/test/software/testcases/test_gpio.c
+++ b/test/software/testcases/test_gpio.c
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2025 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "gpio.h"
+
+int main(void)
+{
+	struct gpio_driver driver;
+	static volatile struct gpio_regs fake_regs;
+
+	gpio_init(&driver, 0xf0000000);
+	driver.regs = &fake_regs;
+
+	gpio_value_get(&driver, 0);
+	gpio_value_set(&driver, 0);
+	gpio_value_clr(&driver, 0);
+	gpio_dir_set(&driver, 0);
+	gpio_dir_clr(&driver, 0);
+	gpio_irq_enable(&driver, 0, GPIO_IRQ_LEVEL_HIGH | GPIO_IRQ_RISING_EDGE);
+	gpio_irq_disable(&driver, 0, GPIO_IRQ_LEVEL_HIGH | GPIO_IRQ_RISING_EDGE);
+	gpio_irq_ready(&driver, 0, GPIO_IRQ_LEVEL_HIGH | GPIO_IRQ_RISING_EDGE);
+
+	return 0;
+}

--- a/test/software/testcases/test_mailbox.c
+++ b/test/software/testcases/test_mailbox.c
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "mailbox.h"
+
+int main(void)
+{
+	struct mailbox_driver driver;
+	static volatile struct mailbox_regs fake_regs;
+
+	mailbox_init(&driver, 0xf0000000);
+	driver.regs = &fake_regs;
+
+	mailbox_status(&driver);
+	mailbox_occupancy(&driver, 0);
+
+	unsigned int data;
+	mailbox_write(&driver, 0, 0xdeadbeef);
+	mailbox_read(&driver, 0, &data);
+
+	mailbox_irq_enable(&driver, 0, MAILBOX_IRQ_NOT_EMPTY | MAILBOX_IRQ_NOT_FULL);
+	mailbox_irq_pending(&driver, 0, MAILBOX_IRQ_NOT_EMPTY);
+	mailbox_irq_clear(&driver, 0, MAILBOX_IRQ_NOT_EMPTY);
+	mailbox_irq_disable(&driver, 0, MAILBOX_IRQ_NOT_EMPTY | MAILBOX_IRQ_NOT_FULL);
+
+	return 0;
+}

--- a/test/software/testcases/test_mtimer.c
+++ b/test/software/testcases/test_mtimer.c
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: 2025 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "mtimer.h"
+
+int main(void)
+{
+	struct mtimer_driver driver;
+	static volatile struct mtimer_regs fake_regs;
+
+	/* mtimer_init writes cmp registers; pass fake address directly */
+	mtimer_init(&driver, (unsigned long)&fake_regs);
+
+	/* cycles == 0: compare = cnt_low + 0 = 0; while(0 > 0) exits immediately */
+	mtimer_sleep32(&driver, 0);
+
+	return 0;
+}

--- a/test/software/testcases/test_pinmux.c
+++ b/test/software/testcases/test_pinmux.c
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "pinmux.h"
+
+int main(void)
+{
+	struct pinmux_driver driver;
+	/* extra space for option[] entries beyond the fixed header */
+	static unsigned char fake_buf[128];
+
+	/* pinmux_init reads info; pass fake buffer address directly */
+	pinmux_init(&driver, (unsigned long)fake_buf);
+
+	pinmux_pin_count(&driver);
+	pinmux_options_count(&driver);
+	/* pin_count == 0 from zeroed buffer; set/get guards return early */
+	pinmux_set(&driver, 0, 0);
+	pinmux_get(&driver, 0);
+
+	return 0;
+}

--- a/test/software/testcases/test_pio.c
+++ b/test/software/testcases/test_pio.c
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2025 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "pio.h"
+
+int main(void)
+{
+	struct pio_driver driver;
+	static volatile struct pio_regs fake_regs;
+
+	pio_init(&driver, 0xf0000000);
+	driver.regs = &fake_regs;
+
+	pio_enable(&driver);
+	pio_disable(&driver);
+	pio_set_stop_at_loop(&driver, 1);
+	pio_set_stop_at_loop(&driver, 0);
+
+	pio_program_reset(&driver);
+	pio_program_write(&driver, PIO_MAKE_CMD(PIO_CMD_HIGH, 0, 0));
+	pio_program_write(&driver, PIO_MAKE_CMD(PIO_CMD_WAIT, 0, 100));
+	pio_program_write(&driver, PIO_MAKE_CMD(PIO_CMD_LOOP, 0, 0));
+
+	unsigned int result;
+	pio_read(&driver, &result);
+
+	pio_irq_enable(&driver, PIO_IRQ_RX_READY | PIO_IRQ_LOOP_DONE);
+	pio_irq_disable(&driver, PIO_IRQ_RX_READY);
+	pio_irq_pending(&driver);
+	pio_irq_clear(&driver, PIO_IRQ_LOOP_DONE);
+
+	return 0;
+}

--- a/test/software/testcases/test_plic.c
+++ b/test/software/testcases/test_plic.c
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2025 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "plic.h"
+
+int main(void)
+{
+	struct plic_driver driver;
+	static unsigned int fake_plic[8];
+
+	plic_init(&driver, 0xf0000000);
+
+	/* redirect raw pointers to fake memory before dereferencing */
+	driver.gateway_priority = &fake_plic[0];
+	driver.gateway_pending  = &fake_plic[1];
+	driver.target_enable    = &fake_plic[2];
+	driver.claim            = &fake_plic[3];
+
+	plic_irq_enable(&driver, 1);
+	plic_irq_disable(&driver, 1);
+	plic_irq_claim(&driver, 1);
+
+	return 0;
+}

--- a/test/software/testcases/test_prng.c
+++ b/test/software/testcases/test_prng.c
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "prng.h"
+
+int main(void)
+{
+	struct prng_driver driver;
+	static volatile struct prng_regs fake_regs;
+
+	prng_init(&driver, 0xf0000000);
+	driver.regs = &fake_regs;
+
+	prng_enable(&driver);
+	prng_seed(&driver, 0xdeadbeef);
+	prng_read(&driver);
+	prng_error_pending(&driver, PRNG_ERROR_ZERO_SEED);
+	prng_error_clear(&driver, PRNG_ERROR_ZERO_SEED);
+	prng_error_mask(&driver, PRNG_ERROR_ZERO_SEED);
+	prng_error_unmask(&driver, PRNG_ERROR_ZERO_SEED);
+	prng_disable(&driver);
+
+	return 0;
+}

--- a/test/software/testcases/test_pwm.c
+++ b/test/software/testcases/test_pwm.c
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2025 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "pwm.h"
+
+int main(void)
+{
+	struct pwm_driver driver;
+	/* extra space for per-channel registers beyond struct pwm_regs */
+	static unsigned char fake_buf[256];
+
+	/* pwm_init reads channel_config; pass fake buffer address directly */
+	pwm_init(&driver, (unsigned long)fake_buf);
+	/* channel_count == 0 from zeroed buffer; override to test channel API */
+	driver.channel_count = 1;
+
+	pwm_channel_count(&driver);
+	pwm_channel_set_clock_div(&driver, 0, 999);
+	pwm_channel_set_period(&driver, 0, 1000);
+	pwm_channel_set_duty(&driver, 0, 250, 750);
+	pwm_channel_set_dead_time(&driver, 0, 10);
+	pwm_channel_set_phase_offset(&driver, 0, 0);
+	pwm_channel_set_shot_count(&driver, 0, 0);
+	pwm_channel_set_invert(&driver, 0, 0);
+	pwm_channel_set_mode_center(&driver, 0, 0);
+	pwm_channel_enable(&driver, 0);
+	pwm_channel_status(&driver, 0);
+	pwm_channel_disable(&driver, 0);
+
+	pwm_irq_enable(&driver, 0x1);
+	pwm_irq_disable(&driver, 0x1);
+	pwm_irq_pending(&driver);
+	pwm_irq_clear(&driver, 0x1);
+
+	return 0;
+}

--- a/test/software/testcases/test_reset.c
+++ b/test/software/testcases/test_reset.c
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "reset.h"
+
+int main(void)
+{
+	struct reset_driver driver;
+	static volatile struct reset_regs fake_regs;
+
+	reset_init(&driver, 0xf0000000);
+	driver.regs = &fake_regs;
+
+	reset_domain_count(&driver);
+	reset_enable_get(&driver);
+	reset_enable_set(&driver, 0x3);
+	reset_trigger(&driver, 0x1);
+	reset_acknowledge(&driver);
+
+	return 0;
+}

--- a/test/software/testcases/test_semaphore.c
+++ b/test/software/testcases/test_semaphore.c
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "semaphore.h"
+
+int main(void)
+{
+	struct semaphore_driver driver;
+	static volatile struct semaphore_regs fake_regs;
+
+	semaphore_init(&driver, 0xf0000000, 4);
+	driver.regs = &fake_regs;
+
+	semaphore_status(&driver);
+	semaphore_claim(&driver, 0);
+	semaphore_release(&driver, 0);
+
+	return 0;
+}

--- a/test/software/testcases/test_syscon.c
+++ b/test/software/testcases/test_syscon.c
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "syscon.h"
+
+int main(void)
+{
+	struct syscon_driver driver;
+	static volatile struct syscon_regs fake_regs;
+
+	syscon_init(&driver, 0xf0000000);
+	driver.regs = &fake_regs;
+
+	syscon_vendor(&driver);
+	syscon_platform(&driver);
+	syscon_platform_class(&driver);
+	syscon_product(&driver);
+	syscon_silicon_major(&driver);
+	syscon_silicon_minor(&driver);
+	syscon_features(&driver);
+	syscon_ref_clock(&driver);
+	syscon_build_date(&driver);
+	syscon_has_feature(&driver, SYSCON_FEATURE_GPIO);
+
+	return 0;
+}

--- a/test/software/testcases/test_timer.c
+++ b/test/software/testcases/test_timer.c
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "timer.h"
+
+int main(void)
+{
+	struct timer_driver driver;
+	/* extra space for per-timer registers beyond struct timer_regs */
+	static unsigned char fake_buf[128];
+
+	/* timer_init reads info register; pass fake buffer address directly */
+	timer_init(&driver, (unsigned long)fake_buf);
+	/* count == 0 from zeroed buffer; stride == 0x10 */
+
+	timer_set_control(&driver, 0, TIMER_CTRL_ENABLE | TIMER_CTRL_MODE_PERIODIC);
+	timer_get_control(&driver, 0);
+	timer_set_prescaler(&driver, 0, 999);
+	timer_set_reload(&driver, 0, 9999);
+	timer_set_counter(&driver, 0, 0);
+	timer_get_counter(&driver, 0);
+	timer_set_compare(&driver, 0, 0, 5000);
+
+	timer_irq_enable(&driver, TIMER_IRQ_OVERFLOW(0, 1));
+	timer_irq_pending(&driver);
+	timer_irq_clear(&driver, TIMER_IRQ_OVERFLOW(0, 1));
+	timer_irq_disable(&driver, TIMER_IRQ_OVERFLOW(0, 1));
+
+	return 0;
+}

--- a/test/software/testcases/test_uart.c
+++ b/test/software/testcases/test_uart.c
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: 2025 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "uart.h"
+
+int main(void)
+{
+	struct uart_driver driver;
+	static volatile struct uart_regs fake_regs;
+
+	/* uart_init writes registers immediately; pass the fake address */
+	uart_init(&driver, (unsigned long)&fake_regs, 115200);
+
+	/* set TX vacancy so uart_putc does not spin */
+	fake_regs.fifo_status = 0x00FF0000;
+
+	uart_putc(&driver, 'A');
+	uart_puts(&driver, (unsigned char *)"ok");
+
+	unsigned char c;
+	uart_getc(&driver, &c);
+
+	uart_irq_rx_enable(&driver);
+	uart_irq_rx_disable(&driver);
+	uart_irq_rx_ready(&driver);
+
+	return 0;
+}

--- a/test/software/testcases/test_watchdog.c
+++ b/test/software/testcases/test_watchdog.c
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "watchdog.h"
+
+int main(void)
+{
+	struct watchdog_driver driver;
+	static volatile struct watchdog_regs fake_regs;
+
+	watchdog_init(&driver, 0xf0000000);
+	driver.regs = &fake_regs;
+
+	watchdog_configure(&driver, 0, 999, 9999);
+	watchdog_configure_window(&driver, 0, 4999);
+	watchdog_enable(&driver, 0);
+	watchdog_status(&driver, 0);
+	watchdog_kick(&driver, 0);
+	watchdog_irq_enable(&driver, 0, WATCHDOG_IRQ_TIMEOUT_IRQ | WATCHDOG_IRQ_TIMEOUT_ERR);
+	watchdog_irq_pending(&driver, 0, WATCHDOG_IRQ_TIMEOUT_IRQ);
+	watchdog_irq_clear(&driver, 0, WATCHDOG_IRQ_TIMEOUT_IRQ);
+	watchdog_irq_disable(&driver, 0, WATCHDOG_IRQ_TIMEOUT_IRQ | WATCHDOG_IRQ_TIMEOUT_ERR);
+	watchdog_disable(&driver, 0);
+	watchdog_lock(&driver, 0);
+
+	return 0;
+}


### PR DESCRIPTION
Adds six new IP cores to the nafarr library: Semaphore, Mailbox, Watchdog, ESM, Timer, Syscon (system), and PRNG, CRC32 (crypto). Each IP ships with SpinalHDL hardware, a C driver, a public header, and simulation tests.

All IP Core classes have been extended to implement PeripheralsComponent, enabling automatic syscon feature flag reporting and bare-metal SoC header generation. The component naming in BaremetalTools has been fixed to strip area prefixes (e.g. system_) from generated macro names.

A software test suite covering all IPs is added alongside a CI workflow. Coding rules and a create-ip skill are added to guide future hardware development in this repository.
