### PR TITLE
hardware: Nafarr: Add Renode emulation objects

### DIFF
--- a/hardware/scala/nafarr/crypto/prng/PrngCtrl.cs
+++ b/hardware/scala/nafarr/crypto/prng/PrngCtrl.cs
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// Renode model of the Nafarr PRNG (nafarr.crypto.prng.PrngCtrl), mirroring PrngCtrl.scala.
+// Register-accurate: the output is a software xorshift32 (seeded via the seed register) so
+// reads return a varying stream — it does NOT reproduce the RTL LFSR sequence (use co-sim for
+// that). The error path feeds the ESM in hardware; here it is just register state.
+//
+// Register map (offsets from base; Regs base = IpIdentification.length = 8):
+//   0x00 header       (RO)  IpIdentification
+//   0x04 version      (RO)
+//   0x08 control      (RW)  bit0 = enable
+//   0x0C errorPending (R/W1C)
+//   0x10 errorMask    (RW)
+//   0x14 seed         (WO)  reseeds the generator
+//   0x18 output       (RO)  next pseudo-random word
+//
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Bus;
+
+namespace Antmicro.Renode.Peripherals.Miscellaneous
+{
+    public class PrngCtrl : IDoubleWordPeripheral, IKnownSize
+    {
+        public PrngCtrl(IMachine machine)
+        {
+            Reset();
+        }
+
+        public void Reset()
+        {
+            enable = false;
+            errorPending = 0;
+            errorMask = 0;
+            state = 0x1234567u; // non-zero default so output is not stuck at 0
+        }
+
+        public uint ReadDoubleWord(long offset)
+        {
+            switch(offset)
+            {
+                case HeaderOffset:       return (uint)(((Api & 0xFF) << 24) | ((Length & 0xFF) << 16) | (Id & 0xFFFF));
+                case VersionOffset:      return 0x01000000; // 1.0.0
+                case ControlOffset:      return enable ? 1u : 0u;
+                case ErrorPendingOffset: return (uint)errorPending;
+                case ErrorMaskOffset:    return (uint)errorMask;
+                case OutputOffset:       return enable ? NextRandom() : 0u;
+                default:
+                    this.Log(LogLevel.Warning, "Unhandled read at offset 0x{0:X}", offset);
+                    return 0;
+            }
+        }
+
+        public void WriteDoubleWord(long offset, uint value)
+        {
+            switch(offset)
+            {
+                case ControlOffset:      enable = (value & 0x1) != 0; return;
+                case ErrorPendingOffset: errorPending &= ~(int)value; return; // write-1-to-clear
+                case ErrorMaskOffset:    errorMask = (int)value; return;
+                case SeedOffset:         state = value == 0 ? 0x1234567u : value; return;
+                case HeaderOffset:
+                case VersionOffset:
+                case OutputOffset:
+                    this.Log(LogLevel.Warning, "Write to read-only register at offset 0x{0:X}", offset);
+                    return;
+                default:
+                    this.Log(LogLevel.Warning, "Unhandled write at offset 0x{0:X}", offset);
+                    return;
+            }
+        }
+
+        public long Size => 0x1000;
+
+        private uint NextRandom()
+        {
+            // xorshift32
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            return state;
+        }
+
+        private bool enable;
+        private int errorPending;
+        private int errorMask;
+        private uint state;
+
+        // IpIdentification header constants (PrngCtrl.scala: id = Prng = 16, length = 8).
+        private const int Api = 0;
+        private const int Length = 8;
+        private const int Id = 16;
+
+        private const long HeaderOffset = 0x00;
+        private const long VersionOffset = 0x04;
+        private const long ControlOffset = 0x08;
+        private const long ErrorPendingOffset = 0x0C;
+        private const long ErrorMaskOffset = 0x10;
+        private const long SeedOffset = 0x14;
+        private const long OutputOffset = 0x18;
+    }
+}

--- a/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
+++ b/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// Renode model of the Nafarr SPI XIP controller's config bus (nafarr.memory.spi.SpiXipControllerCtrl
+// Mapper). Register-accurate config interface only — it does NOT perform SPI/XIP flash transactions
+// (the XIP data path is modeled by a plain flash memory in the platform). The bootrom programs this
+// to configure the flash mode/dummy-cycles; here those writes are stored and read back.
+//
+// Register map (offsets from base; regOffset = IpIdentification.length = 8):
+//   0x00 header    (RO)  IpIdentification
+//   0x04 version   (RO)
+//   0x08 configure (WO)  write triggers a (re)configuration; reads as 0
+//   0x0C config    (RW)  mode[7:0] | dummyCycles[15:8] | evcr[23:16]
+//
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Bus;
+
+namespace Antmicro.Renode.Peripherals.Miscellaneous
+{
+    public class SpiXipControllerCtrl : IDoubleWordPeripheral, IKnownSize
+    {
+        public SpiXipControllerCtrl(IMachine machine)
+        {
+            Reset();
+        }
+
+        public void Reset()
+        {
+            mode = 0;
+            dummyCycles = 0;
+            evcr = 0;
+        }
+
+        public uint ReadDoubleWord(long offset)
+        {
+            switch(offset)
+            {
+                case HeaderOffset:    return (uint)(((Api & 0xFF) << 24) | ((Length & 0xFF) << 16) | (Id & 0xFFFF));
+                case VersionOffset:   return 0x01000000; // 1.0.0
+                case ConfigureOffset: return 0;          // write-only trigger
+                case ConfigOffset:    return (uint)(((evcr & 0xFF) << 16) | ((dummyCycles & 0xFF) << 8) | (mode & 0xFF));
+                default:
+                    this.Log(LogLevel.Warning, "Unhandled read at offset 0x{0:X}", offset);
+                    return 0;
+            }
+        }
+
+        public void WriteDoubleWord(long offset, uint value)
+        {
+            switch(offset)
+            {
+                case ConfigureOffset:
+                    this.Log(LogLevel.Debug, "SPI XIP (re)configuration triggered");
+                    return;
+                case ConfigOffset:
+                    mode = (int)(value & 0xFF);
+                    dummyCycles = (int)((value >> 8) & 0xFF);
+                    evcr = (int)((value >> 16) & 0xFF);
+                    return;
+                case HeaderOffset:
+                case VersionOffset:
+                    this.Log(LogLevel.Warning, "Write to read-only register at offset 0x{0:X}", offset);
+                    return;
+                default:
+                    this.Log(LogLevel.Warning, "Unhandled write at offset 0x{0:X}", offset);
+                    return;
+            }
+        }
+
+        public long Size => 0x1000;
+
+        private int mode;
+        private int dummyCycles;
+        private int evcr;
+
+        // IpIdentification header constants (SpiXipControllerCtrl.scala: id = SpiXipController = 7, length = 8).
+        private const int Api = 0;
+        private const int Length = 8;
+        private const int Id = 7;
+
+        private const long HeaderOffset = 0x00;
+        private const long VersionOffset = 0x04;
+        private const long ConfigureOffset = 0x08;
+        private const long ConfigOffset = 0x0C;
+    }
+}

