### PR TITLE
hardware: nafarr: system: clock: Change gateable default

### DIFF
--- a/hardware/scala/nafarr/system/clock/ClockController.scala
+++ b/hardware/scala/nafarr/system/clock/ClockController.scala
@@ -25,7 +25,10 @@ case class ClockParameter(
     resetConfig: ClockDomainConfig =
       ClockDomainConfig(resetKind = spinal.core.SYNC, resetActiveLevel = LOW),
     synchronousWith: String = "",
-    gateable: Boolean = true
+    // Opt-in: when true, software can stop this domain via the clock controller.
+    // Left false for critical domains (e.g. system, debug) so the CPU/debug
+    // clock cannot be gated and brick the chip.
+    gateable: Boolean = false
 )
 
 object ClockController {

--- a/test/scala/nafarr/system/clock/ClockControllerTest.scala
+++ b/test/scala/nafarr/system/clock/ClockControllerTest.scala
@@ -123,10 +123,10 @@ class ClockControllerTest extends AnyFunSuite {
       val area = new ClockingArea(cd) {
         val dut = ClockDividerController(
           ClockControllerCtrl.Parameter(List(
-            ClockParameter("a", 100 MHz),
-            ClockParameter("b", 50 MHz),
-            ClockParameter("c", 25 MHz),
-            ClockParameter("d", 12.5 MHz)
+            ClockParameter("a", 100 MHz, gateable = true),
+            ClockParameter("b", 50 MHz, gateable = true),
+            ClockParameter("c", 25 MHz, gateable = true),
+            ClockParameter("d", 12.5 MHz, gateable = true)
           ), ClockParameter("input", 100 MHz)),
           ClockParameter("input", 100 MHz),
           List("a", "b", "c", "d")
@@ -320,7 +320,7 @@ class ClockControllerTest extends AnyFunSuite {
         val dut = ClockDividerController(
           ClockControllerCtrl.Parameter(List(
             ClockParameter("a", 100 MHz, gateable = false),
-            ClockParameter("b", 50 MHz)
+            ClockParameter("b", 50 MHz, gateable = true)
           ), ClockParameter("input", 100 MHz)),
           ClockParameter("input", 100 MHz),
           List("a", "b")


### PR DESCRIPTION
Set gateable to false by default. Make it safe to not accidently add a gate to clock domains. Especially since some domains, like CPU, shouldn't be gateable by default. Let the user enable this feature in the top-level configuration.