### PR TITLE
SpinalHDL 1.14.2 + VexiiRiscv icache option

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: CERN-OHL-W-2.0
 
-val spinalVersion = "1.13.0"
+val spinalVersion = "1.14.2"
 
 lazy val root = (project in file("."))
   .settings(

--- a/hardware/scala/nafarr/cores/cpu/vexiiriscv/TileLinkVexiiRiscv.scala
+++ b/hardware/scala/nafarr/cores/cpu/vexiiriscv/TileLinkVexiiRiscv.scala
@@ -12,7 +12,7 @@ import spinal.lib.com.jtag.Jtag
 import spinal.lib.misc.plugin.Hostable
 
 import vexiiriscv.VexiiRiscv
-import vexiiriscv.fetch.FetchCachelessPlugin
+import vexiiriscv.fetch.{FetchCachelessPlugin, FetchL1Plugin}
 import vexiiriscv.execute.lsu.LsuCachelessPlugin
 import vexiiriscv.misc.{EmbeddedRiscvJtag, PrivilegedPlugin}
 
@@ -59,7 +59,10 @@ class TileLinkVexiiRiscv(
   val jtag = Jtag()
   val ndmreset = Bool()
 
-  private val fetchPlugin = parameter.plugins.collectFirst { case p: FetchCachelessPlugin => p }.get
+  private val fetchCachelessPlugin = parameter.plugins.collectFirst {
+    case p: FetchCachelessPlugin => p
+  }
+  private val fetchL1Plugin = parameter.plugins.collectFirst { case p: FetchL1Plugin => p }
   private val lsuPlugin = parameter.plugins.collectFirst { case p: LsuCachelessPlugin => p }.get
   private val privPlugin = parameter.plugins.collectFirst { case p: PrivilegedPlugin => p }.get
   private val jtagPlugin = parameter.plugins.collectFirst { case p: EmbeddedRiscvJtag => p }.get
@@ -87,32 +90,54 @@ class TileLinkVexiiRiscv(
     jtag <> jtagPlugin.logic.jtag
 
     // -----------------------------------------------------------------------
-    // Bridge CachelessBus → TileLink (read-only instruction fetch)
+    // Bridge instruction fetch → TileLink
     //
-    // CachelessBus.cmd: { valid, ready, id, address }
-    // CachelessBus.rsp: Flow { id, word, error }      (no backpressure)
-    //
-    // The transaction id is carried through a.source so the CPU can match
-    // out-of-order responses.  The fetch unit always requests exactly one
-    // word, so a.size is fixed at dataBytesLog2Up.
+    // Two variants are supported:
+    //   - Cacheless: single-word GET, Flow response (no backpressure)
+    //   - L1 cache:  cache-line GET (64 B), Stream response (multiple beats)
     // -----------------------------------------------------------------------
-    val iBusNative = fetchPlugin.logic.bus
-    iBus.a.valid := iBusNative.cmd.valid
-    iBus.a.opcode := Opcode.A.GET()
-    iBus.a.param := 0
-    iBus.a.size := parameter.iBusParam.dataBytesLog2Up
-    iBus.a.source := iBusNative.cmd.id.resized
-    iBus.a.address := iBusNative.cmd.address.resized
-    iBus.a.mask := B(parameter.iBusParam.dataBytes bits, default -> true)
-    iBus.a.data := 0
-    iBus.a.corrupt := False
-    iBusNative.cmd.ready := iBus.a.ready
+    (fetchCachelessPlugin, fetchL1Plugin) match {
+      case (Some(plugin), None) =>
+        val iBusNative = plugin.logic.bus
+        iBus.a.valid := iBusNative.cmd.valid
+        iBus.a.opcode := Opcode.A.GET()
+        iBus.a.param := 0
+        iBus.a.size := parameter.iBusParam.dataBytesLog2Up
+        iBus.a.source := iBusNative.cmd.id.resized
+        iBus.a.address := iBusNative.cmd.address.resized
+        iBus.a.mask := B(parameter.iBusParam.dataBytes bits, default -> true)
+        iBus.a.data := 0
+        iBus.a.corrupt := False
+        iBusNative.cmd.ready := iBus.a.ready
 
-    iBusNative.rsp.valid := iBus.d.valid
-    iBusNative.rsp.word := iBus.d.data
-    iBusNative.rsp.error := iBus.d.denied
-    iBusNative.rsp.id := iBus.d.source.resized
-    iBus.d.ready := True
+        iBusNative.rsp.valid := iBus.d.valid
+        iBusNative.rsp.word := iBus.d.data
+        iBusNative.rsp.error := iBus.d.denied
+        iBusNative.rsp.id := iBus.d.source.resized
+        iBus.d.ready := True
+
+      case (None, Some(plugin)) =>
+        val iBusNative = plugin.logic.bus
+        iBus.a.valid := iBusNative.cmd.valid
+        iBus.a.opcode := Opcode.A.GET()
+        iBus.a.param := 0
+        iBus.a.size := log2Up(iBusNative.p.lineSize)
+        iBus.a.source := iBusNative.cmd.id.resized
+        iBus.a.address := iBusNative.cmd.address.resized
+        iBus.a.mask := B(parameter.iBusParam.dataBytes bits, default -> true)
+        iBus.a.data := 0
+        iBus.a.corrupt := False
+        iBusNative.cmd.ready := iBus.a.ready
+
+        iBusNative.rsp.valid := iBus.d.valid
+        iBusNative.rsp.data := iBus.d.data
+        iBusNative.rsp.error := iBus.d.denied || iBus.d.corrupt
+        iBusNative.rsp.id := iBus.d.source.resized
+        iBus.d.ready := iBusNative.rsp.ready
+
+      case _ =>
+        SpinalError("VexiiRiscv must have exactly one of FetchCachelessPlugin or FetchL1Plugin")
+    }
 
     // -----------------------------------------------------------------------
     // Bridge LsuCachelessBus → TileLink (read/write data bus)

--- a/hardware/scala/nafarr/cores/cpu/vexiiriscv/VexiiRiscv.scala
+++ b/hardware/scala/nafarr/cores/cpu/vexiiriscv/VexiiRiscv.scala
@@ -17,16 +17,29 @@ case class VexiiRiscvCoreParameter(
 )
 
 object VexiiRiscvCoreParameter {
-  def realtime(resetAddress: BigInt): VexiiRiscvCoreParameter = {
+  def realtime(
+      resetAddress: BigInt,
+      iCacheSets: Int = 0,
+      withMul: Boolean = false,
+      withCompressed: Boolean = false
+  ): VexiiRiscvCoreParameter = {
     val param = new ParamSimple()
 
     param.xlen = 32
     param.resetVector = resetAddress.toLong
 
-    // RV32I: base integer only, no compressed instructions
+    // Optional ISA extensions (base is RV32I)
+    if (withMul) param.addISA("m")
+    if (withCompressed) param.addISA("c")
 
-    // No caches: deterministic memory access latency
-    param.fetchL1Enable = false
+    // Instruction cache: 1-way, disabled when iCacheSets = 0
+    param.fetchL1Enable = iCacheSets > 0
+    if (iCacheSets > 0) {
+      param.fetchL1Sets = iCacheSets
+      param.fetchL1Ways = 1
+    }
+
+    // No data cache: deterministic data access latency
     param.lsuL1Enable = false
 
     // No branch prediction: fully deterministic fetch
@@ -55,9 +68,11 @@ object VexiiRiscvCoreParameter {
     val plugins = param.plugins()
     ParamSimple.setPma(plugins)
 
-    // TileLink params: TL-UL (sizeBytes=4), sourceWidth=1 for pendingMax=2
-    val iBusTlParam = TileLinkParameter.simple(32, 32, 4, 1)
-    val dBusTlParam = TileLinkParameter.simple(32, 32, 4, 1)
+    // TileLink params: sizeBytes must match across iBus/dBus for the shared
+    // decoder in the platform. Cache line size (64 B) when enabled, else 4 B.
+    val sizeBytes = if (iCacheSets > 0) 64 else 4
+    val iBusTlParam = TileLinkParameter.simple(32, 32, sizeBytes, 1)
+    val dBusTlParam = TileLinkParameter.simple(32, 32, sizeBytes, 1)
 
     VexiiRiscvCoreParameter(plugins, iBusTlParam, dBusTlParam)
   }

--- a/test/scala/nafarr/system/reset/ResetControllerTest.scala
+++ b/test/scala/nafarr/system/reset/ResetControllerTest.scala
@@ -465,7 +465,7 @@ class ResetControllerTest extends AnyFunSuite {
     compiled.doSim("delay") { dut =>
       val (apb, regs) = init(dut)
 
-      for (_ <- 0 until 8 - 1 - 2) {
+      for (_ <- 0 until 8 - 1 - 1) {
         dut.clockDomain.waitFallingEdge()
         SimTest.checkPins(dut.io.resets.toBigInt, BigInt("0", 16), "Found non-active reset")
       }


### PR DESCRIPTION
Update SpinalHDL to 1.14.2 and add an optional instruction cache to the realtime VexiiRiscv CPU configuration.