--- a/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
+++ b/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// Renode functional model of the Nafarr UART controller (nafarr.peripherals.com.uart.UartCtrl).
+//
+// Register map (offsets from base), mirroring UartCtrl.scala (Regs base = IpIdentification.length = 8):
+//   0x00  header          (RO)  api[31:24] | length[23:16] | id[15:0]
+//   0x04  version         (RO)  major[31:24] | minor[23:16] | patch[15:0]
+//   0x08  dataWidth       (RO)  0 | dataWidthMin[23:16] | dataWidthMax[15:8] | clockDividerWidth[7:0]
+//   0x0C  samplingSize    (RO)  0 | preSampling[23:16] | sampling[15:8] | postSampling[7:0]
+//   0x10  fifoDepth       (RO)  0[31:16] | txFifoDepth[15:8] | rxFifoDepth[7:0]
+//   0x14  permissions     (RO)  canWriteFrameConfig[1] | canWriteClockDivider[0]
+//   0x18  readWrite       (RW)  write: push TX byte; read: rxValid[16] | payload[8:0]
+//   0x1C  fifoStatus      (RO)  rxOccupancy[31:24] | txVacancy[23:16]
+//   0x20  clockDivider    (RW)
+//   0x24  frameConfig     (RW)  stop[17:16] | parity[9:8] | dataLength[?:0]
+//   0x28  transmitTrigger (RW)
+//   0x2C  interruptPending(R: pending / W: write-1-to-clear),  0x30 interruptEnable (RW)
+//   0x34  errorPending    (R/W1C),                              0x38 errorEnable (RW)
+//
+// Behavioral notes:
+//   * TX is instantaneous: a write to readWrite emits the character to the analyzer/console
+//     and the TX FIFO is always reported empty (full vacancy).
+//   * RX bytes injected by the host (WriteChar / analyzer input) queue up and are returned
+//     through readWrite with the valid bit set.
+//   * interruptPending bit1 = RX data available, bit2 = TX idle (ready for next byte).
+//
+//
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Bus;
+using Antmicro.Renode.Peripherals.UART;
+
+namespace Antmicro.Renode.Peripherals.UART
+{
+    public class UartCtrl : UARTBase, IDoubleWordPeripheral, IKnownSize
+    {
+        public UartCtrl(IMachine machine,
+                          int txFifoDepth = 64, int rxFifoDepth = 64,
+                          int dataWidthMin = 5, int dataWidthMax = 9,
+                          int clockDividerWidth = 20,
+                          int preSamplingSize = 1, int samplingSize = 5, int postSamplingSize = 2,
+                          bool canWriteClockDivider = true, bool canWriteFrameConfig = true,
+                          int versionMajor = 1, int versionMinor = 1, int versionPatch = 0)
+            : base(machine)
+        {
+            this.txFifoDepth = txFifoDepth;
+            this.rxFifoDepth = rxFifoDepth;
+            this.dataWidthMin = dataWidthMin;
+            this.dataWidthMax = dataWidthMax;
+            this.clockDividerWidth = clockDividerWidth;
+            this.preSamplingSize = preSamplingSize;
+            this.samplingSize = samplingSize;
+            this.postSamplingSize = postSamplingSize;
+            this.canWriteClockDivider = canWriteClockDivider;
+            this.canWriteFrameConfig = canWriteFrameConfig;
+            this.version = ((versionMajor & 0xFF) << 24) | ((versionMinor & 0xFF) << 16) | (versionPatch & 0xFFFF);
+
+            IRQ = new GPIO();
+            Reset();
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            clockDivider = 0;
+            frameConfig = 0;
+            transmitTrigger = 0;
+            interruptEnable = 0;
+            interruptPending = 0;
+            errorEnable = 0;
+            errorPending = 0;
+            UpdateInterrupt();
+        }
+
+        public uint ReadDoubleWord(long offset)
+        {
+            switch(offset)
+            {
+                case HeaderOffset:
+                    return (uint)(((Api & 0xFF) << 24) | ((Length & 0xFF) << 16) | (Id & 0xFFFF));
+                case VersionOffset:
+                    return (uint)version;
+                case DataWidthOffset:
+                    return (uint)(((dataWidthMin & 0xFF) << 16) | ((dataWidthMax & 0xFF) << 8) | (clockDividerWidth & 0xFF));
+                case SamplingSizeOffset:
+                    return (uint)(((preSamplingSize & 0xFF) << 16) | ((samplingSize & 0xFF) << 8) | (postSamplingSize & 0xFF));
+                case FifoDepthOffset:
+                    return (uint)(((txFifoDepth & 0xFF) << 8) | (rxFifoDepth & 0xFF));
+                case PermissionsOffset:
+                    return (uint)((canWriteFrameConfig ? 0x2 : 0x0) | (canWriteClockDivider ? 0x1 : 0x0));
+                case ReadWriteOffset:
+                    if(TryGetCharacter(out var character))
+                    {
+                        UpdateInterrupt();
+                        return (1u << 16) | character;
+                    }
+                    return 0;
+                case FifoStatusOffset:
+                    // TX always empty -> full vacancy; RX occupancy = queued bytes.
+                    return (uint)(((Count & 0xFF) << 24) | ((txFifoDepth & 0xFF) << 16));
+                case ClockDividerOffset:
+                    return (uint)clockDivider;
+                case FrameConfigOffset:
+                    return (uint)frameConfig;
+                case TransmitTriggerOffset:
+                    return (uint)transmitTrigger;
+                case InterruptPendingOffset:
+                    return (uint)EffectivePending();
+                case InterruptEnableOffset:
+                    return (uint)interruptEnable;
+                case ErrorPendingOffset:
+                    return (uint)errorPending;
+                case ErrorEnableOffset:
+                    return (uint)errorEnable;
+                default:
+                    this.Log(LogLevel.Warning, "Unhandled read at offset 0x{0:X}", offset);
+                    return 0;
+            }
+        }
+
+        public void WriteDoubleWord(long offset, uint value)
+        {
+            switch(offset)
+            {
+                case ReadWriteOffset:
+                    TransmitCharacter((byte)(value & 0xFF));
+                    // TX is instantaneous, so it immediately goes idle: latch the txIdle
+                    // rising-edge interrupt once (cleared by write-1-to-clear), not a level.
+                    interruptPending |= (1 << 2);
+                    UpdateInterrupt();
+                    return;
+                case ClockDividerOffset:
+                    if(canWriteClockDivider) clockDivider = (int)value;
+                    return;
+                case FrameConfigOffset:
+                    if(canWriteFrameConfig) frameConfig = (int)value;
+                    return;
+                case TransmitTriggerOffset:
+                    transmitTrigger = (int)value;
+                    return;
+                case InterruptPendingOffset:
+                    interruptPending &= ~(int)value; // write-1-to-clear
+                    UpdateInterrupt();
+                    return;
+                case InterruptEnableOffset:
+                    interruptEnable = (int)value;
+                    UpdateInterrupt();
+                    return;
+                case ErrorPendingOffset:
+                    errorPending &= ~(int)value;
+                    UpdateInterrupt();
+                    return;
+                case ErrorEnableOffset:
+                    errorEnable = (int)value;
+                    UpdateInterrupt();
+                    return;
+                case HeaderOffset:
+                case VersionOffset:
+                case DataWidthOffset:
+                case SamplingSizeOffset:
+                case FifoDepthOffset:
+                case PermissionsOffset:
+                case FifoStatusOffset:
+                    this.Log(LogLevel.Warning, "Write to read-only register at offset 0x{0:X}", offset);
+                    return;
+                default:
+                    this.Log(LogLevel.Warning, "Unhandled write at offset 0x{0:X}", offset);
+                    return;
+            }
+        }
+
+        public long Size => 0x100;
+        public GPIO IRQ { get; }
+
+        public override Bits StopBits => Bits.One;
+        public override Parity ParityBit => Parity.None;
+        public override uint BaudRate => 115200;
+
+        // Called by UARTBase when a host character is queued for RX.
+        protected override void CharWritten()
+        {
+            UpdateInterrupt();
+        }
+
+        protected override void QueueEmptied()
+        {
+            UpdateInterrupt();
+        }
+
+        // Latched edge interrupts (TX-idle bit2, trigger bit0) plus the RX-available level (bit1).
+        private int EffectivePending()
+        {
+            var pending = interruptPending;
+            if(Count > 0) pending |= (1 << 1); // RX available is a level condition
+            return pending;
+        }
+
+        private void UpdateInterrupt()
+        {
+            // The interrupt line is the enabled subset of the pending bits; pending bits are not
+            // re-masked here, matching the InterruptCtrl behaviour (mask gates the line, W1C clears).
+            var line = (EffectivePending() & interruptEnable) != 0;
+            IRQ.Set(line || ((errorPending & errorEnable) != 0));
+        }
+
+        private int clockDivider;
+        private int frameConfig;
+        private int transmitTrigger;
+        private int interruptEnable;
+        private int interruptPending;
+        private int errorEnable;
+        private int errorPending;
+
+        private readonly int txFifoDepth;
+        private readonly int rxFifoDepth;
+        private readonly int dataWidthMin;
+        private readonly int dataWidthMax;
+        private readonly int clockDividerWidth;
+        private readonly int preSamplingSize;
+        private readonly int samplingSize;
+        private readonly int postSamplingSize;
+        private readonly bool canWriteClockDivider;
+        private readonly bool canWriteFrameConfig;
+        private readonly int version;
+
+        // IpIdentification header constants (UartCtrl.scala: id = Uart = 3, length = 8).
+        private const int Api = 0;
+        private const int Length = 8;
+        private const int Id = 3;
+
+        private const long HeaderOffset = 0x00;
+        private const long VersionOffset = 0x04;
+        private const long DataWidthOffset = 0x08;
+        private const long SamplingSizeOffset = 0x0C;
+        private const long FifoDepthOffset = 0x10;
+        private const long PermissionsOffset = 0x14;
+        private const long ReadWriteOffset = 0x18;
+        private const long FifoStatusOffset = 0x1C;
+        private const long ClockDividerOffset = 0x20;
+        private const long FrameConfigOffset = 0x24;
+        private const long TransmitTriggerOffset = 0x28;
+        private const long InterruptPendingOffset = 0x2C;
+        private const long InterruptEnableOffset = 0x30;
+        private const long ErrorPendingOffset = 0x34;
+        private const long ErrorEnableOffset = 0x38;
+    }
+}

