### PR TITLE
hardware: nafarr: system: Update ClockController Register Map

### DIFF
--- a/hardware/scala/nafarr/system/clock/ClockController.scala
+++ b/hardware/scala/nafarr/system/clock/ClockController.scala
@@ -24,7 +24,8 @@ case class ClockParameter(
     reset: String = "",
     resetConfig: ClockDomainConfig =
       ClockDomainConfig(resetKind = spinal.core.SYNC, resetActiveLevel = LOW),
-    synchronousWith: String = ""
+    synchronousWith: String = "",
+    gateable: Boolean = true
 )
 
 object ClockController {
@@ -39,13 +40,30 @@ object ClockController {
     }
     val busCtrl = factory(io.bus)
 
-    val idCtrl = IpIdentification(IpIdentification.Ids.Clock, 1, 0, 0)
+    val idCtrl = IpIdentification(IpIdentification.Ids.Clock, 1, 1, 0)
     idCtrl.driveFrom(busCtrl)
     val regs = ClockControllerCtrl.Regs(idCtrl.length)
 
     busCtrl.read(B(p.domains.length, 8 bits), regs.domains)
 
-    busCtrl.driveAndRead(io.config.enable, regs.enable).init(U((0 until p.domains.length) -> true))
+    for ((domain, index) <- p.domains.zipWithIndex) {
+      val domainArea = new Area {
+        val (mult, div) = p.ratioOf(domain)
+
+        /* CTRL: enable at bit 31 (only writable bit), lock status at bit 30. */
+        if (domain.gateable) {
+          busCtrl.driveAndRead(io.config.enable(index), regs.control(index), 31).init(True)
+        } else {
+          io.config.enable(index) := True
+          busCtrl.read(True, regs.control(index), 31)
+        }
+        busCtrl.read(True, regs.control(index), 30)
+
+        /* RATIO: rate = reference * MULT / DIV. */
+        busCtrl.read(B(div, 16 bits), regs.ratio(index), 0)
+        busCtrl.read(B(mult, 16 bits), regs.ratio(index), 16)
+      }.setName(s"domain_${domain.name}")
+    }
 
     override def sysconFeatures = Some(List(Feature.Clock))
 

--- a/hardware/scala/nafarr/system/clock/ClockControllerCtrl.scala
+++ b/hardware/scala/nafarr/system/clock/ClockControllerCtrl.scala
@@ -21,10 +21,12 @@ object ClockControllerCtrl {
 
   class Regs(base: BigInt) {
     val domains = base + 0x00
-    val enable = base + 0x04
+    /* Per-domain block, stride 8: CTRL (enable + status) then RATIO (mult/div). */
+    def control(index: Int) = base + 0x08 + index * 0x08
+    def ratio(index: Int) = base + 0x0c + index * 0x08
   }
 
-  case class Parameter(domains: List[ClockParameter]) {
+  case class Parameter(domains: List[ClockParameter], inputClock: ClockParameter) {
     require(domains.length > 0, "At least one domain is required")
     val domainNames = domains.map(_.name).toSet
     for (domain <- domains if domain.synchronousWith.nonEmpty)
@@ -32,6 +34,23 @@ object ClockControllerCtrl {
         domainNames.contains(domain.synchronousWith),
         s"Clock '${domain.name}': synchronousWith '${domain.synchronousWith}' is not a known domain name."
       )
+
+    /** Reduced (multiplier, divider) of a domain relative to the input/reference
+      * clock, so software recovers the rate as `reference * mult / div`. For a
+      * pure divider design mult is always 1; PLL controllers report mult > 1.
+      */
+    def ratioOf(domain: ClockParameter): (Int, Int) = {
+      val refHz = BigInt(inputClock.frequency.toLong)
+      val domHz = BigInt(domain.frequency.toLong)
+      val g = refHz.gcd(domHz)
+      val mult = domHz / g
+      val div = refHz / g
+      require(
+        mult <= 0xffff && div <= 0xffff,
+        s"Clock '${domain.name}': ratio $mult/$div does not fit in 16-bit register fields"
+      )
+      (mult.toInt, div.toInt)
+    }
 
     def getDomainByName(name: String): (Int, ClockParameter) = {
       val domain = domains.find(_.name.equals(name)).get
@@ -85,6 +104,10 @@ object ClockControllerCtrl {
       inputClock: ClockParameter,
       clocks: List[String]
   ) extends ClockControllerBase(parameter) {
+    require(
+      inputClock.frequency.toLong == parameter.inputClock.frequency.toLong,
+      s"ClockDividerController input clock ${inputClock.frequency} must match parameter.inputClock ${parameter.inputClock.frequency}"
+    )
     val inputHz = inputClock.frequency.toDouble
 
     val clockCtrlClockDomain = ClockDomain(
@@ -146,6 +169,10 @@ object ClockControllerCtrl {
       clocks: List[String],
       clockVco: HertzNumber = 400 MHz
   ) extends ClockControllerBase(parameter) {
+    require(
+      inputClock.frequency.toLong == parameter.inputClock.frequency.toLong,
+      s"LatticeECP5PllController input clock ${inputClock.frequency} must match parameter.inputClock ${parameter.inputClock.frequency}"
+    )
     val clockFrequency = inputClock.frequency
     val clockPair = (clockFrequency.toDouble / 1e6, clockVco.toDouble / 1e6)
 
@@ -198,6 +225,10 @@ object ClockControllerCtrl {
       clocks: List[String],
       multiply: Int
   ) extends ClockControllerBase(parameter) {
+    require(
+      inputClock.frequency.toLong == parameter.inputClock.frequency.toLong,
+      s"XilinxPllController input clock ${inputClock.frequency} must match parameter.inputClock ${parameter.inputClock.frequency}"
+    )
     val clockFrequency = inputClock.frequency
 
     val clockCtrlClockDomain = ClockDomain(

--- a/software/driver/clock.c
+++ b/software/driver/clock.c
@@ -6,9 +6,11 @@
 
 #include "clock.h"
 
-void clock_init(struct clock_driver *driver, unsigned long base_address)
+void clock_init(struct clock_driver *driver, unsigned long base_address,
+		unsigned int reference_hz)
 {
 	driver->regs = (struct clock_regs *)base_address;
+	driver->reference_hz = reference_hz;
 }
 
 unsigned int clock_domain_count(struct clock_driver *driver)
@@ -16,12 +18,34 @@ unsigned int clock_domain_count(struct clock_driver *driver)
 	return driver->regs->domains & 0xFF;
 }
 
-unsigned int clock_enable_get(struct clock_driver *driver)
+unsigned int clock_get_rate(struct clock_driver *driver, unsigned int index)
 {
-	return driver->regs->enable;
+	unsigned int ratio = driver->regs->domain[index].ratio;
+	unsigned int mult = (ratio >> 16) & 0xFFFF;
+	unsigned int div = ratio & 0xFFFF;
+
+	if (div == 0)
+		return 0;
+
+	return (unsigned int)(((unsigned long long)driver->reference_hz * mult) / div);
 }
 
-void clock_enable_set(struct clock_driver *driver, unsigned int mask)
+int clock_is_enabled(struct clock_driver *driver, unsigned int index)
 {
-	driver->regs->enable = mask;
+	return (driver->regs->domain[index].control & CLOCK_CTRL_ENABLE) != 0;
+}
+
+int clock_is_locked(struct clock_driver *driver, unsigned int index)
+{
+	return (driver->regs->domain[index].control & CLOCK_CTRL_LOCK) != 0;
+}
+
+void clock_enable(struct clock_driver *driver, unsigned int index)
+{
+	driver->regs->domain[index].control = CLOCK_CTRL_ENABLE;
+}
+
+void clock_disable(struct clock_driver *driver, unsigned int index)
+{
+	driver->regs->domain[index].control = 0;
 }

--- a/software/include/clock.h
+++ b/software/include/clock.h
@@ -7,21 +7,41 @@
 #ifndef ELEMENTS_CLOCK_H
 #define ELEMENTS_CLOCK_H
 
+/* CTRL register bit fields (one CTRL register per clock domain). */
+#define CLOCK_CTRL_ENABLE	(1u << 31)  /* RW: 1 = domain clock running */
+#define CLOCK_CTRL_LOCK		(1u << 30)  /* RO: 1 = source locked/ready */
+
+struct clock_domain_regs {
+	unsigned int control;     /* +0x0 — bit31 enable (RW), bit30 lock (RO) */
+	unsigned int ratio;       /* +0x4 — bits31:16 mult, bits15:0 div (RO) */
+};
+
 struct clock_regs {
 	unsigned int ip_header;   /* 0x000 — IP identification header */
 	unsigned int ip_version;  /* 0x004 — IP identification version */
 	unsigned int domains;     /* 0x008 — number of clock domains (read-only) */
-	unsigned int enable;      /* 0x00C — enabled domain bitmask (1=enabled) */
+	unsigned int reserved;    /* 0x00C — reserved */
+	struct clock_domain_regs domain[]; /* 0x010 — per-domain block, stride 8 */
 };
 
 struct clock_driver {
 	volatile struct clock_regs *regs;
+	unsigned int reference_hz; /* reference clock, read from syscon */
 };
 
-void clock_init(struct clock_driver *driver, unsigned long base_address);
+void clock_init(struct clock_driver *driver, unsigned long base_address,
+		unsigned int reference_hz);
 
 unsigned int clock_domain_count(struct clock_driver *driver);
-unsigned int clock_enable_get(struct clock_driver *driver);
-void clock_enable_set(struct clock_driver *driver, unsigned int mask);
+
+/* Rate of a domain in Hz: reference_hz * mult / div. */
+unsigned int clock_get_rate(struct clock_driver *driver, unsigned int index);
+
+int clock_is_enabled(struct clock_driver *driver, unsigned int index);
+int clock_is_locked(struct clock_driver *driver, unsigned int index);
+
+/* Gating critical domains (e.g. system) is ignored by hardware. */
+void clock_enable(struct clock_driver *driver, unsigned int index);
+void clock_disable(struct clock_driver *driver, unsigned int index);
 
 #endif

--- a/test/scala/nafarr/system/clock/ClockControllerTest.scala
+++ b/test/scala/nafarr/system/clock/ClockControllerTest.scala
@@ -45,19 +45,21 @@ case class ClockDividerController(
 }
 
 class ClockControllerTest extends AnyFunSuite {
+  val inputClock = ClockParameter("input", 100 MHz)
+
   test("Apb3GpioParameters") {
     generationShouldPass(Apb3ClockController(ClockControllerCtrl.Parameter(List(
       ClockParameter("a", 100 MHz),
       ClockParameter("b", 50 MHz, synchronousWith="b"),
       ClockParameter("c", 25 MHz)
-    ))))
+    ), inputClock)))
     generationShouldFail(Apb3ClockController(ClockControllerCtrl.Parameter(List(
-    ))))
+    ), inputClock)))
     generationShouldFail(Apb3ClockController(ClockControllerCtrl.Parameter(List(
       ClockParameter("a", 100 MHz),
       ClockParameter("b", 50 MHz, synchronousWith="d"),
       ClockParameter("c", 25 MHz)
-    ))))
+    ), inputClock)))
   }
 
   test("TileLinkGpioParameters") {
@@ -65,14 +67,14 @@ class ClockControllerTest extends AnyFunSuite {
       ClockParameter("a", 100 MHz),
       ClockParameter("b", 50 MHz, synchronousWith="b"),
       ClockParameter("c", 25 MHz)
-    ))))
+    ), inputClock)))
     generationShouldFail(TileLinkClockController(ClockControllerCtrl.Parameter(List(
-    ))))
+    ), inputClock)))
     generationShouldFail(TileLinkClockController(ClockControllerCtrl.Parameter(List(
       ClockParameter("a", 100 MHz),
       ClockParameter("b", 50 MHz, synchronousWith="d"),
       ClockParameter("c", 25 MHz)
-    ))))
+    ), inputClock)))
   }
 
   test("WishboneGpioParameters") {
@@ -80,14 +82,14 @@ class ClockControllerTest extends AnyFunSuite {
       ClockParameter("a", 100 MHz),
       ClockParameter("b", 50 MHz, synchronousWith="b"),
       ClockParameter("c", 25 MHz)
-    ))))
+    ), inputClock)))
     generationShouldFail(WishboneClockController(ClockControllerCtrl.Parameter(List(
-    ))))
+    ), inputClock)))
     generationShouldFail(WishboneClockController(ClockControllerCtrl.Parameter(List(
       ClockParameter("a", 100 MHz),
       ClockParameter("b", 50 MHz, synchronousWith="d"),
       ClockParameter("c", 25 MHz)
-    ))))
+    ), inputClock)))
   }
 
   private def initBase(bus: Apb3, cd: ClockDomain, idCtrlLength: BigInt): (Apb3Driver, ClockControllerCtrl.Regs) = {
@@ -125,7 +127,7 @@ class ClockControllerTest extends AnyFunSuite {
             ClockParameter("b", 50 MHz),
             ClockParameter("c", 25 MHz),
             ClockParameter("d", 12.5 MHz)
-          )),
+          ), ClockParameter("input", 100 MHz)),
           ClockParameter("input", 100 MHz),
           List("a", "b", "c", "d")
         )
