### PR TITLE
Minor Fixes for VexiiRiscv

### DIFF
--- a/hardware/scala/nafarr/cores/cpu/vexiiriscv/TileLinkVexiiRiscv.scala
+++ b/hardware/scala/nafarr/cores/cpu/vexiiriscv/TileLinkVexiiRiscv.scala
@@ -62,8 +62,21 @@ class TileLinkVexiiRiscv(
   private val fetchCachelessPlugin = parameter.plugins.collectFirst {
     case p: FetchCachelessPlugin => p
   }
-  private val fetchL1Plugin = parameter.plugins.collectFirst { case p: FetchL1Plugin => p }
+  val fetchL1Plugin = parameter.plugins.collectFirst { case p: FetchL1Plugin => p }
   private val lsuPlugin = parameter.plugins.collectFirst { case p: LsuCachelessPlugin => p }.get
+
+  /** I-cache bank RAMs, available after generateVerilog (post-blackboxing).
+    * Searches the VexiiRiscv component tree for blackboxed Mem components
+    * matching the cache bank memories by name.
+    */
+  def iCacheRams: Seq[Component] = {
+    val memNames = fetchL1Plugin.map(_.logic.banks.map(_.mem.getName())).getOrElse(Nil).toSet
+    val result = scala.collection.mutable.ArrayBuffer[Component]()
+    fiber.vexii.walkComponents { c =>
+      if (memNames.contains(c.getName())) result += c
+    }
+    result.toSeq
+  }
   private val privPlugin = parameter.plugins.collectFirst { case p: PrivilegedPlugin => p }.get
   private val jtagPlugin = parameter.plugins.collectFirst { case p: EmbeddedRiscvJtag => p }.get
 
@@ -75,7 +88,7 @@ class TileLinkVexiiRiscv(
   // thread holds the SpinalHDL elaboration lock while plugin threads need it
   // to create signals.
   val fiber = Fiber setup new Area {
-    systemCd {
+    val vexii = systemCd {
       VexiiRiscv(parameter.plugins)
     }
     Fiber.awaitBuild()

--- a/hardware/scala/nafarr/cores/cpu/vexiiriscv/VexiiRiscv.scala
+++ b/hardware/scala/nafarr/cores/cpu/vexiiriscv/VexiiRiscv.scala
@@ -21,7 +21,8 @@ object VexiiRiscvCoreParameter {
       resetAddress: BigInt,
       iCacheSets: Int = 0,
       withMul: Boolean = false,
-      withCompressed: Boolean = false
+      withCompressed: Boolean = false,
+      withBarrelShifter: Boolean = false
   ): VexiiRiscvCoreParameter = {
     val param = new ParamSimple()
 
@@ -57,8 +58,9 @@ object VexiiRiscvCoreParameter {
     // Async register file: shallower pipeline, smaller area
     param.regFileSync = false
 
-    // Iterative shifter: saves area at cost of multi-cycle shifts
-    param.withIterativeShift = true
+    // Barrel shifter: single-cycle shifts, more area
+    // Iterative shifter: multi-cycle shifts, less area
+    param.withIterativeShift = !withBarrelShifter
 
     // Relaxed branch/shift: better timing closure, still fully deterministic
     param.relaxedBranch = true

--- a/hardware/scala/nafarr/cores/cpu/vexiiriscv/VexiiRiscv.scala
+++ b/hardware/scala/nafarr/cores/cpu/vexiiriscv/VexiiRiscv.scala
@@ -19,7 +19,7 @@ case class VexiiRiscvCoreParameter(
 object VexiiRiscvCoreParameter {
   def realtime(
       resetAddress: BigInt,
-      iCacheSets: Int = 0,
+      iCacheSize: BigInt = 0,
       withMul: Boolean = false,
       withCompressed: Boolean = false,
       withBarrelShifter: Boolean = false
@@ -33,10 +33,12 @@ object VexiiRiscvCoreParameter {
     if (withMul) param.addISA("m")
     if (withCompressed) param.addISA("c")
 
-    // Instruction cache: 1-way, disabled when iCacheSets = 0
-    param.fetchL1Enable = iCacheSets > 0
-    if (iCacheSets > 0) {
-      param.fetchL1Sets = iCacheSets
+    // Instruction cache: 1-way with 64 B lines, disabled when iCacheSize = 0
+    val lineSize = 64
+    param.fetchL1Enable = iCacheSize > 0
+    if (iCacheSize > 0) {
+      require(iCacheSize % lineSize == 0, s"iCacheSize must be a multiple of $lineSize")
+      param.fetchL1Sets = (iCacheSize / lineSize).toInt
       param.fetchL1Ways = 1
     }
 
@@ -72,7 +74,7 @@ object VexiiRiscvCoreParameter {
 
     // TileLink params: sizeBytes must match across iBus/dBus for the shared
     // decoder in the platform. Cache line size (64 B) when enabled, else 4 B.
-    val sizeBytes = if (iCacheSets > 0) 64 else 4
+    val sizeBytes = if (iCacheSize > 0) 64 else 4
     val iBusTlParam = TileLinkParameter.simple(32, 32, sizeBytes, 1)
     val dBusTlParam = TileLinkParameter.simple(32, 32, sizeBytes, 1)
 


### PR DESCRIPTION
Allow to access i-cache memory from top-level files and add a multi-cycle shift operation to reduce area.