--- a/hardware/scala/nafarr/peripherals/io/gpio/GpioCtrl.cs
+++ b/hardware/scala/nafarr/peripherals/io/gpio/GpioCtrl.cs
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// Renode functional model of the Nafarr GPIO controller (nafarr.peripherals.io.gpio.GpioCtrl).
+//
+// Register map (offsets from base), mirroring GpioCtrl.scala + IpIdentification.scala:
+//   0x00  header   (RO)  api[31:24] | length[23:16] | id[15:0]
+//   0x04  version  (RO)  major[31:24] | minor[23:16] | patch[15:0]
+//   0x08  info     (RO)  banks[31:16] | width[15:0]
+//   then, per bank b, at (0x0C + b*0x2C):
+//     +0x00 input        (RO)  pin read value
+//     +0x04 output       (RW)  driven value
+//     +0x08 direction    (RW)  1 = output, 0 = input
+//     +0x0C highPending  (R: pending / W: write-1-to-clear)
+//     +0x10 highEnable   (RW)
+//     +0x14 lowPending   / +0x18 lowEnable
+//     +0x1C risePending  / +0x20 riseEnable
+//     +0x24 fallPending  / +0x28 fallEnable
+//
+// Behavioral notes:
+//   * Pins configured as output loop back into the input register (read returns the
+//     driven value), which is convenient for bare-metal self-tests.
+//   * Input pins read external stimulus delivered via OnGPIO(...).
+//   * Output pins drive Connections[pin] so you can wire e.g. `gpio0 -> led@0` in the .repl.
+//
+//
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Bus;
+
+namespace Antmicro.Renode.Peripherals.GPIOPort
+{
+    public class GpioCtrl : BaseGPIOPort, IDoubleWordPeripheral, IKnownSize
+    {
+        public GpioCtrl(IMachine machine, int numberOfPins = 12, int id = 0,
+                          int versionMajor = 1, int versionMinor = 0, int versionPatch = 0)
+            : base(machine, numberOfPins)
+        {
+            this.numberOfPins = numberOfPins;
+            this.banks = (numberOfPins + 31) / 32;
+            this.id = id;
+            this.version = ((versionMajor & 0xFF) << 24) | ((versionMinor & 0xFF) << 16) | (versionPatch & 0xFFFF);
+
+            IRQ = new GPIO();
+
+            outputValue = new bool[numberOfPins];
+            direction = new bool[numberOfPins];
+            externalInput = new bool[numberOfPins];
+            lastSampled = new bool[numberOfPins];
+            driven = new bool[numberOfPins];
+
+            highEnable = new bool[numberOfPins];
+            lowEnable = new bool[numberOfPins];
+            riseEnable = new bool[numberOfPins];
+            fallEnable = new bool[numberOfPins];
+            highPending = new bool[numberOfPins];
+            lowPending = new bool[numberOfPins];
+            risePending = new bool[numberOfPins];
+            fallPending = new bool[numberOfPins];
+
+            Reset();
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            for(var i = 0; i < numberOfPins; i++)
+            {
+                outputValue[i] = false;
+                direction[i] = false;
+                externalInput[i] = false;
+                lastSampled[i] = false;
+                driven[i] = false;
+                highEnable[i] = lowEnable[i] = riseEnable[i] = fallEnable[i] = false;
+                highPending[i] = lowPending[i] = risePending[i] = fallPending[i] = false;
+            }
+            UpdatePins();
+        }
+
+        public uint ReadDoubleWord(long offset)
+        {
+            switch(offset)
+            {
+                case HeaderOffset:
+                    return (uint)(((Api & 0xFF) << 24) | ((Length & 0xFF) << 16) | (id & 0xFFFF));
+                case VersionOffset:
+                    return (uint)version;
+                case InfoOffset:
+                    return (uint)(((banks & 0xFFFF) << 16) | (numberOfPins & 0xFFFF));
+            }
+
+            if(!TryResolveBankRegister(offset, out var bank, out var reg))
+            {
+                this.Log(LogLevel.Warning, "Unhandled read at offset 0x{0:X}", offset);
+                return 0;
+            }
+
+            switch(reg)
+            {
+                case BankInput:       return Pack(bank, PinReadValue);
+                case BankOutput:      return Pack(bank, i => outputValue[i]);
+                case BankDirection:   return Pack(bank, i => direction[i]);
+                case BankHighPending: return Pack(bank, i => highPending[i]);
+                case BankHighEnable:  return Pack(bank, i => highEnable[i]);
+                case BankLowPending:  return Pack(bank, i => lowPending[i]);
+                case BankLowEnable:   return Pack(bank, i => lowEnable[i]);
+                case BankRisePending: return Pack(bank, i => risePending[i]);
+                case BankRiseEnable:  return Pack(bank, i => riseEnable[i]);
+                case BankFallPending: return Pack(bank, i => fallPending[i]);
+                case BankFallEnable:  return Pack(bank, i => fallEnable[i]);
+                default:
+                    this.Log(LogLevel.Warning, "Unhandled read at offset 0x{0:X}", offset);
+                    return 0;
+            }
+        }
+
+        public void WriteDoubleWord(long offset, uint value)
+        {
+            if(offset == HeaderOffset || offset == VersionOffset || offset == InfoOffset)
+            {
+                this.Log(LogLevel.Warning, "Write to read-only register at offset 0x{0:X}", offset);
+                return;
+            }
+
+            if(!TryResolveBankRegister(offset, out var bank, out var reg))
+            {
+                this.Log(LogLevel.Warning, "Unhandled write at offset 0x{0:X}", offset);
+                return;
+            }
+
+            switch(reg)
+            {
+                case BankOutput:      Unpack(bank, value, (i, b) => outputValue[i] = b); break;
+                case BankDirection:   Unpack(bank, value, (i, b) => direction[i] = b); break;
+                case BankHighEnable:  Unpack(bank, value, (i, b) => highEnable[i] = b); break;
+                case BankLowEnable:   Unpack(bank, value, (i, b) => lowEnable[i] = b); break;
+                case BankRiseEnable:  Unpack(bank, value, (i, b) => riseEnable[i] = b); break;
+                case BankFallEnable:  Unpack(bank, value, (i, b) => fallEnable[i] = b); break;
+                // pending registers are write-1-to-clear
+                case BankHighPending: Unpack(bank, value, (i, b) => { if(b) highPending[i] = false; }); break;
+                case BankLowPending:  Unpack(bank, value, (i, b) => { if(b) lowPending[i] = false; }); break;
+                case BankRisePending: Unpack(bank, value, (i, b) => { if(b) risePending[i] = false; }); break;
+                case BankFallPending: Unpack(bank, value, (i, b) => { if(b) fallPending[i] = false; }); break;
+                case BankInput:
+                    this.Log(LogLevel.Warning, "Write to read-only input register at offset 0x{0:X}", offset);
+                    return;
+                default:
+                    this.Log(LogLevel.Warning, "Unhandled write at offset 0x{0:X}", offset);
+                    return;
+            }
+
+            UpdatePins();
+        }
+
+        // External stimulus: drive an input pin from the .repl/monitor or another peripheral.
+        public override void OnGPIO(int number, bool value)
+        {
+            if(number < 0 || number >= numberOfPins)
+            {
+                this.Log(LogLevel.Warning, "Ignoring GPIO stimulus on out-of-range pin {0}", number);
+                return;
+            }
+            externalInput[number] = value;
+            UpdatePins();
+        }
+
+        public long Size => 0x100;
+        public GPIO IRQ { get; }
+
+        private bool PinValue(int pin) => direction[pin] ? outputValue[pin] : externalInput[pin];
+        private bool PinReadValue(int pin) => PinValue(pin); // outputs loop back into input register
+
+        private void UpdatePins()
+        {
+            for(var i = 0; i < numberOfPins; i++)
+            {
+                var current = PinValue(i);
+                var previous = lastSampled[i];
+
+                // Latch pending bits while their (enabled) condition holds.
+                if(highEnable[i] && current) highPending[i] = true;
+                if(lowEnable[i] && !current) lowPending[i] = true;
+                if(riseEnable[i] && current && !previous) risePending[i] = true;
+                if(fallEnable[i] && !current && previous) fallPending[i] = true;
+
+                lastSampled[i] = current;
+
+                // Drive output connections; inputs are released (low). Log driven-value changes
+                // so the GPIO output is observable in the monitor/log (GUI LED analyzer optional).
+                var driving = direction[i] && outputValue[i];
+                if(driving != driven[i])
+                {
+                    driven[i] = driving;
+                    this.Log(LogLevel.Info, "GPIO output pin {0} = {1}", i, driving ? 1 : 0);
+                }
+                Connections[i].Set(driving);
+            }
+
+            var anyPending = highPending.Any(b => b) || lowPending.Any(b => b)
+                          || risePending.Any(b => b) || fallPending.Any(b => b);
+            IRQ.Set(anyPending);
+        }
+
+        private bool TryResolveBankRegister(long offset, out int bank, out long reg)
+        {
+            bank = 0;
+            reg = 0;
+            if(offset < FirstBankOffset)
+            {
+                return false;
+            }
+            var rel = offset - FirstBankOffset;
+            bank = (int)(rel / BankStride);
+            reg = rel % BankStride;
+            return bank < banks && (reg % 4 == 0) && reg <= BankFallEnable;
+        }
+
+        private uint Pack(int bank, System.Func<int, bool> selector)
+        {
+            uint result = 0;
+            var pinsInBank = PinsInBank(bank);
+            for(var i = 0; i < pinsInBank; i++)
+            {
+                if(selector(bank * 32 + i))
+                {
+                    result |= 1u << i;
+                }
+            }
+            return result;
+        }
+
+        private void Unpack(int bank, uint value, System.Action<int, bool> apply)
+        {
+            var pinsInBank = PinsInBank(bank);
+            for(var i = 0; i < pinsInBank; i++)
+            {
+                apply(bank * 32 + i, (value & (1u << i)) != 0);
+            }
+        }
+
+        private int PinsInBank(int bank)
+        {
+            var remaining = numberOfPins - bank * 32;
+            return remaining >= 32 ? 32 : remaining;
+        }
+
+        private readonly int numberOfPins;
+        private readonly int banks;
+        private readonly int id;
+        private readonly int version;
+
+        private readonly bool[] outputValue;
+        private readonly bool[] direction;
+        private readonly bool[] externalInput;
+        private readonly bool[] lastSampled;
+        private readonly bool[] driven;
+
+        private readonly bool[] highEnable;
+        private readonly bool[] lowEnable;
+        private readonly bool[] riseEnable;
+        private readonly bool[] fallEnable;
+        private readonly bool[] highPending;
+        private readonly bool[] lowPending;
+        private readonly bool[] risePending;
+        private readonly bool[] fallPending;
+
+        // IpIdentification header constants (IpIdentification.scala: length = 8, api = 0).
+        private const int Api = 0;
+        private const int Length = 8;
+
+        private const long HeaderOffset = 0x00;
+        private const long VersionOffset = 0x04;
+        private const long InfoOffset = 0x08;
+        private const long FirstBankOffset = 0x0C;
+        private const long BankStride = 0x2C;
+
+        private const long BankInput = 0x00;
+        private const long BankOutput = 0x04;
+        private const long BankDirection = 0x08;
+        private const long BankHighPending = 0x0C;
+        private const long BankHighEnable = 0x10;
+        private const long BankLowPending = 0x14;
+        private const long BankLowEnable = 0x18;
+        private const long BankRisePending = 0x1C;
+        private const long BankRiseEnable = 0x20;
+        private const long BankFallPending = 0x24;
+        private const long BankFallEnable = 0x28;
+    }
+}