@@ -138,13 +140,22 @@ class ClockControllerTest extends AnyFunSuite {
 
       /* Check IP identification */
       IpIdentificationTest.V0.checkApi(apb, IpIdentification.Ids.Clock)
-      IpIdentificationTest.V0.checkVersion(apb, 1, 0, 0)
+      IpIdentificationTest.V0.checkVersion(apb, 1, 1, 0)
 
       /* Read domains */
       SimTest.readField(apb, regs.domains, 7, 0, 4,  "Reset domains")
 
-      /* All domains are enabled */
-      SimTest.readField(apb, regs.enable, 7, 0, BigInt("f", 16),  "Domains enabled")
+      /* Per-domain CTRL: enabled (bit 31) and locked (bit 30) out of reset. */
+      for (index <- 0 until 4) {
+        SimTest.readField(apb, regs.control(index), 31, 30, 3, s"Domain $index ctrl")
+      }
+
+      /* Per-domain RATIO: mult (31:16) = 1, div (15:0) = 100 MHz / domain. */
+      val expectedDiv = List(1, 2, 4, 8)
+      for ((div, index) <- expectedDiv.zipWithIndex) {
+        SimTest.readField(apb, regs.ratio(index), 31, 16, 1, s"Domain $index mult")
+        SimTest.readField(apb, regs.ratio(index), 15, 0, div, s"Domain $index div")
+      }
     }
 
     compiled.doSim("clock output") { dut =>
@@ -234,7 +245,9 @@ class ClockControllerTest extends AnyFunSuite {
         SimTest.checkPins(dut.io.outputs.toBigInt, BigInt("0000", 2), "Found running clock")
       }
 
-      apb.write(regs.enable, BigInt("0101", 2))
+      /* Disable domains b and d via their CTRL enable bit; a and c stay on. */
+      apb.write(regs.control(1), 0)
+      apb.write(regs.control(3), 0)
       dut.io.mainReset #= true
 
       for (_ <- 0 until 4) {
@@ -298,5 +311,47 @@ class ClockControllerTest extends AnyFunSuite {
       dut.clockDomain.waitFallingEdge(10)
     }
 
+  }
+
+  test("ClockDividerController - non-gateable") {
+    val compiled = SimConfig.withWave.addSimulatorFlag("--x-initial 0").compile {
+      val cd = ClockDomain.current.copy(frequency = FixedFrequency(100 MHz))
+      val area = new ClockingArea(cd) {
+        val dut = ClockDividerController(
+          ClockControllerCtrl.Parameter(List(
+            ClockParameter("a", 100 MHz, gateable = false),
+            ClockParameter("b", 50 MHz)
+          ), ClockParameter("input", 100 MHz)),
+          ClockParameter("input", 100 MHz),
+          List("a", "b")
+        )
+      }
+      area.dut
+    }
+
+    compiled.doSim("non-gateable ignores disable") { dut =>
+      val (apb, regs) = init(dut)
+
+      /* Attempt to gate the non-gateable domain a and gate the normal domain b. */
+      apb.write(regs.control(0), 0)
+      apb.write(regs.control(1), 0)
+
+      /* a stays enabled in hardware, b is disabled. */
+      SimTest.readField(apb, regs.control(0), 31, 31, 1, "Domain a stays enabled")
+      SimTest.readField(apb, regs.control(1), 31, 31, 0, "Domain b disabled")
+
+      dut.io.mainReset #= true
+
+      for (_ <- 0 until 4) {
+        dut.clockDomain.waitRisingEdge()
+        sleep(1)
+        SimTest.checkPins(dut.io.outputs.toBigInt, BigInt("01", 2), "Domain a keeps running")
+        dut.clockDomain.waitFallingEdge()
+        sleep(1)
+        SimTest.checkPins(dut.io.outputs.toBigInt, BigInt("00", 2), "Domain a keeps running")
+      }
+
+      dut.clockDomain.waitFallingEdge(10)
+    }
   }
 }

