### PR TITLE
hardware: nafarr: Add RM_IHPSG13_1P_2048x32_c2_bm_bist

### DIFF
--- a/hardware/scala/nafarr/blackboxes/ihp/sg13g2/Memory.scala
+++ b/hardware/scala/nafarr/blackboxes/ihp/sg13g2/Memory.scala
@@ -10,6 +10,7 @@ import spinal.lib.blackbox.ihp.sg13g2.IhpSramMacro
 object Memory {
   // Add custom SRAM macros which are not upstream in SpinalHDL yet.
   val sramMacros: Seq[IhpSramMacro] = IhpSramMacro.defaults ++ Seq(
+    IhpSramMacro("RM_IHPSG13_1P_2048x32_c2_bm_bist", 1, 2048, 32),
     IhpSramMacro("RM_IHPSG13_2P_64x22_c2_bm_bist", 2, 64, 22)
   )
 
@@ -18,6 +19,7 @@ object Memory {
     case (32, 1024) => RM_IHPSG13_1P_256x32_c2_bm_bist()
     case (32, 2048) => RM_IHPSG13_1P_512x32_c2_bm_bist()
     case (32, 4096) => RM_IHPSG13_1P_1024x32_c2_bm_bist()
+    case (32, 8192) => RM_IHPSG13_1P_2048x32_c2_bm_bist()
     case _ => throw new IllegalArgumentException(s"Unsupported width and size: $width x $size")
   }
 
@@ -110,6 +112,20 @@ object Memory {
       System.getenv(
         "NAFARR_BASE"
       ) + "/hardware/scala/nafarr/blackboxes/ihp/sg13g2/RM_IHPSG13_1P_1024x32_c2_bm_bist.v"
+    )
+  }
+
+  case class RM_IHPSG13_1P_2048x32_c2_bm_bist()
+      extends IHPSG13Memory(addrWidth = 11, dataWidth = 32) {
+    addRTLPath(
+      System.getenv(
+        "NAFARR_BASE"
+      ) + "/hardware/scala/nafarr/blackboxes/ihp/sg13g2/RM_IHPSG13_1P_core_behavioral_bm_bist.v"
+    )
+    addRTLPath(
+      System.getenv(
+        "NAFARR_BASE"
+      ) + "/hardware/scala/nafarr/blackboxes/ihp/sg13g2/RM_IHPSG13_1P_2048x32_c2_bm_bist.v"
     )
   }
 }

--- a/hardware/scala/nafarr/cores/cpu/vexiiriscv/TileLinkVexiiRiscv.scala
+++ b/hardware/scala/nafarr/cores/cpu/vexiiriscv/TileLinkVexiiRiscv.scala
@@ -77,6 +77,19 @@ class TileLinkVexiiRiscv(
     }
     result.toSeq
   }
+
+  /** I-cache tag/way RAMs, available after generateVerilog (post-blackboxing).
+    * Companion to iCacheRams, which only covers the data bank memories: the tag
+    * memories live in the plugin's per-way areas (logic.ways) instead.
+    */
+  def iCacheTagRams: Seq[Component] = {
+    val memNames = fetchL1Plugin.map(_.logic.ways.map(_.mem.getName())).getOrElse(Nil).toSet
+    val result = scala.collection.mutable.ArrayBuffer[Component]()
+    fiber.vexii.walkComponents { c =>
+      if (memNames.contains(c.getName())) result += c
+    }
+    result.toSeq
+  }
   private val privPlugin = parameter.plugins.collectFirst { case p: PrivilegedPlugin => p }.get
   private val jtagPlugin = parameter.plugins.collectFirst { case p: EmbeddedRiscvJtag => p }.get
 

--- a/hardware/scala/nafarr/memory/ocram/ihp/sg13g2/TileLinkIhpOnChipRam.scala
+++ b/hardware/scala/nafarr/memory/ocram/ihp/sg13g2/TileLinkIhpOnChipRam.scala
@@ -12,9 +12,9 @@ import nafarr.blackboxes.ihp.sg13g2._
 
 object TileLinkIhpOnChipRam {
 
-  // Largest available 32-bit macro (1024x32 = 4 kB).
+  // Largest available 32-bit macro (2048x32 = 8 kB).
   // When size exceeds this, multiple macros are banked.
-  private val bankSize = 4096
+  private val bankSize = 8192
 
   case class OnePort(p: TileLinkParameter, size: Int) extends Component {
     private val bankCount = size / bankSize


### PR DESCRIPTION
IHP has a new 8kB SRAM macro. Add this to the blackbox and OnChipRam module to make it available for top-level designs.