--- a/hardware/scala/nafarr/peripherals/pinmux/PinmuxCtrl.cs
+++ b/hardware/scala/nafarr/peripherals/pinmux/PinmuxCtrl.cs
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// Renode model of the Nafarr pinmux (nafarr.peripherals.pinmux.PinmuxCtrl), mirroring PinmuxCtrl.scala.
+// Register-accurate: stores the per-pin mux selection. Renode does not model physical pad routing,
+// so the selection is read/write state only (drivers can program and read it back).
+//
+// Register map (offsets from base; Regs base = IpIdentification.length = 8):
+//   0x00 header   (RO)  IpIdentification
+//   0x04 version  (RO)
+//   0x08 info     (RO)  options[15:8] | width[7:0]
+//   0x10 + pin*4  option(pin) (RW)  selected mux option for that pin
+//
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Bus;
+
+namespace Antmicro.Renode.Peripherals.Miscellaneous
+{
+    public class PinmuxCtrl : IDoubleWordPeripheral, IKnownSize
+    {
+        public PinmuxCtrl(IMachine machine, int width = 12, int options = 2)
+        {
+            this.width = width;
+            this.options = options;
+            option = new uint[width];
+            Reset();
+        }
+
+        public void Reset()
+        {
+            for(var i = 0; i < width; i++)
+            {
+                option[i] = 0;
+            }
+        }
+
+        public uint ReadDoubleWord(long offset)
+        {
+            switch(offset)
+            {
+                case HeaderOffset:  return (uint)(((Api & 0xFF) << 24) | ((Length & 0xFF) << 16) | (Id & 0xFFFF));
+                case VersionOffset: return 0x01000000; // 1.0.0
+                case InfoOffset:    return (uint)(((options & 0xFF) << 8) | (width & 0xFF));
+            }
+            if(TryPin(offset, out var pin))
+            {
+                return option[pin];
+            }
+            this.Log(LogLevel.Warning, "Unhandled read at offset 0x{0:X}", offset);
+            return 0;
+        }
+
+        public void WriteDoubleWord(long offset, uint value)
+        {
+            if(TryPin(offset, out var pin))
+            {
+                option[pin] = value;
+                return;
+            }
+            this.Log(LogLevel.Warning, "Write to read-only/unhandled register at offset 0x{0:X}", offset);
+        }
+
+        public long Size => 0x1000;
+
+        private bool TryPin(long offset, out int pin)
+        {
+            pin = 0;
+            if(offset < OptionBaseOffset)
+            {
+                return false;
+            }
+            var rel = offset - OptionBaseOffset;
+            if(rel % 4 != 0)
+            {
+                return false;
+            }
+            pin = (int)(rel / 4);
+            return pin < width;
+        }
+
+        private readonly int width;
+        private readonly int options;
+        private readonly uint[] option;
+
+        // IpIdentification header constants (PinmuxCtrl.scala: id = Pinmux = 13, length = 8).
+        private const int Api = 0;
+        private const int Length = 8;
+        private const int Id = 13;
+
+        private const long HeaderOffset = 0x00;
+        private const long VersionOffset = 0x04;
+        private const long InfoOffset = 0x08;
+        private const long OptionBaseOffset = 0x10;
+    }
+}