--- a/test/software/testcases/test_clock.c
+++ b/test/software/testcases/test_clock.c
@@ -6,17 +6,28 @@
 
 #include "clock.h"
 
+#define FAKE_DOMAINS 2
+
 int main(void)
 {
 	struct clock_driver driver;
-	static volatile struct clock_regs fake_regs;
+	/*
+	 * clock_regs ends in a flexible per-domain array, so back it with
+	 * storage for the header plus a couple of domains.
+	 */
+	static volatile unsigned int fake_regs[(sizeof(struct clock_regs) +
+		FAKE_DOMAINS * sizeof(struct clock_domain_regs)) /
+		sizeof(unsigned int)];
 
-	clock_init(&driver, 0xf0000000);
-	driver.regs = &fake_regs;
+	clock_init(&driver, 0xf0000000, 50000000);
+	driver.regs = (volatile struct clock_regs *)fake_regs;
 
 	clock_domain_count(&driver);
-	clock_enable_get(&driver);
-	clock_enable_set(&driver, 0x3);
+	clock_get_rate(&driver, 0);
+	clock_is_enabled(&driver, 0);
+	clock_is_locked(&driver, 0);
+	clock_enable(&driver, 0);
+	clock_disable(&driver, 0);
 
 	return 0;
 }


### PR DESCRIPTION
Add the clock multiply and divider value to calculate the domain clock at runtime. Use the reference clock from the syscon IP and calculate the frequency.

freq = (ref * multiply) / divider