--- a/hardware/scala/nafarr/system/clock/ClockControllerCtrl.cs
+++ b/hardware/scala/nafarr/system/clock/ClockControllerCtrl.cs
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// Renode model of the Nafarr clock controller (nafarr.system.clock, register mapping in
+// ClockController.scala). Register-accurate: per-domain enable is RW, the running bit and the
+// mult/div ratio are read-only. NOTE: ratios default to 1/1 (placeholder) — the real per-domain
+// mult/div come from the SoC's synthesis-time clock config; use co-sim for exact rates.
+//
+// Register map (offsets from base; Regs base = IpIdentification.length = 8):
+//   0x00 header   (RO)  IpIdentification
+//   0x04 version  (RO)
+//   0x08 domains  (RO)  number of clock domains [7:0]
+//   0x10 + i*8  control(i)  bit31 enable (RW), bit30 running (RO, 1)
+//   0x14 + i*8  ratio(i)    div[15:0] | mult[31:16] (RO); rate = reference * mult / div
+//
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Bus;
+
+namespace Antmicro.Renode.Peripherals.Miscellaneous
+{
+    public class ClockControllerCtrl : IDoubleWordPeripheral, IKnownSize
+    {
+        public ClockControllerCtrl(IMachine machine, int numberOfDomains = 1, int mult = 1, int div = 1)
+        {
+            this.numberOfDomains = numberOfDomains;
+            this.mult = mult;
+            this.div = div;
+            enable = new bool[numberOfDomains];
+            Reset();
+        }
+
+        public void Reset()
+        {
+            for(var i = 0; i < numberOfDomains; i++)
+            {
+                enable[i] = true; // domains run by default
+            }
+        }
+
+        public uint ReadDoubleWord(long offset)
+        {
+            switch(offset)
+            {
+                case HeaderOffset:  return (uint)(((Api & 0xFF) << 24) | ((Length & 0xFF) << 16) | (Id & 0xFFFF));
+                case VersionOffset: return 0x01010000; // 1.1.0
+                case DomainsOffset: return (uint)(numberOfDomains & 0xFF);
+            }
+            if(TryDomain(offset, ControlOffset, out var ci))
+            {
+                return (uint)((enable[ci] ? (1u << 31) : 0u) | (1u << 30)); // running always set
+            }
+            if(TryDomain(offset, RatioOffset, out var ri))
+            {
+                return (uint)(((mult & 0xFFFF) << 16) | (div & 0xFFFF));
+            }
+            this.Log(LogLevel.Warning, "Unhandled read at offset 0x{0:X}", offset);
+            return 0;
+        }
+
+        public void WriteDoubleWord(long offset, uint value)
+        {
+            if(TryDomain(offset, ControlOffset, out var ci))
+            {
+                enable[ci] = (value & (1u << 31)) != 0;
+                return;
+            }
+            if(TryDomain(offset, RatioOffset, out _))
+            {
+                this.Log(LogLevel.Warning, "Write to read-only ratio register at offset 0x{0:X}", offset);
+                return;
+            }
+            this.Log(LogLevel.Warning, "Write to read-only/unhandled register at offset 0x{0:X}", offset);
+        }
+
+        public long Size => 0x1000;
+
+        // Per-domain block stride is 8: control at FirstBlock + i*8, ratio at FirstBlock + 4 + i*8.
+        private bool TryDomain(long offset, long regInBlock, out int index)
+        {
+            index = 0;
+            if(offset < FirstBlockOffset)
+            {
+                return false;
+            }
+            var rel = offset - FirstBlockOffset;
+            if(rel % BlockStride != regInBlock)
+            {
+                return false;
+            }
+            index = (int)(rel / BlockStride);
+            return index < numberOfDomains;
+        }
+
+        private readonly int numberOfDomains;
+        private readonly int mult;
+        private readonly int div;
+        private readonly bool[] enable;
+
+        // IpIdentification header constants (ClockController.scala: id = Clock = 12, length = 8).
+        private const int Api = 0;
+        private const int Length = 8;
+        private const int Id = 12;
+
+        private const long HeaderOffset = 0x00;
+        private const long VersionOffset = 0x04;
+        private const long DomainsOffset = 0x08;
+        private const long FirstBlockOffset = 0x10;
+        private const long BlockStride = 0x08;
+        private const long ControlOffset = 0x00; // within block
+        private const long RatioOffset = 0x04;   // within block
+    }
+}

--- a/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
+++ b/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// Renode functional model of the Nafarr machine timer (nafarr.system.mtimer.MachineTimerCtrl).
+//
+// Register map (offsets from base), mirroring MachineTimerCtrl.Mapper:
+//   0x00  counter low   (RO)  mtime[31:0]
+//   0x04  counter high  (RO)  mtime[63:32]
+//   0x08  compare low   (RW)  mtimecmp[31:0]
+//   0x0C  compare high  (RW)  mtimecmp[63:32]
+//
+// Behavioral notes:
+//   * The counter is "locked" (frozen) after reset and only starts incrementing
+//     once the firmware writes a compare register — matching the RTL's lock/clear logic.
+//   * The interrupt (MTIP) asserts when counter >= compare and is cleared by writing
+//     a compare register. Wire IRQ to the CPU machine-timer line, e.g. `-> cpu@7`.
+//
+//
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Bus;
+using Antmicro.Renode.Peripherals.Timers;
+
+namespace Antmicro.Renode.Peripherals.Timers
+{
+    public class MachineTimerCtrl : IDoubleWordPeripheral, IKnownSize
+    {
+        public MachineTimerCtrl(IMachine machine, long frequency = 50000000)
+        {
+            IRQ = new GPIO();
+            timer = new ComparingTimer(machine.ClockSource, (ulong)frequency, this, "mtime",
+                                       limit: ulong.MaxValue, enabled: false, eventEnabled: true);
+            timer.CompareReached += OnCompareReached;
+            Reset();
+        }
+
+        public void Reset()
+        {
+            timer.Enabled = false;
+            timer.Value = 0;
+            compare = ulong.MaxValue;
+            timer.Compare = compare;
+            hit = false;
+            IRQ.Set(false);
+        }
+
+        public uint ReadDoubleWord(long offset)
+        {
+            switch(offset)
+            {
+                case CounterLowOffset:
+                    return (uint)(timer.Value & 0xFFFFFFFF);
+                case CounterHighOffset:
+                    return (uint)(timer.Value >> 32);
+                case CompareLowOffset:
+                    return (uint)(compare & 0xFFFFFFFF);
+                case CompareHighOffset:
+                    return (uint)(compare >> 32);
+                default:
+                    this.Log(LogLevel.Warning, "Unhandled read at offset 0x{0:X}", offset);
+                    return 0;
+            }
+        }
+
+        public void WriteDoubleWord(long offset, uint value)
+        {
+            switch(offset)
+            {
+                case CompareLowOffset:
+                    compare = (compare & 0xFFFFFFFF00000000) | value;
+                    break;
+                case CompareHighOffset:
+                    compare = (compare & 0x00000000FFFFFFFF) | ((ulong)value << 32);
+                    break;
+                case CounterLowOffset:
+                case CounterHighOffset:
+                    this.Log(LogLevel.Warning, "Write to read-only counter at offset 0x{0:X}", offset);
+                    return;
+                default:
+                    this.Log(LogLevel.Warning, "Unhandled write at offset 0x{0:X}", offset);
+                    return;
+            }
+
+            // Writing a compare register releases the lock and clears the pending interrupt.
+            timer.Compare = compare;
+            timer.Enabled = true;
+            hit = false;
+            IRQ.Set(false);
+        }
+
+        public long Size => 0x10;
+        public GPIO IRQ { get; }
+
+        private void OnCompareReached()
+        {
+            hit = true;
+            IRQ.Set(true);
+        }
+
+        private ulong compare;
+        private bool hit;
+        private readonly ComparingTimer timer;
+
+        private const long CounterLowOffset = 0x00;
+        private const long CounterHighOffset = 0x04;
+        private const long CompareLowOffset = 0x08;
+        private const long CompareHighOffset = 0x0C;
+    }
+}

--- a/hardware/scala/nafarr/system/plic/PlicCtrl.cs
+++ b/hardware/scala/nafarr/system/plic/PlicCtrl.cs
@@ -1,0 +1,225 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// Renode model of the Nafarr PLIC (nafarr.system.plic, SpinalHDL PlicMapping.sifive +
+// PlicGatewayActiveHigh). Models the gateway latch faithfully so the Nafarr driver works:
+//   * gateway: while !waitCompletion, ip follows source and latches waitCompletion;
+//   * READ  of the claim/complete register => doClaim()      (ip := false),
+//   * WRITE of the claim/complete register => doCompletion() (waitCompletion := false).
+// Unlike a strict SiFive PLIC, a WRITE (completion) alone re-arms the gateway and re-evaluates
+// the source, so the driver's "write the known source id to complete" (without a prior read-claim)
+// is valid. Priority is hardwired to 1 and threshold to 0 (Plic.scala), so any enabled pending
+// source is deliverable.
+//
+// Single context (context 0 -> the M-mode hart). Register map (offsets from base):
+//   0x000000 + id*4    priority   (RO, reads 1 for valid sources; writes ignored)
+//   0x001000 + w*4     pending    (RO, bit = gateway ip)
+//   0x002000 + w*4     enable     (RW, context 0)
+//   0x200000           threshold  (RW, context 0)
+//   0x200004           claim/complete (READ = claim, WRITE = complete)
+//
+//
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Bus;
+
+namespace Antmicro.Renode.Peripherals.IRQControllers
+{
+    public class PlicCtrl : IDoubleWordPeripheral, IKnownSize, IGPIOReceiver, INumberedGPIOOutput
+    {
+        public PlicCtrl(IMachine machine, int numberOfSources = 31)
+        {
+            this.numberOfSources = numberOfSources;
+            words = (numberOfSources + 1 + 31) / 32; // sources 0..numberOfSources, source 0 reserved
+
+            var connections = new Dictionary<int, IGPIO> { { 0, new GPIO() } };
+            Connections = new ReadOnlyDictionary<int, IGPIO>(connections);
+
+            source = new bool[numberOfSources + 1];
+            ip = new bool[numberOfSources + 1];
+            waitCompletion = new bool[numberOfSources + 1];
+            enabled = new bool[numberOfSources + 1];
+
+            Reset();
+        }
+
+        public void Reset()
+        {
+            for(var i = 0; i <= numberOfSources; i++)
+            {
+                source[i] = ip[i] = waitCompletion[i] = enabled[i] = false;
+            }
+            threshold = 0;
+            UpdateLine();
+        }
+
+        // Interrupt sources from peripherals (e.g. gpio0.IRQ -> plic@3).
+        public void OnGPIO(int number, bool value)
+        {
+            if(number <= 0 || number > numberOfSources)
+            {
+                this.Log(LogLevel.Warning, "Ignoring interrupt on out-of-range source {0}", number);
+                return;
+            }
+            source[number] = value;
+            GatewayEvaluate(number);
+            UpdateLine();
+        }
+
+        public uint ReadDoubleWord(long offset)
+        {
+            if(offset >= PriorityBase && offset < PendingBase)
+            {
+                var id = (int)(offset / 4);
+                return (id >= 1 && id <= numberOfSources) ? 1u : 0u; // hardwired priority 1
+            }
+            if(offset >= PendingBase && offset < PendingBase + words * 4)
+            {
+                return PackWord((int)((offset - PendingBase) / 4), ip);
+            }
+            if(offset >= EnableBase && offset < EnableBase + words * 4)
+            {
+                return PackWord((int)((offset - EnableBase) / 4), enabled);
+            }
+            if(offset == ThresholdOffset)
+            {
+                return (uint)threshold;
+            }
+            if(offset == ClaimOffset)
+            {
+                return (uint)Claim();
+            }
+            this.Log(LogLevel.Warning, "Unhandled read at offset 0x{0:X}", offset);
+            return 0;
+        }
+
+        public void WriteDoubleWord(long offset, uint value)
+        {
+            if(offset >= EnableBase && offset < EnableBase + words * 4)
+            {
+                UnpackWord((int)((offset - EnableBase) / 4), value, enabled);
+                UpdateLine();
+                return;
+            }
+            if(offset == ThresholdOffset)
+            {
+                threshold = (int)value;
+                UpdateLine();
+                return;
+            }
+            if(offset == ClaimOffset)
+            {
+                Complete((int)value);
+                return;
+            }
+            if(offset >= PriorityBase && offset < PendingBase)
+            {
+                return; // priority hardwired; writes ignored
+            }
+            if(offset >= PendingBase && offset < PendingBase + words * 4)
+            {
+                this.Log(LogLevel.Warning, "Write to read-only pending register at offset 0x{0:X}", offset);
+                return;
+            }
+            this.Log(LogLevel.Warning, "Unhandled write at offset 0x{0:X}", offset);
+        }
+
+        public long Size => 0x4000000;
+        public IReadOnlyDictionary<int, IGPIO> Connections { get; }
+
+        // gateway: ip follows source and latches until a completion clears waitCompletion.
+        private void GatewayEvaluate(int id)
+        {
+            if(!waitCompletion[id])
+            {
+                ip[id] = source[id];
+                waitCompletion[id] = source[id];
+            }
+        }
+
+        private int Claim()
+        {
+            // Highest-priority pending+enabled source; priorities are equal, so lowest id wins.
+            for(var id = 1; id <= numberOfSources; id++)
+            {
+                if(enabled[id] && ip[id])
+                {
+                    ip[id] = false; // doClaim()
+                    UpdateLine();
+                    return id;
+                }
+            }
+            return 0;
+        }
+
+        private void Complete(int id)
+        {
+            if(id <= 0 || id > numberOfSources)
+            {
+                return;
+            }
+            waitCompletion[id] = false; // doCompletion()
+            GatewayEvaluate(id);        // re-arm: ip := source
+            UpdateLine();
+        }
+
+        private void UpdateLine()
+        {
+            var pending = false;
+            for(var id = 1; id <= numberOfSources; id++)
+            {
+                // priority (1) must exceed threshold to be deliverable.
+                if(enabled[id] && ip[id] && 1 > threshold)
+                {
+                    pending = true;
+                    break;
+                }
+            }
+            Connections[0].Set(pending);
+        }
+
+        private uint PackWord(int word, bool[] bits)
+        {
+            uint result = 0;
+            for(var b = 0; b < 32; b++)
+            {
+                var id = word * 32 + b;
+                if(id >= 1 && id <= numberOfSources && bits[id])
+                {
+                    result |= 1u << b;
+                }
+            }
+            return result;
+        }
+
+        private void UnpackWord(int word, uint value, bool[] bits)
+        {
+            for(var b = 0; b < 32; b++)
+            {
+                var id = word * 32 + b;
+                if(id >= 1 && id <= numberOfSources)
+                {
+                    bits[id] = (value & (1u << b)) != 0;
+                }
+            }
+        }
+
+        private readonly int numberOfSources;
+        private readonly int words;
+        private readonly bool[] source;
+        private readonly bool[] ip;
+        private readonly bool[] waitCompletion;
+        private readonly bool[] enabled;
+        private int threshold;
+
+        private const long PriorityBase = 0x000000;
+        private const long PendingBase = 0x001000;
+        private const long EnableBase = 0x002000;
+        private const long ThresholdOffset = 0x200000;
+        private const long ClaimOffset = 0x200004;
+    }
+}

--- a/hardware/scala/nafarr/system/syscon/Syscon.cs
+++ b/hardware/scala/nafarr/system/syscon/Syscon.cs
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+//
+// Renode model of the Nafarr syscon (nafarr.system.syscon.Syscon). All registers are read-only
+// constants (IpIdentification + identity/siliconRev/buildDate/refClock/featureInfo/features),
+// mirroring Syscon.scala's Mapper. Values are constructor parameters so each SoC can supply its own.
+//
+// Register map (offsets from base; Regs base = IpIdentification.length = 8):
+//   0x00 header     (RO)  IpIdentification
+//   0x04 version    (RO)
+//   0x08 identity   (RO)  platformClass[31:24] | product[23:16] | platform[15:8] | vendor[7:0]
+//   0x0C siliconRev (RO)  siliconMajor[31:16] | siliconMinor[15:0]
+//   0x10 buildDate  (RO)
+//   0x14 refClock   (RO)  reference clock in Hz
+//   0x18 featureInfo(RO)  featureRegCount[7:0]
+//   0x1C + i*4 features(i) (RO)  feature bitmask, 32 ordinals per register
+//
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Bus;
+
+namespace Antmicro.Renode.Peripherals.Miscellaneous
+{
+    public class Syscon : IDoubleWordPeripheral, IKnownSize
+    {
+        public Syscon(IMachine machine, uint refClockHz = 50000000, uint identity = 0,
+                      uint siliconMajor = 0, uint siliconMinor = 0, uint buildDate = 0,
+                      ulong featureMask = 0)
+        {
+            this.refClockHz = refClockHz;
+            this.identity = identity;
+            this.siliconRev = (siliconMajor << 16) | (siliconMinor & 0xFFFF);
+            this.buildDate = buildDate;
+            this.featureMask = featureMask;
+            this.featureRegCount = featureMask == 0 ? 1 : (BitLength(featureMask) + 31) / 32;
+        }
+
+        public void Reset()
+        {
+        }
+
+        public uint ReadDoubleWord(long offset)
+        {
+            switch(offset)
+            {
+                case HeaderOffset:     return (uint)(((Api & 0xFF) << 24) | ((Length & 0xFF) << 16) | (Id & 0xFFFF));
+                case VersionOffset:    return 0x01000000; // 1.0.0
+                case IdentityOffset:   return identity;
+                case SiliconRevOffset: return siliconRev;
+                case BuildDateOffset:  return buildDate;
+                case RefClockOffset:   return refClockHz;
+                case FeatureInfoOffset:return featureRegCount & 0xFF;
+            }
+            if(offset >= FeaturesOffset && offset < FeaturesOffset + featureRegCount * 4)
+            {
+                var idx = (int)((offset - FeaturesOffset) / 4);
+                return (uint)((featureMask >> (idx * 32)) & 0xFFFFFFFF);
+            }
+            this.Log(LogLevel.Warning, "Unhandled read at offset 0x{0:X}", offset);
+            return 0;
+        }
+
+        public void WriteDoubleWord(long offset, uint value)
+        {
+            this.Log(LogLevel.Warning, "Write to read-only syscon register at offset 0x{0:X}", offset);
+        }
+
+        public long Size => 0x1000;
+
+        private static uint BitLength(ulong v)
+        {
+            uint n = 0;
+            while(v != 0) { n++; v >>= 1; }
+            return n;
+        }
+
+        private readonly uint refClockHz;
+        private readonly uint identity;
+        private readonly uint siliconRev;
+        private readonly uint buildDate;
+        private readonly ulong featureMask;
+        private readonly uint featureRegCount;
+
+        // IpIdentification header constants (Syscon.scala: id = Syscon = 24, length = 8).
+        private const int Api = 0;
+        private const int Length = 8;
+        private const int Id = 24;
+
+        private const long HeaderOffset = 0x00;
+        private const long VersionOffset = 0x04;
+        private const long IdentityOffset = 0x08;
+        private const long SiliconRevOffset = 0x0C;
+        private const long BuildDateOffset = 0x10;
+        private const long RefClockOffset = 0x14;
+        private const long FeatureInfoOffset = 0x18;
+        private const long FeaturesOffset = 0x1C;
+    }
+}


### PR DESCRIPTION
Add files for some selected peripherals to run Renode emulations based on those. They only have one parameter set so far, but allow to run bare-metal/Zephyr firmwares in almost real-time.